### PR TITLE
DrudeForce did not implement getBondedParticles()

### DIFF
--- a/plugins/drude/openmmapi/include/openmm/internal/DrudeForceImpl.h
+++ b/plugins/drude/openmmapi/include/openmm/internal/DrudeForceImpl.h
@@ -64,6 +64,7 @@ public:
     }
     std::vector<std::string> getKernelNames();
     void updateParametersInContext(ContextImpl& context);
+    std::vector<std::pair<int, int> > getBondedParticles() const;
 private:
     const DrudeForce& owner;
     Kernel kernel;

--- a/plugins/drude/openmmapi/src/DrudeForceImpl.cpp
+++ b/plugins/drude/openmmapi/src/DrudeForceImpl.cpp
@@ -146,12 +146,23 @@ double DrudeForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeFor
     return 0.0;
 }
 
-std::vector<std::string> DrudeForceImpl::getKernelNames() {
-    std::vector<std::string> names;
+vector<string> DrudeForceImpl::getKernelNames() {
+    vector<string> names;
     names.push_back(CalcDrudeForceKernel::Name());
     return names;
 }
 
 void DrudeForceImpl::updateParametersInContext(ContextImpl& context) {
     kernel.getAs<CalcDrudeForceKernel>().copyParametersToContext(context, owner);
+}
+
+vector<pair<int, int> > DrudeForceImpl::getBondedParticles() const {
+    int numParticles = owner.getNumParticles();
+    vector<pair<int, int> > bonds(numParticles);
+    for (int i = 0; i < numParticles; i++) {
+        int p2, p3, p4;
+        double charge, polarizability, aniso12, aniso34;
+        owner.getParticleParameters(i, bonds[i].first, bonds[i].second, p2, p3, p4, charge, polarizability, aniso12, aniso34);
+    }
+    return bonds;
 }


### PR DESCRIPTION
This fixes a bug.  The effect was that if you used a barostat on a system with Drude particles, the Drude particles didn't get translated by exactly the same amount as the parent atom, so the barostat needed to use tiny steps before they would be accepted.
