### PR TITLE
Fix issue where the last CMAP defined in a parameter file is not added to the parameter set.

### DIFF
--- a/wrappers/python/simtk/openmm/app/charmmparameterset.py
+++ b/wrappers/python/simtk/openmm/app/charmmparameterset.py
@@ -471,8 +471,8 @@ class CharmmParameterSet(object):
                 except IndexError:
                     raise CharmmFileError('Could not parse NBFIX terms.')
                 self.nbfix_types[(min(at1, at2), max(at1, at2))] = (emin, rmin)
-        # Now we're done. Load the nonbonded types into the relevant AtomType
-        # instances. In order for this to work, all keys in nonbonded_types
+        # If there were any CMAP terms stored in the parameter set, the last one
+        # defined will not have been added to the set. Add it now.
         if current_cmap is not None:
             ty = CmapType(current_cmap_res, current_cmap_data)
             self.cmap_types[current_cmap] = ty


### PR DESCRIPTION
If someone has a system that uses this particular CMAP parameter, they will get an error message that the parameter could not be found.  So this will never cause results -- just false failures.
