### PR TITLE
Fix Python3 compatibility with the CHARMM parsers

### DIFF
--- a/wrappers/python/simtk/openmm/app/internal/charmm/topologyobjects.py
+++ b/wrappers/python/simtk/openmm/app/internal/charmm/topologyobjects.py
@@ -12,7 +12,7 @@ Copyright (c) 2014 the Authors
 
 Author: Jason M. Swails
 Contributors:
-Date: July 3, 2014
+Date: August 15, 2014
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -346,6 +346,15 @@ class Atom(object):
         else:
             retstr += '; %s> ' % (self.name)
         return retstr
+
+    def __lt__(self, other):
+        return self.idx < other.idx
+    def __gt__(self, other):
+        return self.idx > other.idx
+    def __le__(self, other):
+        return not self > other
+    def __ge__(self, other):
+        return not self < other
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
I can't get `nosetests` to work with Python 3.3 -- all I get is:

```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.3/nosetests", line 9, in <module>
    load_entry_point('nose==1.3.0', 'console_scripts', 'nosetests')()
  File "/usr/lib64/python3.3/site-packages/nose/core.py", line 118, in __init__
    **extra_args)
  File "/usr/lib64/python3.3/unittest/main.py", line 125, in __init__
    self.runTests()
  File "/usr/lib64/python3.3/site-packages/nose/core.py", line 197, in runTests
    result = self.testRunner.run(self.test)
  File "/usr/lib64/python3.3/site-packages/nose/core.py", line 61, in run
    test(result)
  File "/usr/lib64/python3.3/site-packages/nose/suite.py", line 177, in __call__
    return self.run(*arg, **kw)
  File "/usr/lib64/python3.3/site-packages/nose/suite.py", line 224, in run
    test(orig)
  File "/usr/lib64/python3.3/unittest/suite.py", line 67, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib64/python3.3/site-packages/nose/suite.py", line 72, in run
    for test in self._tests:
  File "/usr/lib64/python3.3/site-packages/nose/suite.py", line 99, in _get_tests
    for test in self.test_generator:
  File "/usr/lib64/python3.3/site-packages/nose/loader.py", line 186, in loadTestsFromDir
    entry_path, discovered=True)
  File "/usr/lib64/python3.3/site-packages/nose/loader.py", line 428, in loadTestsFromName
    discovered=discovered)
  File "/usr/lib64/python3.3/site-packages/nose/loader.py", line 331, in loadTestsFromModule
    elif isfunction(test) and self.selector.wantFunction(test):
  File "/usr/lib64/python3.3/inspect.py", line 173, in isfunction
    return isinstance(object, types.FunctionType)
NameError: Unknown C global variable
```

Not sure what's going on there.  But after this commit, the CHARMM example runs just fine (before, it raises an error about `Atom()` not being orderable).
