### PR TITLE
Make element basically immutable

### DIFF
--- a/wrappers/python/simtk/openmm/app/element.py
+++ b/wrappers/python/simtk/openmm/app/element.py
@@ -42,22 +42,34 @@ class Element(object):
 
     The simtk.openmm.app.element module contains objects for all the standard chemical elements,
     such as element.hydrogen or element.carbon.  You can also call the static method Element.getBySymbol() to
-    look up the Element with a particular chemical symbol."""
+    look up the Element with a particular chemical symbol.
+
+    Element objects should be considered immutable
+    """
 
     _elements_by_symbol = {}
     _elements_by_atomic_number = {}
 
     def __init__(self, number, name, symbol, mass):
+        """Create a new element
+
+        Parameters:
+        number (int) The atomic number of the element
+        name (string) The name of the element
+        symbol (string) The chemical symbol of the element
+        mass (float) The atomic mass of the element
+        """
         ## The atomic number of the element
-        self.atomic_number = number
+        self._atomic_number = number
         ## The name of the element
-        self.name = name
+        self._name = name
         ## The chemical symbol of the element
-        self.symbol = symbol
+        self._symbol = symbol
         ## The atomic mass of the element
-        self.mass = mass
+        self._mass = mass
         # Index this element in a global table
         s = symbol.strip().upper()
+
         assert s not in Element._elements_by_symbol
         Element._elements_by_symbol[s] = self
         if number in Element._elements_by_atomic_number:
@@ -80,6 +92,28 @@ class Element(object):
     @staticmethod
     def getByAtomicNumber(atomic_number):
         return Element._elements_by_atomic_number[atomic_number]
+
+    @property
+    def atomic_number(self):
+        return self._atomic_number
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def symbol(self):
+        return self._symbol
+
+    @property
+    def mass(self):
+        return self._mass
+
+    def __str__(self):
+        return '<Element %s>' % self.name
+
+    def __repr__(self):
+        return '<Element %s>' % self.name
 
 # This is for backward compatibility.
 def get_by_symbol(symbol):

--- a/wrappers/python/tests/TestElement.py
+++ b/wrappers/python/tests/TestElement.py
@@ -1,0 +1,31 @@
+import pickle
+import unittest
+from simtk.unit import dalton
+from simtk.openmm.app import element
+
+class TestElement(unittest.TestCase):
+    def test_immutable(self):
+        def modifyElement():
+            # this should not be allowed
+            element.sulfur.mass = 100*dalton
+        self.assertRaises(AttributeError, modifyElement)
+    
+    def test_pickleable(self):
+        newsulfur = pickle.loads(pickle.dumps(element.sulfur))
+        # make sure that a new object is not created during the pickle/unpickle
+        # cycle
+        assert element.sulfur == newsulfur
+        assert element.sulfur is newsulfur
+        assert id(element.sulfur) == id(newsulfur)
+    
+    def test_attributes(self):
+        assert element.hydrogen.atomic_number == 1
+        assert element.hydrogen.symbol == 'H'
+        assert element.hydrogen.name == 'hydrogen'
+        assert element.hydrogen.mass == 1.007947 * dalton
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+        


### PR DESCRIPTION
This isn't _strict_ immutabity, which is basically [impossible](http://stackoverflow.com/questions/4828080/how-to-make-an-immutable-object-in-python) in pure python, but it basically means that you can't change elements by accident.

```
In [5]: element.hydrogen.mass += 1*unit.dalton
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-2beb996c81f0> in <module>()
----> 1 element.hydrogen.mass += 1*unit.dalton

AttributeError: can't set attribute
```

If you want to do it, you at least have to try slightly harder

```
In [6]: element.hydrogen._mass += 1*unit.dalton
In [7]: print element.hydrogen._mass
2.007947 Da
```

cc #332 
