### PR TITLE
Fix AmoebaStretchBendForceGenerator

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -4192,7 +4192,10 @@ class AmoebaStretchBendGenerator(object):
                        raise ValueError(outputString)
 
                     else:
-                        force.addStretchBend(angle[0], angle[1], angle[2], bondAB, bondCB, angleDict['idealAngle']/radian, self.k1[i], self.k2[i])
+                        if type1 == types1:
+                            force.addStretchBend(angle[0], angle[1], angle[2], bondAB, bondCB, angleDict['idealAngle']/radian, self.k1[i], self.k2[i])
+                        else:
+                            force.addStretchBend(angle[0], angle[1], angle[2], bondAB, bondCB, angleDict['idealAngle']/radian, self.k2[i], self.k1[i])
 
                     break
 

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -127,6 +127,8 @@ class PDBFile(object):
                             upper = upper[1:]
                         if upper.startswith('CL'):
                             element = elem.chlorine
+                        elif upper.startswith('BR'):
+                            element = elem.bromine
                         elif upper.startswith('NA'):
                             element = elem.sodium
                         elif upper.startswith('MG'):


### PR DESCRIPTION
AmoebaStretchBendForceGenerator has a bug when swapping the index of A and C. It can swap the value of bondAB and bondCB, but cannot swap k1 and k2.