### PR TITLE
Support gzip and bzip2 compression for StateDataReporter (based on filename extension)

### DIFF
--- a/wrappers/python/simtk/openmm/app/statedatareporter.py
+++ b/wrappers/python/simtk/openmm/app/statedatareporter.py
@@ -31,9 +31,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 __author__ = "Peter Eastman"
 __version__ = "1.0"
 
+import bz2
+import gzip
 import simtk.openmm as mm
 import simtk.unit as unit
-from simtk.openmm.app import PDBFile
 import math
 
 class StateDataReporter(object):
@@ -67,7 +68,14 @@ class StateDataReporter(object):
         self._reportInterval = reportInterval
         self._openedFile = isinstance(file, str)
         if self._openedFile:
-            self._out = open(file, 'w', 0)
+            # Detect the desired compression scheme from the filename extension
+            # and open all files unbuffered
+            if file.endswith('.gz'):
+                self._out = gzip.GzipFile(fileobj=open(file, 'wb', 0))
+            elif file.endswith('.bz2'):
+                self._out = bz2.BZ2File(file, 'w', 0)
+            else:
+                self._out = open(file, 'w', 0)
         else:
             self._out = file
         self._step = step
@@ -109,7 +117,6 @@ class StateDataReporter(object):
             self._initializeConstants(simulation)
             headers = self._constructHeaders()
             print >>self._out, '#"%s"' % ('"'+self._separator+'"').join(headers)
-            self._out.flush()
             self._hasInitialized = True
 
         # Check for errors.
@@ -120,7 +127,6 @@ class StateDataReporter(object):
 
         # Write the values.
         print >>self._out, self._separator.join(str(v) for v in values)
-        self._out.flush()
 
     def _constructReportValues(self, simulation, state):
         """Query the simulation for the current state of our observables of interest.


### PR DESCRIPTION
Users were already able to pass gzip.GzipFile objects to StateDataReporter.  bz2.BZ2File objects do not have 'flush', so attempts to use a BZ2File object passed to StateDataReporter resulted in [AttributeError: 'bz2.BZ2File' object has no attribute 'flush']

I don't think the flush calls are necessary for a few reasons:

1) When StateDataReporter opens files, it opens them unbuffered so the flush() calls did nothing.

2) If users want to pass their own file object, they can create whatever buffer size they want without the file being forcibly flushed. [1]

3) Not all objects that have a 'write' method implement 'flush', as the bz2.BZ2File example above shows. This also lets users implement their own 'file-like' destination (like a GUI text window) without having to implement a flush method. (I have an example using Tkinter).

[1] - I realize that it's common to pass sys.stdout to StateDataReporter.  When printing directly to a terminal, stdout is unbuffered already.  When redirecting stdout to a file, python buffers stdout, but you can still unbuffer stdout with the following code:

import sys, os
stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
