### PR TITLE
Fix weird import segfault with RTLD_GLOBAL

### DIFF
--- a/wrappers/python/simtk/openmm/__init__.py
+++ b/wrappers/python/simtk/openmm/__init__.py
@@ -1,7 +1,3 @@
-#
-#
-#
-
 """
 Package simtk.openmm
 
@@ -13,17 +9,7 @@ It also tries to load any plugin modules it can find.
 
 __author__ = "Randall J. Radmer"
 
-import os, sys, glob, os.path
-if sys.platform not in ['win32', 'darwin']:
-    # The following is an evil incantation that is needed to permit
-    # the POSIX "dlopen" function to work.  I do not understand
-    # it.  If a better solution is known, please forward to the
-    # PyOpenMM code maintainers.
-    import ctypes
-    flags = sys.getdlopenflags()
-    sys.setdlopenflags(flags | ctypes.RTLD_GLOBAL)
-
-
+import os, os.path
 from simtk.openmm.openmm import *
 from simtk.openmm.vec3 import Vec3
 from simtk.openmm import version
@@ -32,7 +18,3 @@ if os.getenv('OPENMM_PLUGIN_DIR') is None and os.path.isdir(version.openmm_libra
 else:
     pluginLoadedLibNames = Platform.loadPluginsFromDirectory(Platform.getDefaultPluginsDirectory())
 __version__ = Platform.getOpenMMVersion()
-
-if sys.platform not in ['win32', 'darwin']:
-    # rset the dlopen flags on linux
-    sys.setdlopenflags(flags)


### PR DESCRIPTION
I think this fixes the bug in #250.

I have tested it with Python-2.7.3 and Python-2.6.8.  There is some indication on the web, e.g. [here](http://www.zeroc.com/forums/help-center/4146-segmentation-fault-ice-python.html), that RTLD_GLOBAL might now be required on python 2.5+ (and openmm requires 2.6+).

But I really have no idea how the dlopen flags work or under what conditions they're necessary. I asked on SO (http://stackoverflow.com/questions/20849755/python-shared-libraries-rtld-global-segfault), but I'm not expecting much.

Does anyone know of a supported platform / situation in which RTLD_GLOBAL is actually required?

p.s. I tested this patch by running testInstallation.py. I think that should be sufficient to exercise the plugin loading code, which this PR concerns, but I'm not 100% sure.
