### PR TITLE
Squash the following warning:

### DIFF
--- a/openmmapi/include/openmm/CustomHbondForce.h
+++ b/openmmapi/include/openmm/CustomHbondForce.h
@@ -474,7 +474,7 @@ public:
     GroupInfo() : p1(-1), p2(-1), p3(-1) {
     }
     GroupInfo(int p1, int p2, int p3, const std::vector<double>& parameters) :
-        p1(p1), p2(p2), p3(p3), parameters(parameters) {
+        parameters(parameters), p1(p1), p2(p2), p3(p3) {
     }
 };
 


### PR DESCRIPTION
```
/usr/local/openmm/include/openmm/CustomHbondForce.h:477:25: warning: field 'p3' will be initialized after field 'parameters' [-Wreorder]
        p1(p1), p2(p2), p3(p3), parameters(parameters) {
                            ^
```

I believe that the initializer is supposed to assign variables in the same
order they're declared in the class definition (not the same order they're
defined in the constructor argument list.

A reason this is worth squashing is that `-Wall` flags this warning (at least with clang), and it is an inline function defined directly in the `CustomHbondForce.h` header, which means that it is included by default in all client code, causing the warning to show up there.
