### PR TITLE
Workaround for compiler bug in Visual Studio

### DIFF
--- a/platforms/cpu/src/CpuNonbondedForceVec8.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceVec8.cpp
@@ -32,7 +32,7 @@ using namespace std;
 using namespace OpenMM;
 
 #ifdef _MSC_VER
-    // Workaround for a compiler bug in Visual Studio 10.  Hopefully we can remove this
+    // Workaround for a compiler bug in Visual Studio 10. Hopefully we can remove this
     // once we move to a later version.
     #undef __AVX__
 #endif


### PR DESCRIPTION
Visual Studio 10 seems to have a compiler bug that occasionally causes incorrect results when using AVX, so I've disabled that.  Hopefully we can reenable it once we move to a later version of VS.
