### PR TITLE
Check for gzip and bz2 modules

### DIFF
--- a/wrappers/python/simtk/openmm/app/statedatareporter.py
+++ b/wrappers/python/simtk/openmm/app/statedatareporter.py
@@ -31,8 +31,16 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 __author__ = "Peter Eastman"
 __version__ = "1.0"
 
-import bz2
-import gzip
+try:
+    import bz2
+    have_bz2 = True
+except: have_bz2 = False
+
+try:
+    import gzip
+    have_gzip = True
+except: have_gzip = False
+
 import simtk.openmm as mm
 import simtk.unit as unit
 import math
@@ -71,8 +79,12 @@ class StateDataReporter(object):
             # Detect the desired compression scheme from the filename extension
             # and open all files unbuffered
             if file.endswith('.gz'):
+                if not have_gzip:
+                    raise RuntimeError("Cannpt write .gz file because Python could not import gzip library")
                 self._out = gzip.GzipFile(fileobj=open(file, 'wb', 0))
             elif file.endswith('.bz2'):
+                if not have_bz2:
+                    raise RuntimeError("Cannpt write .bz2 file because Python could not import bz2 library")
                 self._out = bz2.BZ2File(file, 'w', 0)
             else:
                 self._out = open(file, 'w', 0)


### PR DESCRIPTION
Sometimes, the gzip and bz2 modules are not present in a Python installation which leads to errors when importing the app layer.  This makes it so that an exception is thrown only when trying to write the zipped file (i.e. not at the import level).
