### PR TITLE
XmlSerializer generates XML directly rather than going through TinyXml

### DIFF
--- a/serialization/include/openmm/serialization/XmlSerializer.h
+++ b/serialization/include/openmm/serialization/XmlSerializer.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010 Stanford University and the Authors.           *
+ * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -79,7 +79,7 @@ public:
 private:
     static void serialize(const SerializationNode& node, std::ostream& stream);
     static void* deserializeStream(std::istream& stream);
-    static TiXmlElement* encodeNode(const SerializationNode& node);
+    static void encodeNode(const SerializationNode& node, std::ostream& stream, int depth);
     static void decodeNode(SerializationNode& node, const TiXmlElement& element);
 };
 


### PR DESCRIPTION
This makes serializing to XML slightly faster, and reduces the memory use quite a bit
