### PR TITLE
Fix residue assignment in PSF parser

### DIFF
--- a/wrappers/python/simtk/openmm/app/internal/charmm/topologyobjects.py
+++ b/wrappers/python/simtk/openmm/app/internal/charmm/topologyobjects.py
@@ -421,8 +421,10 @@ class ResidueList(list):
         if self._last_residue is None:
             res = self._last_residue = Residue(resname, resnum)
             list.append(self, res)
-        elif self._last_residue != (resname, resnum):
-            if self._last_residue.idx == resnum:
+        elif (self._last_residue != (resname, resnum) or
+              system != self._last_residue.system):
+            if (self._last_residue.idx == resnum and
+                system == self._last_residue.system):
                 lresname = self._last_residue.resname
                 warnings.warn('Residue %d split into separate residues %s '
                               'and %s' % (resnum, lresname, resname),


### PR DESCRIPTION
Fix PSF parser in cases where single residues are differentiated by their system

(which means that consecutive residues may have the same residue number _and_
name, but are different residues).
