### PR TITLE
Implemented equality and inequality operators for BaseDimension

### DIFF
--- a/wrappers/python/simtk/unit/basedimension.py
+++ b/wrappers/python/simtk/unit/basedimension.py
@@ -91,14 +91,14 @@ class BaseDimension(object):
         return 'BaseDimension("%s")' % self.name
     
     def __eq__(self, other):
-        if self._index == other._index:
-            return True
+        if isInstance(other, BaseDimension):
+            return self._index == other._index
         return False
     
     def __ne__(self, other):
-        if self._index == other._index:
-            return False
-        return True
+        if isInstance(other, BaseDimension):
+            return self._index != other._index
+        return False
 
 
 # run module directly for testing


### PR DESCRIPTION
I added implementations of `__eq__()` and `__ne__()` methods to `simtk.unit.basedimension.BaseDimension` class, so that serialized unit objects are not erroneously considered incompatible with their own units.
