### PR TITLE
Improve numpy compatability

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
@@ -274,15 +274,15 @@ def stripUnits(args):
     """
     newArgList=[]
     for arg in args:
-        if unit.is_quantity(arg):
+        if 'numpy' in sys.modules and isinstance(arg, numpy.ndarray):
+           arg = arg.tolist()
+        elif unit.is_quantity(arg):
             # JDC: Ugly workaround for OpenMM using 'bar' for fundamental pressure unit.
             if arg.unit.is_compatible(unit.bar):
                 arg = arg / unit.bar
             else:
                 arg=arg.value_in_unit_system(unit.md_unit_system)                
             # JDC: End workaround.
-            if 'numpy' in sys.modules and isinstance(arg, numpy.ndarray):
-                arg = arg.tolist()
         elif isinstance(arg, dict):
             newKeys = stripUnits(arg.keys())
             newValues = stripUnits(arg.values())


### PR DESCRIPTION
For users of the python app who are writing applications that use OpenMM as well as other libraries, its pretty common that they'll be using numpy arrays in the rest of their code. OpenMM lets you get numpy arrays out, but it'd be nice if it also let you pass arrays in.

The error that you get currently when you pass numpy arrays into methods like `context.setPositions` isn't very helpful either:

```
  File "model.py", line 92, in rethread
    simulation.context.setPositions(mutant_positions)
  File "/home/rmcgibbo/envs/latest/lib/python2.7/site-packages/simtk/openmm/openmm.py", line 7171, in setPositions
    try: args=stripUnits(args)
  File "/home/rmcgibbo/envs/latest/lib/python2.7/site-packages/simtk/openmm/openmm.py", line 1122, in stripUnits
    elif not _is_string(arg):
  File "/home/rmcgibbo/envs/latest/lib/python2.7/site-packages/simtk/openmm/openmm.py", line 1060, in _is_string
    if first_item == inner_item:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This PR adds one check to stripUnits that lets you use numpy arrays. Instead of writing a new typemap in the swig interface files, I just added it to stripUnits.
