### PR TITLE
Set cutoff correctly for CHARMM polarizable force field

### DIFF
--- a/wrappers/python/simtk/openmm/app/data/charmm_polar_2013.xml
+++ b/wrappers/python/simtk/openmm/app/data/charmm_polar_2013.xml
@@ -11370,6 +11370,7 @@ sigma14 = [
 
 customNonbondedForce = mm.CustomNonbondedForce('4*eps*((sig/r)^12-(sig/r)^6); eps=epsilon(type1, type2); sig=sigma(type1, type2)')
 customNonbondedForce.setNonbondedMethod(min(nonbondedForce.getNonbondedMethod(), 2))
+customNonbondedForce.setCutoffDistance(nonbondedForce.getCutoffDistance())
 customNonbondedForce.addTabulatedFunction('epsilon', mm.Discrete2DFunction(numAtomClasses, numAtomClasses, epsilon))
 customNonbondedForce.addTabulatedFunction('sigma', mm.Discrete2DFunction(numAtomClasses, numAtomClasses, sigma))
 customNonbondedForce.addPerParticleParameter('type')


### PR DESCRIPTION
The script in the XML file did not copy the cutoff distance over to the CustomNonbondedForce.  As a result, if you specified a non-default value for the cutoff, it would throw an exception complaining that all nonbonded forces needed to use the same cutoff distance.

The workaround was to call setCutoffDistance() on the CustomNonbondedForce yourself.
