### PR TITLE
StateDataReporter buffering

### DIFF
--- a/wrappers/python/simtk/openmm/app/statedatareporter.py
+++ b/wrappers/python/simtk/openmm/app/statedatareporter.py
@@ -109,6 +109,7 @@ class StateDataReporter(object):
             self._initializeConstants(simulation)
             headers = self._constructHeaders()
             print >>self._out, '#"%s"' % ('"'+self._separator+'"').join(headers)
+            self._out.flush()
             self._hasInitialized = True
 
         # Check for errors.
@@ -119,6 +120,7 @@ class StateDataReporter(object):
 
         # Write the values.
         print >>self._out, self._separator.join(str(v) for v in values)
+        self._out.flush()
 
     def _constructReportValues(self, simulation, state):
         """Query the simulation for the current state of our observables of interest.


### PR DESCRIPTION
There's no reason for statedatareporter to buffer its output stream -- if you're reporting frequently enough that this causes a performance improvement, you're clearly reporting too often. Without buffering, watching the progress of a simulation easier, since you can `tail -f` the reporter's outfile and effectively see the speed.
