### PR TITLE
[WIP] Updated vagrant scripts for conda build and upload

### DIFF
--- a/devtools/build-vm/linux/build_conda_package_vagrant.sh
+++ b/devtools/build-vm/linux/build_conda_package_vagrant.sh
@@ -2,7 +2,19 @@ export PATH=$HOME/miniconda/bin:$PATH
 export SWIG_LIB=$HOME/miniconda/share/swig/
 export CC="clang++"
 
-git clone -b vagrant https://github.com/simtk/openmm.git
+git clone https://github.com/simtk/openmm.git
 cd openmm
-conda install --file tools/ci/requirements-conda.txt --yes
-conda build tools/conda-recipe
+git checkout tags/6.1  # To checkout specific release for packaging. 
+conda install --file devtools/ci/requirements-conda.txt --yes
+
+# For CI build:
+conda build devtools/conda-recipe
+
+# For release build:
+cd ../
+git clone https://github.com/omnia-md/conda-recipes.git
+conda build conda-recipes/openmm
+
+# To upload the file, do something the following command but with the package version changed:
+
+binstar upload -u omnia /home/vagrant/miniconda/conda-bld/linux-64/openmm-6.1-py27_0.tar.bz2

--- a/devtools/build-vm/linux/setup_centos_vm.sh
+++ b/devtools/build-vm/linux/setup_centos_vm.sh
@@ -9,13 +9,14 @@
 mkdir ~/Software
 cd Software
 sudo yum install wget -y
-wget http://mirror.umd.edu/fedora/epel/6/i386/epel-release-6-8.noarch.rpm
+wget http://dl.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
 sudo rpm -i epel-release-6-8.noarch.rpm
 
 sudo yum update -y
 
 # Several of these come from the EPEL repo
-sudo yum install clang-3.4 cmake28 graphviz perl flex bison rpm-build texlive texlive-latex ghostscript gcc gcc-c++ git vim -y
+sudo yum install clang cmake28 graphviz perl flex bison rpm-build texlive texlive-latex ghostscript gcc gcc-c++ git vim -y
+# Note: changed from clang-3.4 to clang because the package has apparently been renamed.  KAB Oct 2 2014.  
 
 # Probably can't use RHEL6 version of doxygen because it's very old.
 wget http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.7.src.tar.gz
@@ -35,25 +36,26 @@ sudo yum clean expire-cache
 sudo yum install cuda -y
 rm cuda-repo-rhel6-6.0-37.x86_64.rpm
 
+sudo yum update -y  # Force a second update, in case CUDA has necessary patches.
 
 # Install Conda
 cd ~/Software
-wget http://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86_64.sh
-bash Miniconda-3.0.5-Linux-x86_64.sh -b
+wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh
+bash Miniconda-3.7.0-Linux-x86_64.sh -b
 
 # So there is a bug in some versions of anaconda where the path to swig files is HARDCODED.  Below is workaround.  See https://github.com/ContinuumIO/anaconda-issues/issues/48
 sudo ln -s  ~/miniconda/ /opt/anaconda1anaconda2anaconda3
 
 export PATH=$HOME/miniconda/bin:$PATH
 conda config --add channels http://conda.binstar.org/omnia
-conda install --yes fftw3f jinja2 swig sphinx conda-build cmake
+conda install --yes fftw3f jinja2 swig sphinx conda-build cmake binstar
 
 
 # Download AMD APP SDK from here, requires click agreement: http://developer.amd.com/amd-license-agreement-appsdk/
 # Ideally we could cache this on AWS or something...
 mkdir ~/Software/AMD
 cd ~/Software/AMD
-# Copy the tarball to this directory from wherever you got it.
+# Copy the tarball to the directory containing VagrantFile, which will be shared on the guest as /vagrant/
 cp /vagrant/AMD-APP-SDK-v2.9-lnx64.tgz  ./
 tar -zxvf  /vagrant/AMD-APP-SDK-v2.9-lnx64.tgz
 sudo ./Install-AMD-APP.sh


### PR DESCRIPTION
It appears that were lots of deadlinks that appeared in our old vagrant scripts.  I believe the current scripts should work out of the box for building the 6.1 release.  

I have uploaded a 6.1 Linux conda package here: https://binstar.org/omnia/openmm/6.1/download/linux-64/openmm-6.1-py27_0.tar.bz2
