### PR TITLE
Bug fix to addExtraParticles()

### DIFF
--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -922,7 +922,7 @@ class Modeller(object):
                                     # Record the corresponding atoms.
                                     matchingAtoms = {}
                                     for atom, match in zip(residueNoEP.atoms(), matches):
-                                        templateAtomName = t.atoms[match].name
+                                        templateAtomName = templatesNoEP[t].atoms[match].name
                                         for templateAtom in template.atoms:
                                             if templateAtom.name == templateAtomName:
                                                 matchingAtoms[templateAtom] = atom


### PR DESCRIPTION
The effect of the bug was that addExtraParticles() would sometimes select an initial position for a Drude particle that was on top of the wrong atom.
