### PR TITLE
Fix to PR #152

### DIFF
--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -287,10 +287,14 @@ class PDBFile(object):
                     else:
                         atomName = atom.name
                     coords = positions[posIndex]
+                    if atom.element is not None:
+                        symbol = atom.element.symbol
+                    else:
+                        symbol = ' '
                     line = "ATOM  %5d %-4s %3s %s%4d    %s%s%s  1.00  0.00          %2s  " % (
                         atomIndex%100000, atomName, resName, chainName,
                         (resIndex+1)%10000, _format_83(coords[0]),
-                        _format_83(coords[1]), _format_83(coords[2]), atom.element.symbol)
+                        _format_83(coords[1]), _format_83(coords[2]), symbol)
                     assert len(line) == 80, 'Fixed width overflow detected'
                     print >>file, line
                     posIndex += 1


### PR DESCRIPTION
I forgot the edge case when `atom.element is None`, which happens for vsites in the topology.

```
from simtk.openmm import app
p = app.PDBFile('<opennmm>/wrappers/python/simtk/openmm/app/data/tip5p.pdb')
app.PDBFile.writeFile(p.topology, p.positions, open('tip5p', 'w')
```

will throw `AttributeError: 'NoneType' object has no attribute 'symbol'`
