### PR TITLE
Fix Clang warning about unhandled enum values.

### DIFF
--- a/libraries/lepton/src/ParsedExpression.cpp
+++ b/libraries/lepton/src/ParsedExpression.cpp
@@ -269,7 +269,15 @@ ExpressionTreeNode ParsedExpression::substituteSimplerExpression(const Expressio
                 return ExpressionTreeNode(new Operation::Constant(dynamic_cast<const Operation::MultiplyConstant*>(&node.getOperation())->getValue()*getConstantValue(children[0])));
             if (children[0].getOperation().getId() == Operation::NEGATE) // Combine a multiply and a negate into a single multiply
                 return ExpressionTreeNode(new Operation::MultiplyConstant(-dynamic_cast<const Operation::MultiplyConstant*>(&node.getOperation())->getValue()), children[0].getChildren()[0]);
+            break;
         }
+        default:
+        {
+            // If operation ID is not one of the above,
+            // we don't substitute a simpler expression.
+            break;
+        }
+
     }
     return ExpressionTreeNode(node.getOperation().clone(), children);
 }


### PR DESCRIPTION
Clang had been generating the following warning:

```
ParsedExpression.cpp:123:13:
warning:
      30 enumeration values not handled in switch: 'CONSTANT', 'VARIABLE',
      'CUSTOM'...
            [-Wswitch]
                switch (node.getOperation().getId()) {
                                ^
                                1 warning generated.
```

To get rid of this warning, I added a default case, which does nothing.
