### PR TITLE
Fixed an atom ordering bug in AmoebaMultipoleForce

### DIFF
--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -747,7 +747,8 @@ void CudaContext::findMoleculeGroups() {
             for (int j = 0; j < forces[i]->getNumParticleGroups(); j++) {
                 vector<int> particles;
                 forces[i]->getParticlesInGroup(j, particles);
-                molecules[atomMolecule[particles[0]]].groups[i].push_back(j);
+                if (particles.size() > 0)
+                    molecules[atomMolecule[particles[0]]].groups[i].push_back(j);
             }
     }
 

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -778,6 +778,17 @@ public:
         }
         return true;
     }
+    int getNumParticleGroups() {
+        return 7*force.getNumMultipoles();
+    }
+    void getParticlesInGroup(int index, vector<int>& particles) {
+        int particle = index/7;
+        int type = index-7*particle;
+        force.getCovalentMap(particle, AmoebaMultipoleForce::CovalentType(type), particles);
+    }
+    bool areGroupsIdentical(int group1, int group2) {
+        return ((group1%7) == (group2%7));
+    }
 private:
     const AmoebaMultipoleForce& force;
 };


### PR DESCRIPTION
This is a fairly obscure bug.  It came up while writing a unit test, but is unlikely to have affected any real simulations, since bonded forces would supply the same grouping information.
