### PR TITLE
Fixed uninitialized memory error when using multiple GPUs

### DIFF
--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1520,6 +1520,7 @@ void CudaCalcNonbondedForceKernel::initialize(const System& system, const Nonbon
     else
         dispersionCoefficient = 0.0;
     alpha = 0;
+    ewaldSelfEnergy = 0.0;
     if (force.getNonbondedMethod() == NonbondedForce::Ewald) {
         // Compute the Ewald parameters.
 
@@ -1702,8 +1703,6 @@ void CudaCalcNonbondedForceKernel::initialize(const System& system, const Nonbon
             }
         }
     }
-    else
-        ewaldSelfEnergy = 0.0;
 
     // Add the interaction to the default nonbonded kernel.
    

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -1492,6 +1492,7 @@ void OpenCLCalcNonbondedForceKernel::initialize(const System& system, const Nonb
     else
         dispersionCoefficient = 0.0;
     alpha = 0;
+    ewaldSelfEnergy = 0.0;
     if (force.getNonbondedMethod() == NonbondedForce::Ewald) {
         // Compute the Ewald parameters.
 
@@ -1648,8 +1649,6 @@ void OpenCLCalcNonbondedForceKernel::initialize(const System& system, const Nonb
             }
         }
     }
-    else
-        ewaldSelfEnergy = 0.0;
 
     // Add the interaction to the default nonbonded kernel.
     


### PR DESCRIPTION
This came up when parallelizing a simulation across multiple GPUs.  The Ewald self energy did not get initialized correctly for some of the GPUs, so an incorrect value (usually huge or nan) would get added to the energy.
