### PR TITLE
Updated broken links in travis badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## OpenMM: A High Performance Molecular Dynamics Library
 
-[![Build Status](https://travis-ci.org/SimTk/openmm.png?branch=master)](https://travis-ci.org/SimTk/openmm)
+[![Build Status](https://travis-ci.org/pandegroup/openmm.png?branch=master)](https://travis-ci.org/pandegroup/openmm)
 
 Introduction
 ------------


### PR DESCRIPTION
This fixes the broken travis badge in the README.
