### PR TITLE
Added TIP3P-FB and TIP4P-FB water models

### DIFF
--- a/docs/usersguide/application.rst
+++ b/docs/usersguide/application.rst
@@ -677,7 +677,9 @@ files:
 File         Water Model                                 
 ===========  ============================================
 tip3p.xml    TIP3P water model\ :cite:`Jorgensen1983`  
+tip3pfb.xml  TIP3P-FB water model\ :cite:`Wang2014`    
 tip4pew.xml  TIP4P-Ew water model\ :cite:`Horn2004`    
+tip4pfb.xml  TIP4P-FB water model\ :cite:`Wang2014`    
 tip5p.xml    TIP5P water model\ :cite:`Mahoney2000`    
 spce.xml     SPC/E water model\ :cite:`Berendsen1987`  
 swm4ndp.xml  SWM4-NDP water model\ :cite:`Lamoureux2006`
@@ -1300,8 +1302,9 @@ water models:
 
     modeller.addSolvent(forcefield, model='tip5p')
 
-Allowed values for the :code:`model` option are 'tip3p', 'spce', 'tip4pew',
-and 'tip5p'.  Be sure to include the single quotes around the value.
+Allowed values for the :code:`model` option are 'tip3p', 'tip3pfb', 'spce', 
+'tip4pew', 'tip4pfb', and 'tip5p'.  Be sure to include the single quotes 
+around the value.
 
 Another option is to add extra ion pairs to give a desired total ionic strength.
 For example:

--- a/docs/usersguide/references.bib
+++ b/docs/usersguide/references.bib
@@ -409,3 +409,12 @@
    type = {Journal Article}
 }
 
+@article{Wang2014
+   author = {Wang, Lee-Ping and Martinez, Todd J. and Pande, Vijay S.},
+   title = {Building force fields: an automatic, systematic, and reproducible approach},
+   journal = {Journal of Physical Chemistry Letters},
+   volume = {5},
+   pages = {1885-1891},
+   year = {2014},
+   type = {Journal Article}
+}

--- a/wrappers/python/simtk/openmm/app/data/tip3pfb.xml
+++ b/wrappers/python/simtk/openmm/app/data/tip3pfb.xml
@@ -1,5 +1,6 @@
 <ForceField>
  <Info>
+  <DateGenerated>2014-05-28</DateGenerated>
   <Reference>Lee-Ping Wang, Todd J. Martinez and Vijay S. Pande. Building force fields - an automatic, systematic and reproducible approach.  Journal of Physical Chemistry Letters, 2014, 5, pp 1885-1891.  DOI:10.1021/jz500737m</Reference>
  </Info>
  <AtomTypes>

--- a/wrappers/python/simtk/openmm/app/data/tip4pfb.xml
+++ b/wrappers/python/simtk/openmm/app/data/tip4pfb.xml
@@ -1,5 +1,6 @@
 <ForceField>
  <Info>
+  <DateGenerated>2014-05-28</DateGenerated>
   <Reference>Lee-Ping Wang, Todd J. Martinez and Vijay S. Pande. Building force fields - an automatic, systematic and reproducible approach.  Journal of Physical Chemistry Letters, 2014, 5, pp 1885-1891.  DOI:10.1021/jz500737m</Reference>
  </Info>
  <AtomTypes>


### PR DESCRIPTION
Added the parameters in this recently published article: http://pubs.acs.org/doi/abs/10.1021/jz500737m

These parameters are compatible with AMBER-style protein force fields.
