### PR TITLE
Fixep

### DIFF
--- a/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
@@ -720,7 +720,7 @@ def readAmberSystem(prmtop_filename=None, prmtop_loader=None, shake=None, gbmode
         system.addParticle(mass)
 
     # Add constraints.
-    isWater = [prmtop.getResidueLabel(i) == ('WAT', 'TP4', 'TP5', 'T4E') for i in range(prmtop.getNumAtoms())]
+    isWater = [prmtop.getResidueLabel(i) in ('WAT', 'TP4', 'TP5', 'T4E') for i in range(prmtop.getNumAtoms())]
     if shake in ('h-bonds', 'all-bonds', 'h-angles'):
         for (iAtom, jAtom, k, rMin) in prmtop.getBondsWithH():
             system.addConstraint(iAtom, jAtom, rMin)


### PR DESCRIPTION
At some point, at least, TP4 was the residue label for TIP4P water (I think tleap
currently translates most of the water residue labels to WAT, but there are at
least some -- like `$AMBERHOME/test/tip4p/prmtop` -- that use older labels).

This really confused me when I was trying to run tests on one of the TIP4P test files in Amber (because the _energies_ came out OK, but the dynamics is obviously screwy).
