### PR TITLE
Improve warning messages coming from the CHARMM parsers.

### DIFF
--- a/wrappers/python/simtk/openmm/app/charmmparameterset.py
+++ b/wrappers/python/simtk/openmm/app/charmmparameterset.py
@@ -341,9 +341,10 @@ class CharmmParameterSet(object):
                     replaced = False
                     for i, dtype in enumerate(self.dihedral_types[key]):
                         if dtype.per == dihedral.per:
-                            # Replace. Should we warn here?
-                            warnings.warn('Replacing dihedral %r with %r' % 
-                                          (dtype, dihedral))
+                            # Replace. Warn if they are different
+                            if dtype != dihedral:
+                                warnings.warn('Replacing dihedral %r with %r' % 
+                                              (dtype, dihedral))
                             self.dihedral_types[key]
                             replaced = True
                             break

--- a/wrappers/python/simtk/openmm/app/internal/charmm/topologyobjects.py
+++ b/wrappers/python/simtk/openmm/app/internal/charmm/topologyobjects.py
@@ -926,6 +926,10 @@ class DihedralType(object):
         self.per = int(per)
         self.phase = float(phase)
 
+    def __repr__(self):
+        return "<DihedralType: k=%s; phase=%s; per=%s>" % (self.phi_k,
+                self.phase, self.per)
+
     def __eq__(self, other):
         return (self.phi_k == other.phi_k and self.per == other.per and
                 self.phase == other.phase)


### PR DESCRIPTION
If a dihedral type was 'replaced', this warning used to be issued:

```
/usr/local/openmm/dev/openmm/python2.7/simtk/openmm/app/charmmparameterset.py:347: UserWarning: Replacing dihedral <simtk.openmm.app.internal.charmm.topologyobjects.DihedralType object at 0x7f7249df2150> with <simtk.openmm.app.internal.charmm.topologyobjects.DihedralType object at 0x7f7249d2d7d0>
```

This is a pretty useless message.  With this change, it now reads:

```
/usr/local/openmm/dev/openmm/python2.7/simtk/openmm/app/charmmparameterset.py:347: UserWarning: Replacing dihedral <DihedralType: k=0.14; phase=0.0; per=3> with <DihedralType: k=0.0; phase=0.0; per=3>
```
