### PR TITLE
[WIP] Add an explicit (shallow) copy constructor for CustomNonbondedForce.

### DIFF
--- a/openmmapi/include/openmm/CustomNonbondedForce.h
+++ b/openmmapi/include/openmm/CustomNonbondedForce.h
@@ -157,6 +157,7 @@ public:
      *                  of r, the distance between them, as well as any global and per-particle parameters
      */
     explicit CustomNonbondedForce(const std::string& energy);
+    CustomNonbondedForce(const CustomNonbondedForce& rhs); // copy constructor
     ~CustomNonbondedForce();
     /**
      * Get the number of particles for which force field parameters have been defined.
@@ -474,7 +475,7 @@ private:
     class InteractionGroupInfo;
     NonbondedMethod nonbondedMethod;
     double cutoffDistance, switchingDistance;
-    bool useSwitchingFunction, useLongRangeCorrection;
+    bool useSwitchingFunction, useLongRangeCorrection, iOwnTabulatedFunctions;
     std::string energyExpression;
     std::vector<PerParticleParameterInfo> parameters;
     std::vector<GlobalParameterInfo> globalParameters;

--- a/openmmapi/src/CustomNonbondedForce.cpp
+++ b/openmmapi/src/CustomNonbondedForce.cpp
@@ -48,12 +48,30 @@ using std::stringstream;
 using std::vector;
 
 CustomNonbondedForce::CustomNonbondedForce(const string& energy) : energyExpression(energy), nonbondedMethod(NoCutoff), cutoffDistance(1.0),
-    switchingDistance(-1.0), useSwitchingFunction(false), useLongRangeCorrection(false) {
+    switchingDistance(-1.0), useSwitchingFunction(false), useLongRangeCorrection(false), iOwnTabulatedFunctions(true) {
+}
+
+CustomNonbondedForce::CustomNonbondedForce(const CustomNonbondedForce& rhs) {
+    // Copy everything, but the copy does *not* own the tabulated functions
+    energyExpression = rhs.energyExpression;
+    nonbondedMethod = rhs.nonbondedMethod;
+    cutoffDistance = rhs.cutoffDistance;
+    switchingDistance = rhs.switchingDistance;
+    useSwitchingFunction = rhs.useSwitchingFunction;
+    useLongRangeCorrection = rhs.useLongRangeCorrection;
+    iOwnTabulatedFunctions = false;
+    parameters = rhs.parameters;
+    globalParameters = rhs.globalParameters;
+    particles = rhs.particles;
+    exclusions = rhs.exclusions;
+    functions = rhs.functions;
+    interactionGroups = rhs.interactionGroups;
 }
 
 CustomNonbondedForce::~CustomNonbondedForce() {
-    for (int i = 0; i < (int) functions.size(); i++)
-        delete functions[i].function;
+    if (iOwnTabulatedFunctions)
+        for (int i = 0; i < (int) functions.size(); i++)
+            delete functions[i].function;
 }
 
 const string& CustomNonbondedForce::getEnergyFunction() const {


### PR DESCRIPTION
 This solves segfaults when you use the long-range dispersion correction with the
CustomNonbondedForce if the force uses TabulatedFunction objects. Basically, it
prevents the copy from taking ownership (and deleting) the functions in its
destructor.

The use cases for CustomNonbondedForce copying currently is to recompute the
long-range prefactor if the parameters change (so the CustomNonbondedForceImpl
kernels need a copy of the Force object). Doing a full (deep) copy would be a
bit slower (although would only need to be paid once for each
CustomNonbondedForce object being used).

I'm still checking it; not ready for merge yet.
