### PR TITLE
Fix broken Python wrappers

### DIFF
--- a/wrappers/python/src/swig_doxygen/OpenMM.i
+++ b/wrappers/python/src/swig_doxygen/OpenMM.i
@@ -64,7 +64,7 @@ using namespace OpenMM;
 
 %include OpenMM_docstring.i
 
-%include OpenMM_headers.i
+%include OpenMMSwigHeaders.i
 
 %pythoncode %{
   # when we import * from the python module, we only want to import the


### PR DESCRIPTION
A previous commit had renamed `OpenMM_headers.i` to `OpenMMSwigHeaders.i` without changing the corresponding include statement in `OpenMM.i`.  This fixes that, hopefully restoring the ability to build Python wrappers.
