### PR TITLE
Temporary file names for nvcc now include the process id.

### DIFF
--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -402,7 +402,7 @@ CUmodule CudaContext::createModule(const string source, const map<string, string
     stringstream tempFileName;
 #ifdef WIN32
     // on windows include the address of the CudaContext in the temporary file name
-    tempFileName << "openmmTempKernel_" << this << "_" << getpid();
+    tempFileName << "openmmTempKernel_" << this;
 #else
     // on other platforms include the address of the CudaContext and the process id
     tempFileName << "openmmTempKernel_" << this << "_" << getpid();


### PR DESCRIPTION
Previously, the CudaContext objects from different processes could
have the same addresses, which would lead to name collisions when writing
temporary files for nvcc. This patch now includes the process id
as well, so conflicts are avoided. This partially fixes issue #45.
