### PR TITLE
Copy missing ApoA1 benchmarking file into examples/ on install

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Generate and install examples.
 #
 # This is boilerplate code for generating a set of executables, one per
-# .cpp file in an "examples" subdirectory. 
+# .cpp file in an "examples" subdirectory.
 #
 # For IDEs that can deal with PROJECT_LABEL properties (at least
 # Visual Studio) the projects for building each of these adhoc
@@ -93,15 +93,15 @@ FOREACH(EX_ROOT ${F_EXAMPLES})
     INSTALL(FILES ${EX_ROOT}.f90 DESTINATION examples)
 ENDFOREACH(EX_ROOT ${F_EXAMPLES})
 
-INSTALL(FILES simulateAmber.py simulatePdb.py simulateGromacs.py benchmark.py argon-chemical-potential.py input.inpcrd input.prmtop input.pdb input.gro input.top 5dfr_minimized.pdb 5dfr_solv-cube_equil.pdb
+INSTALL(FILES simulateAmber.py simulatePdb.py simulateGromacs.py benchmark.py argon-chemical-potential.py input.inpcrd input.prmtop input.pdb input.gro input.top 5dfr_minimized.pdb 5dfr_solv-cube_equil.pdb apoa1.pdb 
         DESTINATION examples)
 
-INSTALL(FILES VisualStudio/HelloArgon.vcproj 
-              VisualStudio/HelloArgon.sln 
-              VisualStudio/HelloArgonInC.sln 
-              VisualStudio/HelloArgonInC.vcproj 
-              VisualStudio/HelloArgonInFortran.sln 
-              VisualStudio/HelloArgonInFortran.vfproj 
+INSTALL(FILES VisualStudio/HelloArgon.vcproj
+              VisualStudio/HelloArgon.sln
+              VisualStudio/HelloArgonInC.sln
+              VisualStudio/HelloArgonInC.vcproj
+              VisualStudio/HelloArgonInFortran.sln
+              VisualStudio/HelloArgonInFortran.vfproj
         DESTINATION examples/VisualStudio)
 
 INSTALL(FILES README.txt DESTINATION examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -93,7 +93,8 @@ FOREACH(EX_ROOT ${F_EXAMPLES})
     INSTALL(FILES ${EX_ROOT}.f90 DESTINATION examples)
 ENDFOREACH(EX_ROOT ${F_EXAMPLES})
 
-INSTALL(FILES simulateAmber.py simulatePdb.py simulateGromacs.py benchmark.py argon-chemical-potential.py input.inpcrd input.prmtop input.pdb input.gro input.top 5dfr_minimized.pdb 5dfr_solv-cube_equil.pdb apoa1.pdb 
+# Install Python and input files for various codes
+INSTALL(FILES *.py *.pdb *.inpcrd *.prmtop *.dms *.gro *.top *.psf *.par *.rtf
         DESTINATION examples)
 
 INSTALL(FILES VisualStudio/HelloArgon.vcproj


### PR DESCRIPTION
@peastman: The `apoa1.pdb` file (required by `benchmark.py` for some benchmarks) was not copied into `examples` on installation. This PR adds that file to the installation.

I notice there are other files in the `examples/` directory that are also not installed, such as `input-charmm36-tip5p.dms`. Should these other files be included as well?

Is there a more robust way to do this with `CMakeLists.txt` than to list all the files explicitly, especially since we seem to forget to modify this file when new example files are added?