### PR TITLE
typo

### DIFF
--- a/wrappers/python/src/swig_doxygen/swigInputBuilder.py
+++ b/wrappers/python/src/swig_doxygen/swigInputBuilder.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 #
 #
  


### PR DESCRIPTION
I think this is a little typo. At least on *nix, there's no /bin/env. CMake is calling this directly with /usr/bin/python, so the shebang is irrelevant anyways.
