### PR TITLE
return correct subtype for getIntegrator()

### DIFF
--- a/wrappers/python/src/swig_doxygen/swigInputBuilder.py
+++ b/wrappers/python/src/swig_doxygen/swigInputBuilder.py
@@ -218,6 +218,10 @@ class SwigInputBuilder:
         for name in sorted(integratorSubclassList):
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")
+        self.fOut.write("%factory(OpenMM::Integrator& OpenMM::Context::getIntegrator")
+        for name in sorted(integratorSubclassList):
+            self.fOut.write(",\n         OpenMM::%s" % name)
+        self.fOut.write(");\n\n")
         self.fOut.write("%factory(OpenMM::VirtualSite& OpenMM::System::getVirtualSite, OpenMM::TwoParticleAverageSite, OpenMM::ThreeParticleAverageSite, OpenMM::OutOfPlaneSite);\n\n")
         self.fOut.write("\n")
 


### PR DESCRIPTION
This is a fix for issue #67. I'm not really sure how it the swig input builder works, but this does pass the "test" code in issue #67.
