### PR TITLE
del the context after its use in addHydrogens

### DIFF
--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -769,6 +769,7 @@ class Modeller(object):
         LocalEnergyMinimizer.minimize(context)
         self.topology = newTopology
         self.positions = context.getState(getPositions=True).getPositions()
+        del context
         return actualVariants
 
     def addExtraParticles(self, forcefield):


### PR DESCRIPTION
When the device is in thread-exclusive mode, trying to create multiple contexts on the same device leads to CUDA_ERROR_INVALID_DEVICE errors.

This is the same error from https://github.com/SimTk/openmm/commit/2413fd82ed9e4b5df0607eb17f2872b756d0a7bb / #62

Possible extension: it might be a good idea to add `__enter__` and `__exit__` methods to context (and Simulation?) so that they can optionally be used with a PEP343-style context manager that handles resource deallocation when the block is exited, as opposed to waiting for the GC to kick in. e.g.

```
with Context(system, integrator) as context:
    # do stuff with automatic deallocation of the context
    # after this block exits
```

cc: @tjlane.
