### PR TITLE
Added missing required kernel names to check of platform capabilities.

### DIFF
--- a/openmmapi/src/ContextImpl.cpp
+++ b/openmmapi/src/ContextImpl.cpp
@@ -94,6 +94,8 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
     vector<string> kernelNames;
     kernelNames.push_back(CalcForcesAndEnergyKernel::Name());
     kernelNames.push_back(UpdateStateDataKernel::Name());
+    kernelNames.push_back(ApplyConstraintsKernel::Name());
+    kernelNames.push_back(VirtualSitesKernel::Name());
     for (int i = 0; i < system.getNumForces(); ++i) {
         forceImpls.push_back(system.getForce(i).createImpl());
         map<string, double> forceParameters = forceImpls[forceImpls.size()-1]->getDefaultParameters();


### PR DESCRIPTION
This fix addresses Issue https://github.com/SimTk/openmm/issues/267#issuecomment-31578212

The kernel names `ApplyConstraintsKernel` and `VirtualSitesKernel` are added to the platform capability check for safety, since they are initialized in the next code block.
