### PR TITLE
Add support for pickle protocol 2 for Vec3

### DIFF
--- a/wrappers/python/simtk/openmm/vec3.py
+++ b/wrappers/python/simtk/openmm/vec3.py
@@ -40,6 +40,10 @@ class Vec3(tuple):
         """Create a new Vec3."""
         return tuple.__new__(cls, (x, y, z))
 
+    def __getnewargs__(self):
+        "Support for pickle protocol 2: http://docs.python.org/2/library/pickle.html#pickling-and-unpickling-normal-class-instances"
+        return self[0], self[1], self[2]
+
     def __add__(self, other):
         """Add two Vec3s."""
         return Vec3(self[0]+other[0], self[1]+other[1], self[2]+other[2])


### PR DESCRIPTION
Currently, vec3 doesn't support the highest protocol for pickle. This PR adds support, via [this](http://docs.python.org/2/library/pickle.html#object.__getnewargs__) magic method.

```
>>> # current master
>>> import pickle
>>> import simtk.openmm as mm
>>> vec3 = mm.Vec3(1,1,1)
>>> assert vec3 == pickle.loads(pickle.dumps(vec3, pickle.HIGHEST_PROTOCOL))
Traceback (most recent call last):
  File "f.py", line 5, in <module>
    assert vec3 == pickle.loads(pickle.dumps(vec3, pickle.HIGHEST_PROTOCOL))
  File "/home/rmcgibbo/opt/python/2.7.5/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/home/rmcgibbo/opt/python/2.7.5/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/home/rmcgibbo/opt/python/2.7.5/lib/python2.7/pickle.py", line 1083, in load_newobj
    obj = cls.__new__(cls, *args)
TypeError: __new__() takes exactly 4 arguments (2 given)
```
