### PR TITLE
Fix segfaults in GCC when using the C-API

### DIFF
--- a/plugins/amoeba/wrappers/generateAmoebaWrappers.py
+++ b/plugins/amoeba/wrappers/generateAmoebaWrappers.py
@@ -550,6 +550,8 @@ class CSourceGenerator(WrapperGenerator):
             unwrappedType = type[:-1].strip()
             if unwrappedType in self.classesByShortName:
                 unwrappedType  = self.classesByShortName[unwrappedType]
+            if unwrappedType == 'const std::string':
+                return 'std::string(%s)' % value
             return '*'+self.unwrapValue(unwrappedType+'*', value)
         if type in self.classesByShortName:
             return 'static_cast<%s>(%s)' % (self.classesByShortName[type], value)

--- a/wrappers/generateWrappers.py
+++ b/wrappers/generateWrappers.py
@@ -624,6 +624,8 @@ class CSourceGenerator(WrapperGenerator):
             unwrappedType = type[:-1].strip()
             if unwrappedType in self.classesByShortName:
                 unwrappedType  = self.classesByShortName[unwrappedType]
+            if unwrappedType == 'const std::string':
+                return 'std::string(%s)' % value
             return '*'+self.unwrapValue(unwrappedType+'*', value)
         if type in self.classesByShortName:
             return 'static_cast<%s>(%s)' % (self.classesByShortName[type], value)


### PR DESCRIPTION
Relevant details are in the commit log.  This is the pull request addressing the issues (and promised by) issue #318.

A direct comparison between the generated C wrapper files indicates that only the `reinterpret_cast<const std::string*>` chunks were replaced with `std::string(thing)`.
