### PR TITLE
GromacsTopFile parses define value with one extra leading character

### DIFF
--- a/wrappers/python/simtk/openmm/app/gromacstopfile.py
+++ b/wrappers/python/simtk/openmm/app/gromacstopfile.py
@@ -111,7 +111,7 @@ class GromacsTopFile(object):
                 if len(fields) < 2:
                     raise ValueError('Illegal line in .top file: '+line)
                 name = fields[1]
-                valueStart = stripped.find(name, len(command))+len(name)
+                valueStart = stripped.find(name, len(command))+len(name)+1
                 value = line[valueStart:].strip()
                 self._defines[name] = value
             elif command == '#ifdef':


### PR DESCRIPTION
When GromacsTopFile reads the `#define` lines, the last character of the variable name got read into the value.  

For instance, the following line:

`#define            tor_ARG_N_CA_CB_CG_m1   0.0   0.0   1 ; PRM 2 3`

got read in as the following:

`top._defines['tor_ARG_N_CA_CB_CG_m1'] = '1   0.0   0.0   1'`.

The leading `1` is not part of the value.  Simply shifting the parser by one character fixes the issue.
