### PR TITLE
Fixed uninitialized memory in variable step size integrators

### DIFF
--- a/openmmapi/src/VariableLangevinIntegrator.cpp
+++ b/openmmapi/src/VariableLangevinIntegrator.cpp
@@ -49,6 +49,7 @@ VariableLangevinIntegrator::VariableLangevinIntegrator(double temperature, doubl
     setErrorTolerance(errorTol);
     setConstraintTolerance(1e-5);
     setRandomNumberSeed(osrngseed());
+    setStepSize(0.0);
 }
 
 void VariableLangevinIntegrator::initialize(ContextImpl& contextRef) {

--- a/openmmapi/src/VariableVerletIntegrator.cpp
+++ b/openmmapi/src/VariableVerletIntegrator.cpp
@@ -43,6 +43,7 @@ using std::vector;
 
 VariableVerletIntegrator::VariableVerletIntegrator(double errorTol) : errorTol(errorTol) {
     setConstraintTolerance(1e-5);
+    setStepSize(0.0);
 }
 
 void VariableVerletIntegrator::initialize(ContextImpl& contextRef) {


### PR DESCRIPTION
The effect of this bug was that if you were using a variable step size integrator, and you queried the kinetic energy _before_ taking the very first time step, it would return a wrong value (often nan or infinity).
