### PR TITLE
Add __repr__ to app's enums, so that we can print them easily

### DIFF
--- a/wrappers/python/simtk/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/simtk/openmm/app/amberprmtopfile.py
@@ -41,10 +41,25 @@ import simtk.openmm as mm
 
 # Enumerated values for implicit solvent model
 
-HCT = object()
-OBC1 = object()
-OBC2 = object()
-GBn = object()
+class HCT(object):
+    def __repr__(self):
+        return 'HCT'
+HCT = HCT()
+
+class OBC1(object):
+    def __repr__(self):
+        return 'OBC1'
+OBC1 = OBC1()
+
+class OBC2(object):
+    def __repr__(self):
+        return 'OBC2'
+OBC2 = OBC2()
+
+class GBn(object):
+    def __repr__(self):
+        return 'GBn'
+GBn = GBn()
 
 class AmberPrmtopFile(object):
     """AmberPrmtopFile parses an AMBER prmtop file and constructs a Topology and (optionally) an OpenMM System from it."""

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -42,17 +42,47 @@ from simtk.openmm.app import Topology
 
 # Enumerated values for nonbonded method
 
-NoCutoff = object()
-CutoffNonPeriodic = object()
-CutoffPeriodic = object()
-Ewald = object()
-PME = object()
+class NoCutoff(object):
+    def __repr__(self):
+        return 'NoCutoff'
+NoCutoff = NoCutoff()
+
+class CutoffNonPeriodic(object):
+    def __repr__(self):
+        return 'CutoffNonPeriodic'
+CutoffNonPeriodic = CutoffNonPeriodic()
+
+class CutoffPeriodic(object):
+    def __repr__(self):
+        return 'CutoffPeriodic'
+CutoffPeriodic = CutoffPeriodic()
+
+class Ewald(object):
+    def __repr__(self):
+        return 'Ewald'
+Ewald = Ewald()
+
+class PME(object):
+    def __repr__(self):
+        return 'PME'
+PME = PME()
 
 # Enumerated values for constraint type
 
-HBonds = object()
-AllBonds = object()
-HAngles = object()
+class HBonds(object):
+    def __repr__(self):
+        return 'HBonds'
+HBonds = HBonds()
+
+class AllBonds(object):
+    def __repr__(self):
+        return 'AllBonds'
+AllBonds = AllBonds()
+
+class HAngles(object):
+    def __repr__(self):
+        return 'HAngles'
+HAngles = HAngles()
 
 # A map of functions to parse elements of the XML file.
 


### PR DESCRIPTION
Right now, you don't get very useful information if you print out enumerated constants in the python app. The use case for this is in a python script where you'd like to report to the user what openmm api calls are being executed, or what options they've selected.

```
In [1]: print app.PME
<object object at 0x7f7592100770>
```
