### PR TITLE
ATOM lines should be 80 chars

### DIFF
--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -287,7 +287,7 @@ class PDBFile(object):
                     else:
                         atomName = atom.name
                     coords = positions[posIndex]
-                    line = "ATOM  %5d %-4s %3s %s%4d    %s%s%s  1.00  0.00           %-2s " % (
+                    line = "ATOM  %5d %-4s %3s %s%4d    %s%s%s  1.00  0.00          %2s  " % (
                         atomIndex%100000, atomName, resName, chainName,
                         (resIndex+1)%10000, _format_83(coords[0]),
                         _format_83(coords[1]), _format_83(coords[2]), atom.element.symbol)


### PR DESCRIPTION
This PR fixes a bug (I think) w.r.t following the wwPDB format, where ATOM lines are currently being written out with 66 character lines, without the element symbol in chars 77-78.

http://www.wwpdb.org/documentation/format33/sect9.html#ATOM
