### PR TITLE
In travis, use multiple cores.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ before_install:
 
 script:
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM .
-  - make
-  - make install
+  - make -j2
+  - make -j2 install
   - sudo make PythonInstall
   - # run all of the tests
-  - ctest -V
+  - ctest -j2 -V
   - # get a list of all of the failed tests into this stupid ctest format
   - python -c 'fn = "Testing/Temporary/LastTestsFailed.log"; import os; os.path.exists(fn) or exit(0); l = [line.split(":")[0] for line in open(fn)]; triplets = zip(l, l, [","]*len(l)); print "".join(",".join(t) for t in triplets)' > FailedTests.log
   - # rerun all of the failed tests


### PR DESCRIPTION
Travis VM's have up through 2 cores. Passing a -j2 flag should make/ctest the builds/tests faster.
