### PR TITLE
Add virtual sites

### DIFF
--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -956,10 +956,10 @@ class Modeller(object):
                                     elif site.type == 'average3':
                                         position = site.weights[0]*templateAtomPositions[site.atoms[0]] + site.weights[1]*templateAtomPositions[site.atoms[1]] + site.weights[2]*templateAtomPositions[site.atoms[2]]
                                     elif site.type == 'outOfPlane':
-                                        v1 = templateAtomPositions[index+site.atoms[1]] - templateAtomPositions[index+site.atoms[0]]
-                                        v2 = templateAtomPositions[index+site.atoms[2]] - templateAtomPositions[index+site.atoms[0]]
+                                        v1 = templateAtomPositions[site.atoms[1]] - templateAtomPositions[site.atoms[0]]
+                                        v2 = templateAtomPositions[site.atoms[2]] - templateAtomPositions[site.atoms[0]]
                                         cross = Vec3(v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1]-v1[1]*v2[0])
-                                        position = templateAtomPositions[index+site.atoms[0]] + site.weights[0]*v1 + site.weights[1]*v2 + site.weights[2]*cross
+                                        position = templateAtomPositions[site.atoms[0]] + site.weights[0]*v1 + site.weights[1]*v2 + site.weights[2]*cross
                             if position is None and atom.type in drudeTypeMap:
                                 # This is a Drude particle.  Put it on top of its parent atom.
 


### PR DESCRIPTION
I was trying to use `modeller.addExtraParticles` to add a virtual site so I could use tip4p. As written, this code kept throwing an exception as `index = 3` and `site.atoms = [0, 1, 2]`

This probably shouldn't be merged because there must have been some logic to including the index offset, but these changes worked for my particular case.
