### PR TITLE
Fix compatibility with `unit.Quantity` and numpy arrays by having array methods accept and pass through relevant arguments.

### DIFF
--- a/wrappers/python/simtk/unit/quantity.py
+++ b/wrappers/python/simtk/unit/quantity.py
@@ -580,7 +580,7 @@ class Quantity(object):
         same units as the current object rather than a plain numpy.ndarray
         """
         try:
-            return Quantity(self._value.reshape(shape, order=order))
+            return Quantity(self._value.reshape(shape, order=order), self.unit)
         except AttributeError:
             raise AttributeError('Only numpy array Quantity objects can be '
                                  'reshaped')

--- a/wrappers/python/tests/TestNumpyCompatibility.py
+++ b/wrappers/python/tests/TestNumpyCompatibility.py
@@ -75,7 +75,7 @@ class TestNumpyCompatibility(unittest.TestCase):
         f.addMap(10, energy)
         size, energy_out = f.getMapParameters(0)
     
-        assert size == 10
+        self.assertEqual(size, 10)
         np.testing.assert_array_almost_equal(energy, np.asarray(energy_out))
 
 class TestNumpyUnits(unittest.TestCase):
@@ -85,7 +85,7 @@ class TestNumpyUnits(unittest.TestCase):
 
     def testNumpyAttributes(self):
         d = self.data.reshape((100, 3))
-        self.assertTrue(unit.is_quantity(d))
+        self.assertTrue(unit.is_quantity(d) and d.unit is unit.nanometers)
         self.assertTrue(unit.is_quantity(d.sum()))
         self.assertTrue(unit.is_quantity(d.sum(axis=0)))
         self.assertTrue(unit.is_quantity(d.std()))


### PR DESCRIPTION
Also implements `reshape` so that the result is a `Quantity` rather than a `numpy.ndarray`
