### PR TITLE
set currentStep in DCDReporter

### DIFF
--- a/wrappers/python/simtk/openmm/app/dcdreporter.py
+++ b/wrappers/python/simtk/openmm/app/dcdreporter.py
@@ -101,7 +101,10 @@ class DCDReporter(object):
         """
 
         if self._dcd is None:
-            self._dcd = DCDFile(self._out, simulation.topology, simulation.integrator.getStepSize(), 0, self._reportInterval, self._append)
+            self._dcd = DCDFile(
+                self._out, simulation.topology, simulation.integrator.getStepSize(),
+                simulation.currentStep, self._reportInterval, self._append
+            )
         self._dcd.writeModel(state.getPositions(), periodicBoxVectors=state.getPeriodicBoxVectors())
 
     def __del__(self):


### PR DESCRIPTION
This should be the correct behavior.

When the step is initialized as 0 (current master version) postprocessing the trajectories in CHARMM leads to warnings and the first frame is skipped.