### PR TITLE
Get rid of size_t warning on vs2013 for lepton.

### DIFF
--- a/libraries/lepton/include/lepton/CompiledExpression.h
+++ b/libraries/lepton/include/lepton/CompiledExpression.h
@@ -38,6 +38,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace Lepton {
 
@@ -80,9 +81,9 @@ private:
     void compileExpression(const ExpressionTreeNode& node, std::vector<std::pair<ExpressionTreeNode, int> >& temps);
     int findTempIndex(const ExpressionTreeNode& node, std::vector<std::pair<ExpressionTreeNode, int> >& temps);
     std::vector<std::vector<int> > arguments;
-    std::vector<int> target;
+    std::vector<size_t> target;
     std::vector<Operation*> operation;
-    std::map<std::string, int> variableIndices;
+    std::map<std::string, size_t> variableIndices;
     std::set<std::string> variableNames;
     mutable std::vector<double> workspace;
     mutable std::vector<double> argValues;

--- a/libraries/lepton/include/lepton/ExpressionProgram.h
+++ b/libraries/lepton/include/lepton/ExpressionProgram.h
@@ -37,6 +37,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace Lepton {
 
@@ -60,7 +61,7 @@ public:
     /**
      * Get the number of Operations that make up this program.
      */
-    int getNumOperations() const;
+    size_t getNumOperations() const;
     /**
      * Get an Operation in this program.
      */

--- a/libraries/lepton/include/lepton/ParsedExpression.h
+++ b/libraries/lepton/include/lepton/ParsedExpression.h
@@ -36,6 +36,7 @@
 #include "windowsIncludes.h"
 #include <map>
 #include <string>
+#include <stdint.h>
 
 namespace Lepton {
 

--- a/libraries/lepton/src/CompiledExpression.cpp
+++ b/libraries/lepton/src/CompiledExpression.cpp
@@ -88,7 +88,7 @@ void CompiledExpression::compileExpression(const ExpressionTreeNode& node, vecto
         variableNames.insert(node.getOperation().getName());
     }
     else {
-        int stepIndex = arguments.size();
+        size_t stepIndex = arguments.size();
         arguments.push_back(vector<int>());
         target.push_back(workspace.size());
         operation.push_back(node.getOperation().clone());
@@ -126,7 +126,7 @@ const set<string>& CompiledExpression::getVariables() const {
 }
 
 double& CompiledExpression::getVariableReference(const string& name) {
-    map<string, int>::iterator index = variableIndices.find(name);
+    map<string, size_t>::iterator index = variableIndices.find(name);
     if (index == variableIndices.end())
         throw Exception("getVariableReference: Unknown variable '"+name+"'");
     return workspace[index->second];

--- a/libraries/lepton/src/ExpressionProgram.cpp
+++ b/libraries/lepton/src/ExpressionProgram.cpp
@@ -71,12 +71,12 @@ ExpressionProgram& ExpressionProgram::operator=(const ExpressionProgram& program
 }
 
 void ExpressionProgram::buildProgram(const ExpressionTreeNode& node) {
-    for (int i = node.getChildren().size()-1; i >= 0; i--)
+    for (size_t i = node.getChildren().size()-1; i >= 0; i--)
         buildProgram(node.getChildren()[i]);
     operations.push_back(node.getOperation().clone());
 }
 
-int ExpressionProgram::getNumOperations() const {
+size_t ExpressionProgram::getNumOperations() const {
     return operations.size();
 }
 

--- a/libraries/lepton/src/ParsedExpression.cpp
+++ b/libraries/lepton/src/ParsedExpression.cpp
@@ -60,8 +60,8 @@ double ParsedExpression::evaluate(const map<string, double>& variables) const {
 }
 
 double ParsedExpression::evaluate(const ExpressionTreeNode& node, const map<string, double>& variables) {
-    int numArgs = node.getChildren().size();
-    vector<double> args(max(numArgs, 1));
+    size_t numArgs = node.getChildren().size();
+    vector<double> args(max(numArgs, (size_t)1));
     for (int i = 0; i < numArgs; i++)
         args[i] = evaluate(node.getChildren()[i], variables);
     return node.getOperation().evaluate(&args[0], variables);


### PR DESCRIPTION
A few weeks ago, the OpenSim people upgraded to the latest lepton from this repo. Then we started getting warnings in VS2013 (see https://github.com/opensim-org/opensim-core/issues/39). This PR intends to get rid of those warnings. If this gets merged in, then at OpenSim, we'll upgrade our lepton again to the latest from this repo.
