### PR TITLE
Add Softcore support to AmoebaVdwForce.

### DIFF
--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -258,12 +258,12 @@ public:
     /**
      * Set the softcore power on lambda (default = 5).
      */
-    void setSoftcorePower(double n);
+    void setSoftcorePower(int n);
 
     /**
      * Get the softcore power on lambda.
      */
-    double getSoftcorePower() const;
+    int getSoftcorePower() const;
 
     /**
      * Set the softcore alpha value (default = 0.7).

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -71,6 +71,21 @@ public:
     };
 
     /**
+     * This is an enumeration of the different alchemical methods used when applying softcore interactions.
+     */
+    enum AlchemicalMethod {
+        /**
+         * Maintain full strength vdW interactions between two alchemical particles. This is the default.
+         */
+        Decouple = 0,
+        /**
+         * Interactions between two alchemical particles are turned off at lambda=0.
+         */
+        Annihilate = 1,
+    };
+
+
+    /**
      * Create an Amoeba VdwForce.
      */
     AmoebaVdwForce();
@@ -91,8 +106,9 @@ public:
      * @param epsilon         vdw epsilon
      * @param reductionFactor the fraction of the distance along the line from the parent particle to this particle
      *                        at which the interaction site should be placed
+     * @param isAlchemical    if true, this vdW particle is undergoing an alchemical change.
      */
-    void setParticleParameters(int particleIndex, int parentIndex, double sigma, double epsilon, double reductionFactor);
+    void setParticleParameters(int particleIndex, int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical);
 
     /**
      * Get the force field parameters for a vdw particle.
@@ -103,8 +119,11 @@ public:
      * @param[out] epsilon         vdw epsilon
      * @param[out] reductionFactor the fraction of the distance along the line from the parent particle to this particle
      *                             at which the interaction site should be placed
+     * @param[out] isAlchemical    if true, this vdW particle is undergoing an alchemical change.
      */
-    void getParticleParameters(int particleIndex, int& parentIndex, double& sigma, double& epsilon, double& reductionFactor) const;
+     */
+    void getParticleParameters(int particleIndex, int& parentIndex, double& sigma, double& epsilon, 
+                               double& reductionFactor, bool& isAlchemical) const;
 
 
     /**
@@ -115,9 +134,10 @@ public:
      * @param epsilon         vdw epsilon
      * @param reductionFactor the fraction of the distance along the line from the parent particle to this particle
      *                        at which the interaction site should be placed
+     * @param isAlchemical    if true, this vdW particle is undergoing an alchemical change.
      * @return index of added particle
      */
-    int addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor);
+    int addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical);
 
     /**
      * Set sigma combining rule
@@ -223,6 +243,47 @@ public:
      * Set the method used for handling long range nonbonded interactions.
      */
     void setNonbondedMethod(NonbondedMethod method);
+
+    /**
+     * Set the vdw Lambda value.
+     */
+    void setLambda(double lambda);
+
+    /**
+     * Get the vdw Lambda value.
+     */
+    double getLambda() const;
+
+    /**
+     * Set the softcore power on lambda.
+     */
+    void setN(double n);
+
+    /**
+     * Get the softcore power on lambda.
+     */
+    double getN() const;
+
+    /**
+     * Set the softcore alpha value.
+     */
+    void setAlpha(double alpha);
+
+    /**
+     * Get the softcore alpha value.
+     */
+    double getAlpha() const;
+
+    /**
+     * Get the method used for alchemical interactions.
+     */
+    AlchemicalMethod getAlchemicalMethod() const;
+
+    /**
+     * Set the method used for handling long range nonbonded interactions.
+     */
+    void setAlchemicalMethod(AlchemicalMethod method);
+
     /**
      * Update the per-particle parameters in a Context to match those stored in this Force object.  This method provides
      * an efficient method to update certain parameters in an existing Context without needing to reinitialize it.
@@ -250,6 +311,9 @@ private:
     NonbondedMethod nonbondedMethod;
     double cutoff;
     bool useDispersionCorrection;
+    double amoebaVdwLambda;
+    int n;
+    double alpha;
 
     std::string sigmaCombiningRule;
     std::string epsilonCombiningRule;
@@ -267,14 +331,16 @@ class AmoebaVdwForce::VdwInfo {
 public:
     int parentIndex;
     double reductionFactor, sigma, epsilon, cutoff;
+    bool isAlchemical;
     VdwInfo() {
         parentIndex = -1;
         reductionFactor      = 0.0;
         sigma                = 1.0;
         epsilon              = 0.0;
+        isAlchemical         = false;
     }
-    VdwInfo(int parentIndex, double sigma, double epsilon, double reductionFactor) :
-        parentIndex(parentIndex), reductionFactor(reductionFactor), sigma(sigma), epsilon(epsilon)  {
+    VdwInfo(int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical) :
+        parentIndex(parentIndex), reductionFactor(reductionFactor), sigma(sigma), epsilon(epsilon), isAlchemical(isAlchemical)  {
     }
 };
 

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -312,9 +312,9 @@ private:
     NonbondedMethod nonbondedMethod;
     double cutoff;
     bool useDispersionCorrection;
-    AlchemicalMethod alchemicalMethod = AlchemicalMethod.None;
-    int n = 5;
-    double alpha = 0.7;
+    AlchemicalMethod alchemicalMethod;
+    int n;
+    double alpha;
 
     std::string sigmaCombiningRule;
     std::string epsilonCombiningRule;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -50,6 +50,19 @@ namespace OpenMM {
  * particle to another one.  This is typically done for hydrogens to place the interaction site slightly
  * closer to the parent atom.  The fraction is known as the "reduction factor", since it reduces the distance
  * from the parent atom to the interaction site.
+ *
+ * Support is also available for softcore interactions based on setting a per particle alchemical flag and
+ * setting the AmoebaVdwForce to use an "AlchemicalMethod" -- either Decouple or Annihilate.
+ * For Decouple, two alchemical atoms interact normally. For Annihilate, all interactions involving an 
+ * alchemical atom are influenced. The softcore state is specified by setting a single 
+ * Context parameter "AmoebaVdwLambda" between 0.0 and 1.0.
+ *
+ * The softcore functional form can be modified by setting the softcore power (default of 5) and the softcore
+ * alpha (default of 0,7). For more information on the softcore functional form see Eq. 2 from:
+ * Jiao, D.;  Golubkov, P. A.;  Darden, T. A.; Ren, P., 
+ * Calculation of protein-ligand binding free energy by using a polarizable potential.
+ * Proc. Natl. Acad. Sci. U.S.A. 2008, 105 (17), 6290-6295.
+ * https://www.pnas.org/content/105/17/6290.
  */
 
 class OPENMM_EXPORT_AMOEBA AmoebaVdwForce : public Force {

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -55,6 +55,14 @@ namespace OpenMM {
 class OPENMM_EXPORT_AMOEBA AmoebaVdwForce : public Force {
 public:
     /**
+     * This is the name of the parameter which stores the current Amoeba vdW lambda value.
+     */
+    static const std::string& Lambda() {
+        static const std::string key = "AmoebaVdwLambda";
+        return key;
+    }
+
+    /**
      * This is an enumeration of the different methods that may be used for handling long range nonbonded forces.
      */
     enum NonbondedMethod {
@@ -75,15 +83,18 @@ public:
      */
     enum AlchemicalMethod {
         /**
-         * Maintain full strength vdW interactions between two alchemical particles. This is the default.
+         * All vdW interactions are treated normally. This is the default.
          */
-        Decouple = 0,
+        None = 0,
+        /**
+         * Maintain full strength vdW interactions between two alchemical particles.
+         */
+        Decouple = 1,
         /**
          * Interactions between two alchemical particles are turned off at lambda=0.
          */
-        Annihilate = 1,
+        Annihilate = 2,
     };
-
 
     /**
      * Create an Amoeba VdwForce.
@@ -108,7 +119,8 @@ public:
      *                        at which the interaction site should be placed
      * @param isAlchemical    if true, this vdW particle is undergoing an alchemical change.
      */
-    void setParticleParameters(int particleIndex, int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical);
+    void setParticleParameters(int particleIndex, int parentIndex, double sigma, double epsilon, 
+                               double reductionFactor, bool isAlchemical = false);
 
     /**
      * Get the force field parameters for a vdw particle.
@@ -120,7 +132,6 @@ public:
      * @param[out] reductionFactor the fraction of the distance along the line from the parent particle to this particle
      *                             at which the interaction site should be placed
      * @param[out] isAlchemical    if true, this vdW particle is undergoing an alchemical change.
-     */
      */
     void getParticleParameters(int particleIndex, int& parentIndex, double& sigma, double& epsilon, 
                                double& reductionFactor, bool& isAlchemical) const;
@@ -137,7 +148,7 @@ public:
      * @param isAlchemical    if true, this vdW particle is undergoing an alchemical change.
      * @return index of added particle
      */
-    int addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical);
+    int addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical = false);
 
     /**
      * Set sigma combining rule
@@ -245,34 +256,24 @@ public:
     void setNonbondedMethod(NonbondedMethod method);
 
     /**
-     * Set the vdw Lambda value.
+     * Set the softcore power on lambda (default = 5).
      */
-    void setLambda(double lambda);
-
-    /**
-     * Get the vdw Lambda value.
-     */
-    double getLambda() const;
-
-    /**
-     * Set the softcore power on lambda.
-     */
-    void setN(double n);
+    void setSoftcorePower(double n);
 
     /**
      * Get the softcore power on lambda.
      */
-    double getN() const;
+    double getSoftcorePower() const;
 
     /**
-     * Set the softcore alpha value.
+     * Set the softcore alpha value (default = 0.7).
      */
-    void setAlpha(double alpha);
+    void setSoftcoreAlpha(double alpha);
 
     /**
      * Get the softcore alpha value.
      */
-    double getAlpha() const;
+    double getSoftcoreAlpha() const;
 
     /**
      * Get the method used for alchemical interactions.
@@ -311,9 +312,9 @@ private:
     NonbondedMethod nonbondedMethod;
     double cutoff;
     bool useDispersionCorrection;
-    double amoebaVdwLambda;
-    int n;
-    double alpha;
+    AlchemicalMethod alchemicalMethod = AlchemicalMethod.None;
+    int n = 5;
+    double alpha = 0.7;
 
     std::string sigmaCombiningRule;
     std::string epsilonCombiningRule;

--- a/plugins/amoeba/openmmapi/include/openmm/internal/AmoebaVdwForceImpl.h
+++ b/plugins/amoeba/openmmapi/include/openmm/internal/AmoebaVdwForceImpl.h
@@ -60,7 +60,9 @@ public:
     }
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups);
     std::map<std::string, double> getDefaultParameters() {
-        return std::map<std::string, double>(); // This force field doesn't define any parameters.
+       std::map<std::string, double> parameters;
+       parameters[AmoebaVdwForce::Lambda()] = 1.0;
+       return parameters;
     }
     std::vector<std::string> getKernelNames();
     /**

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForce.cpp
@@ -140,11 +140,11 @@ void AmoebaVdwForce::setAlchemicalMethod(AlchemicalMethod method) {
     alchemicalMethod = method;
 }
 
-void AmoebaVdwForce::setSoftcorePower(double power) {
+void AmoebaVdwForce::setSoftcorePower(int power) {
     n = power;
 }
 
-double AmoebaVdwForce::getSoftcorePower() const {
+int AmoebaVdwForce::getSoftcorePower() const {
     return n;
 }
 

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForce.cpp
@@ -38,28 +38,30 @@ using namespace OpenMM;
 using std::string;
 using std::vector;
 
-AmoebaVdwForce::AmoebaVdwForce() : nonbondedMethod(NoCutoff), sigmaCombiningRule("CUBIC-MEAN"), epsilonCombiningRule("HHG"), cutoff(1.0e+10), useDispersionCorrection(true) {
+AmoebaVdwForce::AmoebaVdwForce() : nonbondedMethod(NoCutoff), sigmaCombiningRule("CUBIC-MEAN"), epsilonCombiningRule("HHG"), cutoff(1.0e+10), useDispersionCorrection(true), alchemicalMethod(None), n(5), alpha(0.7) {
 }
 
-int AmoebaVdwForce::addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor) {
-    parameters.push_back(VdwInfo(parentIndex, sigma, epsilon, reductionFactor));
+int AmoebaVdwForce::addParticle(int parentIndex, double sigma, double epsilon, double reductionFactor, bool isAlchemical) {
+    parameters.push_back(VdwInfo(parentIndex, sigma, epsilon, reductionFactor, isAlchemical));
     return parameters.size()-1;
 }
 
 void AmoebaVdwForce::getParticleParameters(int particleIndex, int& parentIndex,
-                                           double& sigma, double& epsilon, double& reductionFactor) const {
+                                           double& sigma, double& epsilon, double& reductionFactor, bool& isAlchemical) const {
     parentIndex     = parameters[particleIndex].parentIndex;
     sigma           = parameters[particleIndex].sigma;
     epsilon         = parameters[particleIndex].epsilon;
     reductionFactor = parameters[particleIndex].reductionFactor;
+    isAlchemical    = parameters[particleIndex].isAlchemical;
 }
 
 void AmoebaVdwForce::setParticleParameters(int particleIndex, int parentIndex,
-                                           double sigma, double epsilon, double reductionFactor) {
+                                           double sigma, double epsilon, double reductionFactor, bool isAlchemical) {
     parameters[particleIndex].parentIndex     = parentIndex;
     parameters[particleIndex].sigma           = sigma;
     parameters[particleIndex].epsilon         = epsilon;
     parameters[particleIndex].reductionFactor = reductionFactor;
+    parameters[particleIndex].isAlchemical    = isAlchemical;
 }
 
 void AmoebaVdwForce::setSigmaCombiningRule(const std::string& inputSigmaCombiningRule) {
@@ -127,6 +129,33 @@ void AmoebaVdwForce::setNonbondedMethod(NonbondedMethod method) {
         throw OpenMMException("AmoebaVdwForce: Illegal value for nonbonded method");
     nonbondedMethod = method;
 }
+
+AmoebaVdwForce::AlchemicalMethod AmoebaVdwForce::getAlchemicalMethod() const {
+    return alchemicalMethod;
+}
+
+void AmoebaVdwForce::setAlchemicalMethod(AlchemicalMethod method) {
+    if (method < 0 || method > 2)
+        throw OpenMMException("AmoebaVdwForce: Illegal value for alchemical method");
+    alchemicalMethod = method;
+}
+
+void AmoebaVdwForce::setSoftcorePower(double power) {
+    n = power;
+}
+
+double AmoebaVdwForce::getSoftcorePower() const {
+    return n;
+}
+
+void AmoebaVdwForce::setSoftcoreAlpha(double a) {
+    alpha = a;
+}
+
+double AmoebaVdwForce::getSoftcoreAlpha() const {
+    return alpha;
+}
+
 
 ForceImpl* AmoebaVdwForce::createImpl() const {
     return new AmoebaVdwForceImpl(*this);

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
@@ -260,3 +260,5 @@ std::vector<std::string> AmoebaVdwForceImpl::getKernelNames() {
 void AmoebaVdwForceImpl::updateParametersInContext(ContextImpl& context) {
     kernel.getAs<CalcAmoebaVdwForceKernel>().copyParametersToContext(context, owner);
 }
+
+

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
@@ -91,7 +91,7 @@ double AmoebaVdwForceImpl::calcDispersionCorrection(const System& system, const 
     for (int i = 0; i < force.getNumParticles(); i++) {
         double sigma, epsilon, reduction;
         bool isAlchemical;
-        // The variables reduction, ivindex are not used.
+        // The variables reduction, ivindex and isAlchemical are not used.
         int ivindex;
         // Get the sigma and epsilon parameters, ignoring everything else.
         force.getParticleParameters(i, ivindex, sigma, epsilon, reduction, isAlchemical);
@@ -152,8 +152,11 @@ double AmoebaVdwForceImpl::calcDispersionCorrection(const System& system, const 
     int ndelta = int(double(nstep) * (range - cut));
     double rdelta = (range - cut) / double(ndelta);
     double offset = cut - 0.5 * rdelta;
-    double dhal = 0.07; // This magic number also appears in kCalculateAmoebaCudaVdw14_7.cu
-    double ghal = 0.12; // This magic number also appears in kCalculateAmoebaCudaVdw14_7.cu
+
+    // Buffered-14-7 buffering constants
+    double dhal = 0.07; 
+    double ghal = 0.12;
+
     double elrc = 0.0; // This number is incremented and passed out at the end
     double e = 0.0;
     double sigma, epsilon; // The pairwise sigma and epsilon parameters.

--- a/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaVdwForceImpl.cpp
@@ -90,10 +90,11 @@ double AmoebaVdwForceImpl::calcDispersionCorrection(const System& system, const 
     map<pair<double, double>, int> classCounts;
     for (int i = 0; i < force.getNumParticles(); i++) {
         double sigma, epsilon, reduction;
+        bool isAlchemical;
         // The variables reduction, ivindex are not used.
         int ivindex;
         // Get the sigma and epsilon parameters, ignoring everything else.
-        force.getParticleParameters(i, ivindex, sigma, epsilon, reduction);
+        force.getParticleParameters(i, ivindex, sigma, epsilon, reduction, isAlchemical);
         pair<double, double> key = make_pair(sigma, epsilon);
         map<pair<double, double>, int>::iterator entry = classCounts.find(key);
         if (entry == classCounts.end())

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -2343,9 +2343,10 @@ public:
     bool areParticlesIdentical(int particle1, int particle2) {
         int iv1, iv2;
         double sigma1, sigma2, epsilon1, epsilon2, reduction1, reduction2;
-        force.getParticleParameters(particle1, iv1, sigma1, epsilon1, reduction1);
-        force.getParticleParameters(particle2, iv2, sigma2, epsilon2, reduction2);
-        return (sigma1 == sigma2 && epsilon1 == epsilon2 && reduction1 == reduction2);
+        bool isAlchemical1, isAlchemical2;
+        force.getParticleParameters(particle1, iv1, sigma1, epsilon1, reduction1, isAlchemical1);
+        force.getParticleParameters(particle2, iv2, sigma2, epsilon2, reduction2, isAlchemical2);
+        return (sigma1 == sigma2 && epsilon1 == epsilon2 && reduction1 == reduction2 && isAlchemical1 == isAlchemical2);
     }
 private:
     const AmoebaVdwForce& force;
@@ -2378,7 +2379,8 @@ void CudaCalcAmoebaVdwForceKernel::initialize(const System& system, const Amoeba
     for (int i = 0; i < force.getNumParticles(); i++) {
         int ivIndex;
         double sigma, epsilon, reductionFactor;
-        force.getParticleParameters(i, ivIndex, sigma, epsilon, reductionFactor);
+        bool isAlchemical;
+        force.getParticleParameters(i, ivIndex, sigma, epsilon, reductionFactor, isAlchemical);
         sigmaEpsilonVec[i] = make_float2((float) sigma, (float) epsilon);
         bondReductionAtomsVec[i] = ivIndex;
         bondReductionFactorsVec[i] = (float) reductionFactor;
@@ -2479,7 +2481,8 @@ void CudaCalcAmoebaVdwForceKernel::copyParametersToContext(ContextImpl& context,
     for (int i = 0; i < force.getNumParticles(); i++) {
         int ivIndex;
         double sigma, epsilon, reductionFactor;
-        force.getParticleParameters(i, ivIndex, sigma, epsilon, reductionFactor);
+        bool isAlchemical;
+        force.getParticleParameters(i, ivIndex, sigma, epsilon, reductionFactor, isAlchemical);
         sigmaEpsilonVec[i] = make_float2((float) sigma, (float) epsilon);
         bondReductionAtomsVec[i] = ivIndex;
         bondReductionFactorsVec[i] = (float) reductionFactor;

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -2365,7 +2365,7 @@ CudaCalcAmoebaVdwForceKernel::~CudaCalcAmoebaVdwForceKernel() {
 void CudaCalcAmoebaVdwForceKernel::initialize(const System& system, const AmoebaVdwForce& force) {
     cu.setAsCurrent();
     sigmaEpsilon.initialize<float2>(cu, cu.getPaddedNumAtoms(), "sigmaEpsilon");
-    isAlchemical.initialize<int>(cu, cu.getPaddedNumAtoms(), "isAlchemical");
+    isAlchemical.initialize<float>(cu, cu.getPaddedNumAtoms(), "isAlchemical");
     vdwLambda.initialize<float>(cu, 1, "vdwLambda");
     bondReductionAtoms.initialize<int>(cu, cu.getPaddedNumAtoms(), "bondReductionAtoms");
     bondReductionFactors.initialize<float>(cu, cu.getPaddedNumAtoms(), "bondReductionFactors");
@@ -2375,7 +2375,7 @@ void CudaCalcAmoebaVdwForceKernel::initialize(const System& system, const Amoeba
     // Record atom parameters.
     
     vector<float2> sigmaEpsilonVec(cu.getPaddedNumAtoms(), make_float2(0, 1));
-    vector<int> isAlchemicalVec(cu.getPaddedNumAtoms(), 0);
+    vector<float> isAlchemicalVec(cu.getPaddedNumAtoms(), 0);
     vector<int> bondReductionAtomsVec(cu.getPaddedNumAtoms(), 0);
     vector<float> bondReductionFactorsVec(cu.getPaddedNumAtoms(), 0);
     vector<vector<int> > exclusions(cu.getNumAtoms());
@@ -2385,7 +2385,7 @@ void CudaCalcAmoebaVdwForceKernel::initialize(const System& system, const Amoeba
         bool alchemical;
         force.getParticleParameters(i, ivIndex, sigma, epsilon, reductionFactor, alchemical);
         sigmaEpsilonVec[i] = make_float2((float) sigma, (float) epsilon);
-        isAlchemicalVec[i] = (alchemical) ? 1 : 0;
+        isAlchemicalVec[i] = (alchemical) ? 1.0f : 0.0f;
         bondReductionAtomsVec[i] = ivIndex;
         bondReductionFactorsVec[i] = (float) reductionFactor;
         force.getParticleExclusions(i, exclusions[i]);
@@ -2402,7 +2402,7 @@ void CudaCalcAmoebaVdwForceKernel::initialize(const System& system, const Amoeba
 
     // A single lambda parameter to define the alchemical vdW state.
     vector<float> vdwLambdaVec(1, 0);
-    vdwLambdaVec[0] = 1.0;
+    vdwLambdaVec[0] = 1.0f;
     vdwLambda.upload(vdwLambdaVec);
  
     // This force is applied based on modified atom positions, where hydrogens have been moved slightly
@@ -2411,7 +2411,7 @@ void CudaCalcAmoebaVdwForceKernel::initialize(const System& system, const Amoeba
     
     nonbonded = new CudaNonbondedUtilities(cu);
     nonbonded->addParameter(CudaNonbondedUtilities::ParameterInfo("sigmaEpsilon", "float", 2, sizeof(float2), sigmaEpsilon.getDevicePointer()));
-    nonbonded->addParameter(CudaNonbondedUtilities::ParameterInfo("isAlchemical", "int", 1, sizeof(int), isAlchemical.getDevicePointer()));
+    nonbonded->addParameter(CudaNonbondedUtilities::ParameterInfo("isAlchemical", "float", 1, sizeof(float), isAlchemical.getDevicePointer()));
     nonbonded->addArgument(CudaNonbondedUtilities::ParameterInfo("vdwLambda", "float", 1, sizeof(float), vdwLambda.getDevicePointer()));
     
     // Create the interaction kernel.
@@ -2498,7 +2498,7 @@ void CudaCalcAmoebaVdwForceKernel::copyParametersToContext(ContextImpl& context,
     
     // Record the per-particle parameters.
     vector<float2> sigmaEpsilonVec(cu.getPaddedNumAtoms(), make_float2(0, 1));
-    vector<int> isAlchemicalVec(cu.getPaddedNumAtoms(), 0);
+    vector<float> isAlchemicalVec(cu.getPaddedNumAtoms(), 0);
     vector<int> bondReductionAtomsVec(cu.getPaddedNumAtoms(), 0);
     vector<float> bondReductionFactorsVec(cu.getPaddedNumAtoms(), 0);
     for (int i = 0; i < force.getNumParticles(); i++) {
@@ -2507,7 +2507,7 @@ void CudaCalcAmoebaVdwForceKernel::copyParametersToContext(ContextImpl& context,
         bool alchemical;
         force.getParticleParameters(i, ivIndex, sigma, epsilon, reductionFactor, alchemical);
         sigmaEpsilonVec[i] = make_float2((float) sigma, (float) epsilon);
-        isAlchemicalVec[i] = (alchemical) ? 1 : 0;
+        isAlchemicalVec[i] = (alchemical) ? 1.0f : 0.0f;
         bondReductionAtomsVec[i] = ivIndex;
         bondReductionFactorsVec[i] = (float) reductionFactor;
     }

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -571,12 +571,22 @@ private:
     CudaContext& cu;
     const System& system;
     bool hasInitializedNonbonded;
+
+    // True if the AmoebaVdwForce AlchemicalMethod is not None.
+    bool hasAlchemical;
+    // Pinned host memory; allocated if necessary in initialize, and freed in the destructor.
+    void* vdwLambdaPinnedBuffer;
+    // Device memory for the alchemical state.
+    CudaArray vdwLambda;
+    // Only update device memory when lambda changes.
+    float currentVdwLambda;
+    // Per particle alchemical flag.
+    CudaArray isAlchemical;
+
     double dispersionCoefficient;
     CudaArray sigmaEpsilon;
     CudaArray bondReductionAtoms;
     CudaArray bondReductionFactors;
-    CudaArray isAlchemical;
-    CudaArray vdwLambda;
     CudaArray tempPosq;
     CudaArray tempForces;
     CudaNonbondedUtilities* nonbonded;

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -547,7 +547,7 @@ public:
      * Initialize the kernel.
      * 
      * @param system     the System this kernel will be applied to
-     * @param force      the AmoebaMultipoleForce this kernel will be used for
+     * @param force      the AmoebaVdwForce this kernel will be used for
      */
     void initialize(const System& system, const AmoebaVdwForce& force);
     /**
@@ -575,6 +575,7 @@ private:
     CudaArray sigmaEpsilon;
     CudaArray bondReductionAtoms;
     CudaArray bondReductionFactors;
+    CudaArray isAlchemical
     CudaArray tempPosq;
     CudaArray tempForces;
     CudaNonbondedUtilities* nonbonded;

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -575,7 +575,8 @@ private:
     CudaArray sigmaEpsilon;
     CudaArray bondReductionAtoms;
     CudaArray bondReductionFactors;
-    CudaArray isAlchemical
+    CudaArray isAlchemical;
+    CudaArray vdwLambda;
     CudaArray tempPosq;
     CudaArray tempForces;
     CudaNonbondedUtilities* nonbonded;

--- a/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
@@ -29,13 +29,13 @@
     real softcore = 0.0f;
 #if VDW_ALCHEMICAL_METHOD == 1
     if (isAlchemical1 != isAlchemical2) { 
-       epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
-       softcore = VDW_SOFTCORE_ALPHA * (1.0 - vdwLambda) * (1.0 - vdwLambda);
-    }
 #elif VDW_ALCHEMICAL_METHOD == 2 
     if (isAlchemical1 || isAlchemical2) {
-       epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
-       softcore = VDW_SOFTCORE_ALPHA * (1.0 - vdwLambda) * (1.0 - vdwLambda);
+#endif
+#if VDW_ALCHEMICAL_METHOD != 0
+       real lambda = vdwLambda[0];
+       epsilon = epsilon * POW(lambda, VDW_SOFTCORE_POWER);
+       softcore = VDW_SOFTCORE_ALPHA * (1.0f - lambda) * (1.0f - lambda);
     }
 #endif
     real dhal = 0.07f;

--- a/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
@@ -1,4 +1,4 @@
-
+{
 #ifdef USE_CUTOFF
     unsigned int includeInteraction = (!isExcluded && r2 < CUTOFF_SQUARED);
 #else
@@ -26,46 +26,38 @@
     real epsilon_s = SQRT(sigmaEpsilon1.y) + SQRT(sigmaEpsilon2.y);
     real epsilon = (epsilon_s == 0.0f ? (real) 0 : 4*sigmaEpsilon1.y*sigmaEpsilon2.y/(epsilon_s*epsilon_s));
 #endif
-
     real softcore = 0.0f;
 #if VDW_ALCHEMICAL_METHOD == 1
-    // Decouple
     if (isAlchemical1 != isAlchemical2) { 
        epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
        softcore = VDW_SOFTCORE_ALPHA * (1.0 - vdwLambda) * (1.0 - vdwLambda);
     }
-#else if VDW_ALCHEMICAL_METHOD == 2 
-    // Annihilate
+#elif VDW_ALCHEMICAL_METHOD == 2 
     if (isAlchemical1 || isAlchemical2) {
        epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
        softcore = VDW_SOFTCORE_ALPHA * (1.0 - vdwLambda) * (1.0 - vdwLambda);
     }
-@endif
-
-    // The Buffered-14-7 buffering constants.
-    real dhal = 0.07;
-    real ghal = 0.12;
-    // The buffering constant plus one.
-    real dhal1 = 1.07;
-    real ghal1 = 1.12;
-
+#endif
+    real dhal = 0.07f;
+    real ghal = 0.12f;
+    real dhal1 = 1.07f;
+    real ghal1 = 1.12f;
     real rho = r / sigma;
     real rho2 = rho * rho;
     real rho6 = rho2 * rho2 * rho2;
     real rhoplus = rho + dhal;
     real rhodec2 = rhoplus * rhoplus;
     real rhodec = rhodec2 * rhodec2 * rhodec2;
-    real s1 = 1.0 / (softcore + rhodec * rhoplus);
-    real s2 = 1.0 / (softcore + rho6 * rho + 0.12);
+    real s1 = 1.0f / (softcore + rhodec * rhoplus);
+    real s2 = 1.0f / (softcore + rho6 * rho + ghal);
     real point72 = dhal1 * dhal1;
     real t1 = dhal1 * point72 * point72 * point72 * s1;
     real t2 = ghal1 * s2;
-    real t2min = t2 - 2;
-    real dt1 = -7.0 * rhodec * t1 * s1;
-    real dt2 = -7.0 * rho6 * t2 * s2;
+    real t2min = t2 - 2.0f;
+    real dt1 = -7.0f * rhodec * t1 * s1;
+    real dt2 = -7.0f * rho6 * t2 * s2;
     real termEnergy = epsilon * t1 * t2min;
     real deltaE = epsilon * (dt1 * t2min + t1 * dt2) / sigma;
-
 #ifdef USE_CUTOFF
     if (r > TAPER_CUTOFF) {
         real x = r-TAPER_CUTOFF;

--- a/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
@@ -27,22 +27,18 @@
     real epsilon = (epsilon_s == 0.0f ? (real) 0 : 4*sigmaEpsilon1.y*sigmaEpsilon2.y/(epsilon_s*epsilon_s));
 #endif
 
-    real softcore = 0.0;
-#if USE_SOFTCORE == 1
+    real softcore = 0.0f;
+#if VDW_ALCHEMICAL_METHOD == 1
     // Decouple
-    bool both = isAlchemicalI && isAlchemicalJ;
-    bool either = isAlchemicalI || isAlchemicalJ;
-    bool soft = !both && either;
-    if (soft) { 
+    if (isAlchemical1 != isAlchemical2) { 
        epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
-       softcore = VDW_SOFTCORE_ALPHA * (1.0 - VDW_LAMBDA) * (1.0 - VDW_LAMBDA);
+       softcore = VDW_SOFTCORE_ALPHA * (1.0 - vdwLambda) * (1.0 - vdwLambda);
     }
-#else if USE_SOFTCORE == 2 
+#else if VDW_ALCHEMICAL_METHOD == 2 
     // Annihilate
-    bool soft = isAlchemicalI || isAlchemicalJ;
-    if (soft) {
+    if (isAlchemical1 || isAlchemical2) {
        epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
-       softcore = VDW_SOFTCORE_ALPHA * (1.0 - VDW_LAMBDA) * (1.0 - VDW_LAMBDA);
+       softcore = VDW_SOFTCORE_ALPHA * (1.0 - vdwLambda) * (1.0 - vdwLambda);
     }
 @endif
 

--- a/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/amoebaVdwForce2.cu
@@ -1,4 +1,4 @@
-{
+
 #ifdef USE_CUTOFF
     unsigned int includeInteraction = (!isExcluded && r2 < CUTOFF_SQUARED);
 #else
@@ -26,20 +26,50 @@
     real epsilon_s = SQRT(sigmaEpsilon1.y) + SQRT(sigmaEpsilon2.y);
     real epsilon = (epsilon_s == 0.0f ? (real) 0 : 4*sigmaEpsilon1.y*sigmaEpsilon2.y/(epsilon_s*epsilon_s));
 #endif
-    real r6 = r2*r2*r2;
-    real r7 = r6*r;
-    real sigma7 = sigma*sigma;
-    sigma7 = sigma7*sigma7*sigma7*sigma;
-    real rho = r7 + sigma7*0.12f;
-    real invRho = RECIP(rho);
-    real tau = 1.07f/(r + 0.07f*sigma);
-    real tau7 = tau*tau*tau;
-    tau7 = tau7*tau7*tau;
-    real dTau = tau/1.07f;
-    real tmp = sigma7*invRho;
-    real gTau = epsilon*tau7*r6*1.12f*tmp*tmp;
-    real termEnergy = epsilon*sigma7*tau7*((sigma7*1.12f*invRho)-2.0f);
-    real deltaE = -7.0f*(dTau*termEnergy+gTau);
+
+    real softcore = 0.0;
+#if USE_SOFTCORE == 1
+    // Decouple
+    bool both = isAlchemicalI && isAlchemicalJ;
+    bool either = isAlchemicalI || isAlchemicalJ;
+    bool soft = !both && either;
+    if (soft) { 
+       epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
+       softcore = VDW_SOFTCORE_ALPHA * (1.0 - VDW_LAMBDA) * (1.0 - VDW_LAMBDA);
+    }
+#else if USE_SOFTCORE == 2 
+    // Annihilate
+    bool soft = isAlchemicalI || isAlchemicalJ;
+    if (soft) {
+       epsilon = epsilon * pow(VDW_LAMBDA, VDW_SOFTCORE_POWER);
+       softcore = VDW_SOFTCORE_ALPHA * (1.0 - VDW_LAMBDA) * (1.0 - VDW_LAMBDA);
+    }
+@endif
+
+    // The Buffered-14-7 buffering constants.
+    real dhal = 0.07;
+    real ghal = 0.12;
+    // The buffering constant plus one.
+    real dhal1 = 1.07;
+    real ghal1 = 1.12;
+
+    real rho = r / sigma;
+    real rho2 = rho * rho;
+    real rho6 = rho2 * rho2 * rho2;
+    real rhoplus = rho + dhal;
+    real rhodec2 = rhoplus * rhoplus;
+    real rhodec = rhodec2 * rhodec2 * rhodec2;
+    real s1 = 1.0 / (softcore + rhodec * rhoplus);
+    real s2 = 1.0 / (softcore + rho6 * rho + 0.12);
+    real point72 = dhal1 * dhal1;
+    real t1 = dhal1 * point72 * point72 * point72 * s1;
+    real t2 = ghal1 * s2;
+    real t2min = t2 - 2;
+    real dt1 = -7.0 * rhodec * t1 * s1;
+    real dt2 = -7.0 * rho6 * t2 * s2;
+    real termEnergy = epsilon * t1 * t2min;
+    real deltaE = epsilon * (dt1 * t2min + t1 * dt2) / sigma;
+
 #ifdef USE_CUTOFF
     if (r > TAPER_CUTOFF) {
         real x = r-TAPER_CUTOFF;

--- a/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaVdwForce.cpp
+++ b/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaVdwForce.cpp
@@ -197,17 +197,25 @@ void testVdw() {
     ASSERT_EQUAL_TOL(state1.getPotentialEnergy(), state2.getPotentialEnergy(), tolerance);
 }
 
-void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule, double cutoff,
-                                       double boxDimension, std::vector<Vec3>& forces, double& energy) {
+void setupAndGetForcesEnergyVdwAmmonia2(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule, double cutoff,
+                                       double boxDimension, std::vector<Vec3>& forces, double& energy,
+                                       AmoebaVdwForce::AlchemicalMethod alchemicalMethod, int softcorePower, double softcoreAlpha, double vdwLambda){
 
     // beginning of Vdw setup
 
     System system;
-    AmoebaVdwForce* amoebaVdwForce        = new AmoebaVdwForce();;
+    AmoebaVdwForce* amoebaVdwForce        = new AmoebaVdwForce();
     int numberOfParticles                 = 8;
     amoebaVdwForce->setSigmaCombiningRule(sigmaCombiningRule);
     amoebaVdwForce->setEpsilonCombiningRule(epsilonCombiningRule);
     amoebaVdwForce->setCutoff(cutoff);
+    bool alchemical = false;
+    if (alchemicalMethod != AmoebaVdwForce::None) {
+       amoebaVdwForce->setAlchemicalMethod(alchemicalMethod);
+       amoebaVdwForce->setSoftcorePower(softcorePower);
+       amoebaVdwForce->setSoftcoreAlpha(softcoreAlpha);
+       alchemical = true;
+    }
     if (boxDimension > 0.0) {
         Vec3 a(boxDimension, 0.0, 0.0);
         Vec3 b(0.0, boxDimension, 0.0);
@@ -215,10 +223,12 @@ void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, co
         system.setDefaultPeriodicBoxVectors(a, b, c);
         amoebaVdwForce->setNonbondedMethod(AmoebaVdwForce::CutoffPeriodic);
         amoebaVdwForce->setUseDispersionCorrection(1);
-    } else {
+    }
+    else {
         amoebaVdwForce->setNonbondedMethod(AmoebaVdwForce::NoCutoff);
         amoebaVdwForce->setUseDispersionCorrection(0);
     }
+
 
     // addParticle: ivIndex, radius, epsilon, reductionFactor
 
@@ -235,16 +245,16 @@ void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, co
     amoebaVdwForce->addParticle(0,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
 
     system.addParticle(  1.4007000e+01);
-    amoebaVdwForce->addParticle(4,   1.8550000e-01,   4.3932000e-01,   0.0000000e+00);
+    amoebaVdwForce->addParticle(4,   1.8550000e-01,   4.3932000e-01,   0.0000000e+00, alchemical);
 
     system.addParticle(  1.0080000e+00);
-    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
+    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01, alchemical);
 
     system.addParticle(  1.0080000e+00);
-    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
+    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01, alchemical);
 
     system.addParticle(  1.0080000e+00);
-    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
+    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01, alchemical);
 
     // ParticleExclusions
 
@@ -325,10 +335,26 @@ void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, co
     LangevinIntegrator integrator(0.0, 0.1, 0.01);
     Context context(system, integrator, Platform::getPlatformByName(platformName));
 
+    // Load the vdw lambda value into the context.
+    if (alchemicalMethod != AmoebaVdwForce::None) {
+       context.setParameter(AmoebaVdwForce::Lambda(), vdwLambda);
+    }
+
+
     context.setPositions(positions);
     State state                      = context.getState(State::Forces | State::Energy);
     forces                           = state.getForces();
     energy                           = state.getPotentialEnergy();
+}
+
+void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule, double cutoff,
+                                       double boxDimension, std::vector<Vec3>& forces, double& energy) {
+     AmoebaVdwForce::AlchemicalMethod alchemicalMethod = AmoebaVdwForce::None;
+     int softcorePower = 5;
+     double softcoreAlpha = 0.7;
+     double vdwLambda = 1.0;
+     setupAndGetForcesEnergyVdwAmmonia2(sigmaCombiningRule, epsilonCombiningRule, cutoff, boxDimension, forces, energy,
+                                       alchemicalMethod, softcorePower, softcoreAlpha, vdwLambda);
 }
 
 void compareForcesEnergy(std::string& testName, double expectedEnergy, double energy,
@@ -369,6 +395,43 @@ void testVdwAmmoniaCubicMeanHhg() {
     double tolerance          = 1.0e-04;
     compareForcesEnergy(testName, expectedEnergy, energy, expectedForces, forces, tolerance);
 }
+
+// test alchemical VDW 
+
+void testVdwAlchemical(int power, double alpha, double lambda, AmoebaVdwForce::AlchemicalMethod method) {
+
+    std::string testName      = "testVdwAlchemical";
+
+    int numberOfParticles     = 8;
+    double boxDimension       = -1.0;
+    double cutoff             = 9000000.0;
+    std::vector<Vec3> forces;
+    double energy;
+
+    setupAndGetForcesEnergyVdwAmmonia2("CUBIC-MEAN", "HHG", cutoff, boxDimension, forces, energy,
+                                      method, power, alpha, lambda);
+    std::vector<Vec3> expectedForces(numberOfParticles);
+
+    double expectedEnergy     =  4.8012258e+00;
+    expectedForces[0]         = Vec3( 2.9265247e+02,  -1.4507808e-02,  -6.9562123e+00);
+    expectedForces[1]         = Vec3(-2.2451693e+00,   4.8143073e-01,  -2.0041494e-01);
+    expectedForces[2]         = Vec3(-2.2440698e+00,  -4.7905450e-01,  -2.0125284e-01);
+    expectedForces[3]         = Vec3(-1.0840394e+00,  -5.8531253e-04,   2.6934135e-01);
+    expectedForces[4]         = Vec3(-5.6305662e+01,   1.4733908e-03,  -1.8083306e-01);
+    expectedForces[5]         = Vec3( 1.6750145e+00,  -3.2448374e-01,  -1.8030914e-01);
+    expectedForces[6]         = Vec3(-2.3412420e+02,   1.0754069e-02,   7.6287492e+00);
+    expectedForces[7]         = Vec3( 1.6756544e+00,   3.2497316e-01,  -1.7906832e-01);
+
+    double scale = pow(lambda, power);
+    expectedEnergy *= scale;
+    for (int i=0; i<8; i++) {
+        expectedForces[i] *= scale;
+    }
+
+    double tolerance          = 1.0e-04;
+    compareForcesEnergy(testName, expectedEnergy, energy, expectedForces, forces, tolerance);
+}
+
 
 // test VDW w/ sigmaRule=Arithmetic and epsilonRule=Arithmetic
 
@@ -2063,6 +2126,25 @@ int main(int argc, char* argv[]) {
         // test triclinic boxes
 
         testTriclinic();
+
+        // Set lambda and the softcore power (n) to any values, while softcore alpha set to 0. 
+        // The energy and forces are equal to scaling those from testVdwAmmoniaCubicMeanHhg by lambda^n;
+        int n = 5;
+        double alpha = 0.0;
+        double lambda = 0.9;
+        AmoebaVdwForce::AlchemicalMethod method = AmoebaVdwForce::Annihilate;
+        testVdwAlchemical(n, alpha, lambda, method);
+
+        // Test the Decouple alchemical method.
+        lambda = 0.5;
+        method = AmoebaVdwForce::Decouple;
+        testVdwAlchemical(n, alpha, lambda, method);
+
+        // Test alpha > 0.
+        // This requires lambda = 0, since the energy and forces are not simply scaled by lambda^n.
+        lambda = 0.0;
+        alpha = 0.7;
+        testVdwAlchemical(n, alpha, lambda, method);
 
     } catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaVdwForce.cpp
+++ b/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaVdwForce.cpp
@@ -140,10 +140,11 @@ void testVdw() {
     for (int ii = 0; ii < amoebaVdwForce->getNumParticles();  ii++) {
         int indexIV;
         double sigma, epsilon, reduction;
-        amoebaVdwForce->getParticleParameters(ii, indexIV, sigma, epsilon, reduction);
+        bool isAlchemical;
+        amoebaVdwForce->getParticleParameters(ii, indexIV, sigma, epsilon, reduction, isAlchemical);
         sigma        *= AngstromToNm;
         epsilon      *= CalToJoule;
-        amoebaVdwForce->setParticleParameters(ii, indexIV, sigma, epsilon, reduction);
+        amoebaVdwForce->setParticleParameters(ii, indexIV, sigma, epsilon, reduction, isAlchemical);
     }
     platformName = "CUDA";
     Context context(system, integrator, Platform::getPlatformByName(platformName));
@@ -170,8 +171,9 @@ void testVdw() {
     for (int i = 0; i < numberOfParticles; i++) {
         int indexIV;
         double mass, sigma, epsilon, reduction;
-        amoebaVdwForce->getParticleParameters(i, indexIV, sigma, epsilon, reduction);
-        amoebaVdwForce->setParticleParameters(i, indexIV, 0.9*sigma, 2.0*epsilon, 0.95*reduction);
+        bool isAlchemical;
+        amoebaVdwForce->getParticleParameters(i, indexIV, sigma, epsilon, reduction, isAlchemical);
+        amoebaVdwForce->setParticleParameters(i, indexIV, 0.9*sigma, 2.0*epsilon, 0.95*reduction, isAlchemical);
     }
     LangevinIntegrator integrator2(0.0, 0.1, 0.01);
     Context context2(system, integrator2, Platform::getPlatformByName(platformName));

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
@@ -1059,7 +1059,7 @@ double ReferenceCalcAmoebaVdwForceKernel::execute(ContextImpl& context, bool inc
     vector<Vec3>& forceData = extractForces(context);
     AmoebaReferenceVdwForce vdwForce(sigmaCombiningRule, epsilonCombiningRule);
     double energy;
-    double lambda = context.getParameter("AmoebaVdwLambda");
+    double lambda = context.getParameter(AmoebaVdwForce::Lambda());
     if (useCutoff) {
         vdwForce.setCutoff(cutoff);
         computeNeighborListVoxelHash(*neighborList, numParticles, posData, allExclusions, extractBoxVectors(context), usePBC, cutoff, 0.0);

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
@@ -499,6 +499,9 @@ private:
     int numParticles;
     int useCutoff;
     int usePBC;
+    int alchemicalMethod;
+    double n;
+    double alpha;
     double cutoff;
     double dispersionCoefficient;
     std::vector<int> indexIVs;
@@ -506,6 +509,7 @@ private:
     std::vector<double> sigmas;
     std::vector<double> epsilons;
     std::vector<double> reductions;
+    std::vector<bool> isAlchemical;
     std::string sigmaCombiningRule;
     std::string epsilonCombiningRule;
     const System& system;

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
@@ -499,11 +499,11 @@ private:
     int numParticles;
     int useCutoff;
     int usePBC;
-    int alchemicalMethod;
-    double n;
-    double alpha;
     double cutoff;
     double dispersionCoefficient;
+    AmoebaVdwForce::AlchemicalMethod alchemicalMethod;
+    int n;
+    double alpha;
     std::vector<int> indexIVs;
     std::vector< std::set<int> > allExclusions;
     std::vector<double> sigmas;

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.cpp
@@ -313,24 +313,18 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles, double
                 double combinedEpsilon = (this->*_combineEpsilons)(epsilonI, epsilons[jj]);
                 double softcore = 0.0;
 
-                // Apply softcore modifications using an alchemical method.
-                if (this->_alchemicalMethod != None) {
-                   if (isAlchemicalI || isAlchemical[jj]) {
-                      // Decouple maintains interactions between two softcore atoms.
-                      if (this->_alchemicalMethod == Decouple && isAlchemicalI && isAlchemical[jj]) {
-                         // No softcore 
-                      } else {
-                         combinedEpsilon *= pow(lambda, this->_n); 
-                         softcore = this->_alpha * pow(1.0 - lambda, 2);
-                      } 
-                   }
+                if (this->_alchemicalMethod == Decouple && (isAlchemicalI != isAlchemical[jj])) {
+                   combinedEpsilon *= pow(lambda, this->_n);
+                   softcore = this->_alpha * pow(1.0 - lambda, 2);
+                } else if (this->_alchemicalMethod == Annihilate && (isAlchemicalI || isAlchemical[jj])) {
+                   combinedEpsilon *= pow(lambda, this->_n);
+                   softcore = this->_alpha * pow(1.0 - lambda, 2);
                 }
 
                 Vec3 force;
-                energy                     += calculatePairIxn(combinedSigma, combinedEpsilon, softcore,
-                                                               reducedPositions[ii], reducedPositions[jj],
-                                                               force);
-                
+                energy += calculatePairIxn(combinedSigma, combinedEpsilon, softcore,
+                                           reducedPositions[ii], reducedPositions[jj], force);
+
                 if (indexIVs[ii] == ii) {
                     forces[ii][0] -= force[0];
                     forces[ii][1] -= force[1];
@@ -390,22 +384,17 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles, double
         int isAlchemicalI      = isAlchemical[siteI];
         int isAlchemicalJ      = isAlchemical[siteJ];
 
-        // Apply softcore modifications using an alchemical method.
-        if (this->_alchemicalMethod != None) {
-           if (isAlchemicalI || isAlchemicalJ) {
-              // Decouple maintains interactions between two softcore atoms.
-              if (this->_alchemicalMethod == Decouple && isAlchemicalI && isAlchemicalJ) {
-                 // No softcore
-              } else {
-                 combinedEpsilon *= pow(lambda, this->_n);
-                 softcore = this->_alpha * pow(1.0 - lambda, 2);
-              }
-           }
+        if (this->_alchemicalMethod == Decouple && (isAlchemicalI != isAlchemicalJ)) {
+           combinedEpsilon *= pow(lambda, this->_n);
+           softcore = this->_alpha * pow(1.0 - lambda, 2);
+        } else if (this->_alchemicalMethod == Annihilate && (isAlchemicalI || isAlchemicalJ)) {
+           combinedEpsilon *= pow(lambda, this->_n);
+           softcore = this->_alpha * pow(1.0 - lambda, 2);
         }
 
         Vec3 force;
-        energy                     += calculatePairIxn(combinedSigma, combinedEpsilon, softcore,
-                                                       reducedPositions[siteI], reducedPositions[siteJ], force);
+        energy += calculatePairIxn(combinedSigma, combinedEpsilon, softcore,
+                                   reducedPositions[siteI], reducedPositions[siteJ], force);
                 
         if (indexIVs[siteI] == siteI) {
             forces[siteI][0] -= force[0];

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.cpp
@@ -364,7 +364,7 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles, double
 
     std::vector<Vec3> reducedPositions;
     setReducedPositions(numParticles, particlePositions, indexIVs, reductions, reducedPositions);
- 
+
     // loop over neighbor list
     //    (1) calculate pair vdw ixn
     //    (2) accumulate forces: if particle is a site where interaction position != particle position,

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.cpp
@@ -32,7 +32,7 @@
 using std::vector;
 using namespace OpenMM;
 
-AmoebaReferenceVdwForce::AmoebaReferenceVdwForce() : _nonbondedMethod(NoCutoff), _cutoff(1.0e+10), _taperCutoffFactor(0.9) {
+AmoebaReferenceVdwForce::AmoebaReferenceVdwForce() : _nonbondedMethod(NoCutoff), _cutoff(1.0e+10), _taperCutoffFactor(0.9), _n(5), _alpha(0.7), _alchemicalMethod(None) {
 
     setTaperCoefficients(_cutoff);
     setSigmaCombiningRule("ARITHMETIC");
@@ -40,7 +40,7 @@ AmoebaReferenceVdwForce::AmoebaReferenceVdwForce() : _nonbondedMethod(NoCutoff),
 }
 
 
-AmoebaReferenceVdwForce::AmoebaReferenceVdwForce(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule) : _nonbondedMethod(NoCutoff), _cutoff(1.0e+10), _taperCutoffFactor(0.9) {
+AmoebaReferenceVdwForce::AmoebaReferenceVdwForce(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule) : _nonbondedMethod(NoCutoff), _cutoff(1.0e+10), _taperCutoffFactor(0.9),  _n(5), _alpha(0.7), _alchemicalMethod(None) {
 
     setTaperCoefficients(_cutoff);
     setSigmaCombiningRule(sigmaCombiningRule);
@@ -54,6 +54,32 @@ AmoebaReferenceVdwForce::NonbondedMethod AmoebaReferenceVdwForce::getNonbondedMe
 void AmoebaReferenceVdwForce::setNonbondedMethod(AmoebaReferenceVdwForce::NonbondedMethod nonbondedMethod) {
     _nonbondedMethod = nonbondedMethod;
 }
+
+AmoebaReferenceVdwForce::AlchemicalMethod AmoebaReferenceVdwForce::getAlchemicalMethod() const {
+    return _alchemicalMethod;
+}
+
+
+void AmoebaReferenceVdwForce::setAlchemicalMethod(AmoebaReferenceVdwForce::AlchemicalMethod alchemicalMethod){
+    _alchemicalMethod = alchemicalMethod;
+}
+
+void AmoebaReferenceVdwForce::setSoftcorePower(int n) {
+    _n = n;
+}
+
+int AmoebaReferenceVdwForce::getSoftcorePower() const {
+    return _n;
+}
+
+void AmoebaReferenceVdwForce::setSoftcoreAlpha(double alpha) {
+    _alpha = alpha;
+}
+
+double AmoebaReferenceVdwForce::getSoftcoreAlpha() const {
+    return _alpha;
+}
+
 
 void AmoebaReferenceVdwForce::setTaperCoefficients(double cutoff) {
     _taperCutoff = cutoff*_taperCutoffFactor;
@@ -170,13 +196,15 @@ void AmoebaReferenceVdwForce::addReducedForce(unsigned int particleI, unsigned i
     forces[particleIV][2] += sign*force[2]*(1.0 - reduction);
 }
 
-double AmoebaReferenceVdwForce::calculatePairIxn(double combinedSigma, double combinedEpsilon,
+double AmoebaReferenceVdwForce::calculatePairIxn(double combinedSigma, double combinedEpsilon, double softcore,
                                                  const Vec3& particleIPosition,
                                                  const Vec3& particleJPosition,
                                                  Vec3& force) const {
     
     static const double dhal = 0.07;
     static const double ghal = 0.12;
+    static const double dhal1 = 1.07;
+    static const double ghal1 = 1.12;
 
     // get deltaR, R2, and R between 2 atoms
 
@@ -188,29 +216,25 @@ double AmoebaReferenceVdwForce::calculatePairIxn(double combinedSigma, double co
 
     double r_ij_2       = deltaR[ReferenceForce::R2Index];
     double r_ij         = deltaR[ReferenceForce::RIndex];
-    double sigma_7      = combinedSigma*combinedSigma*combinedSigma;
-           sigma_7      = sigma_7*sigma_7*combinedSigma;
 
-    double r_ij_6       = r_ij_2*r_ij_2*r_ij_2;
-    double r_ij_7       = r_ij_6*r_ij;
-
-    double rho          = r_ij_7 + ghal*sigma_7;
-
-    double tau          = (dhal + 1.0)/(r_ij + dhal*combinedSigma);
-    double tau_7        = tau*tau*tau;
-           tau_7        = tau_7*tau_7*tau;
-
-    double dtau         = tau/(dhal + 1.0);
-
-    double ratio        = (sigma_7/rho);
-    double gtau         = combinedEpsilon*tau_7*r_ij_6*(ghal+1.0)*ratio*ratio;
-
-    double energy       = combinedEpsilon*tau_7*sigma_7*((ghal+1.0)*sigma_7/rho - 2.0);
-
-    double dEdR         = -7.0*(dtau*energy + gtau);
+    double rho = r_ij / combinedSigma;
+    double rho2 = rho * rho;
+    double rho6 = rho2 * rho2 * rho2;
+    double rhoplus = rho + dhal;
+    double rhodec2 = rhoplus * rhoplus;
+    double rhodec = rhodec2 * rhodec2 * rhodec2;
+    double s1 = 1.0 / (softcore + rhodec * rhoplus);
+    double s2 = 1.0 / (softcore + rho6 * rho + 0.12);
+    double point72 = dhal1 * dhal1;
+    double t1 = dhal1 * point72 * point72 * point72 * s1;
+    double t2 = ghal1 * s2;
+    double t2min = t2 - 2;
+    double dt1 = -7.0 * rhodec * t1 * s1;
+    double dt2 = -7.0 * rho6 * t2 * s2;
+    double energy = combinedEpsilon * t1 * t2min;
+    double dEdR = combinedEpsilon * (dt1 * t2min + t1 * dt2) / combinedSigma;
 
     // tapering
-
     if ((_nonbondedMethod == CutoffNonPeriodic || _nonbondedMethod == CutoffPeriodic) && r_ij > _taperCutoff) {
         double delta    = r_ij - _taperCutoff;
         double taper    = 1.0 + delta*delta*delta*(_taperCoefficients[C3] + delta*(_taperCoefficients[C4] + delta*_taperCoefficients[C5]));
@@ -248,12 +272,13 @@ void AmoebaReferenceVdwForce::setReducedPositions(int numParticles,
     }
 }
 
-double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles,
+double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles, double lambda,
                                                         const vector<Vec3>& particlePositions,
                                                         const std::vector<int>& indexIVs, 
                                                         const std::vector<double>& sigmas,
                                                         const std::vector<double>& epsilons,
                                                         const std::vector<double>& reductions,
+                                                        const std::vector<bool>& isAlchemical,
                                                         const std::vector< std::set<int> >& allExclusions,
                                                         vector<Vec3>& forces) const {
 
@@ -277,6 +302,7 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles,
  
         double sigmaI      = sigmas[ii];
         double epsilonI    = epsilons[ii];
+        bool isAlchemicalI = isAlchemical[ii];
         for (int jj : allExclusions[ii])
             exclusions[jj] = 1;
 
@@ -285,9 +311,23 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles,
 
                 double combinedSigma   = (this->*_combineSigmas)(sigmaI, sigmas[jj]);
                 double combinedEpsilon = (this->*_combineEpsilons)(epsilonI, epsilons[jj]);
+                double softcore = 0.0;
+
+                // Apply softcore modifications using an alchemical method.
+                if (this->_alchemicalMethod != None) {
+                   if (isAlchemicalI || isAlchemical[jj]) {
+                      // Decouple maintains interactions between two softcore atoms.
+                      if (this->_alchemicalMethod == Decouple && isAlchemicalI && isAlchemical[jj]) {
+                         // No softcore 
+                      } else {
+                         combinedEpsilon *= pow(lambda, this->_n); 
+                         softcore = this->_alpha * pow(1.0 - lambda, 2);
+                      } 
+                   }
+                }
 
                 Vec3 force;
-                energy                     += calculatePairIxn(combinedSigma, combinedEpsilon,
+                energy                     += calculatePairIxn(combinedSigma, combinedEpsilon, softcore,
                                                                reducedPositions[ii], reducedPositions[jj],
                                                                force);
                 
@@ -316,12 +356,13 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles,
     return energy;
 }
 
-double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles,
+double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles, double lambda,
                                                         const vector<Vec3>& particlePositions,
                                                         const std::vector<int>& indexIVs, 
                                                         const std::vector<double>& sigmas,
                                                         const std::vector<double>& epsilons,
                                                         const std::vector<double>& reductions,
+                                                        const std::vector<bool>& isAlchemical,
                                                         const NeighborList& neighborList,
                                                         vector<Vec3>& forces) const {
 
@@ -345,9 +386,25 @@ double AmoebaReferenceVdwForce::calculateForceAndEnergy(int numParticles,
 
         double combinedSigma   = (this->*_combineSigmas)(sigmas[siteI], sigmas[siteJ]);
         double combinedEpsilon = (this->*_combineEpsilons)(epsilons[siteI], epsilons[siteJ]);
+        double softcore        = 0.0;
+        int isAlchemicalI      = isAlchemical[siteI];
+        int isAlchemicalJ      = isAlchemical[siteJ];
+
+        // Apply softcore modifications using an alchemical method.
+        if (this->_alchemicalMethod != None) {
+           if (isAlchemicalI || isAlchemicalJ) {
+              // Decouple maintains interactions between two softcore atoms.
+              if (this->_alchemicalMethod == Decouple && isAlchemicalI && isAlchemicalJ) {
+                 // No softcore
+              } else {
+                 combinedEpsilon *= pow(lambda, this->_n);
+                 softcore = this->_alpha * pow(1.0 - lambda, 2);
+              }
+           }
+        }
 
         Vec3 force;
-        energy                     += calculatePairIxn(combinedSigma, combinedEpsilon,
+        energy                     += calculatePairIxn(combinedSigma, combinedEpsilon, softcore,
                                                        reducedPositions[siteI], reducedPositions[siteJ], force);
                 
         if (indexIVs[siteI] == siteI) {

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.h
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceVdwForce.h
@@ -63,6 +63,25 @@ public:
          */
         CutoffPeriodic = 2,
     };
+
+    /**
+     * This is an enumeration of the different alchemical methods used when applying softcore interactions.
+     */
+    enum AlchemicalMethod {
+        /**
+         * All vdW interactions are treated normally. This is the default.
+         */
+        None = 0,
+        /**
+         * Maintain full strength vdW interactions between two alchemical particles.
+         */
+        Decouple = 1,
+        /**
+         * Interactions between two alchemical particles are turned off at lambda=0.
+         */
+        Annihilate = 2,
+    };
+
  
     /**---------------------------------------------------------------------------------------
        
@@ -110,6 +129,27 @@ public:
     void setNonbondedMethod(NonbondedMethod nonbondedMethod);
 
     /**---------------------------------------------------------------------------------------
+
+       Get alchemical method
+
+       @return alchemical method
+
+       --------------------------------------------------------------------------------------- */
+
+    AlchemicalMethod getAlchemicalMethod() const;
+
+    /**---------------------------------------------------------------------------------------
+
+       Set alchemical method
+
+       @param alchemical method
+
+       --------------------------------------------------------------------------------------- */
+
+    void setAlchemicalMethod(AlchemicalMethod alchemicalMethod);
+
+
+    /**---------------------------------------------------------------------------------------
     
        Get cutoff
     
@@ -128,6 +168,47 @@ public:
        --------------------------------------------------------------------------------------- */
     
     void setCutoff(double cutoff);
+
+    /**---------------------------------------------------------------------------------------
+   
+       Get softcore power
+   
+       @return n
+   
+       --------------------------------------------------------------------------------------- */
+   
+    int getSoftcorePower() const;
+
+    /**---------------------------------------------------------------------------------------
+   
+       Set softcore power
+   
+       @param n
+
+       --------------------------------------------------------------------------------------- */
+
+    void setSoftcorePower(int n);
+
+   /**---------------------------------------------------------------------------------------
+
+       Get softcore alpha
+  
+       @return alpha
+  
+       --------------------------------------------------------------------------------------- */
+  
+    double getSoftcoreAlpha() const;
+
+    /**---------------------------------------------------------------------------------------
+  
+       Set softcore alpha 
+  
+       @param alpha
+
+       --------------------------------------------------------------------------------------- */
+
+    void setSoftcoreAlpha(double alpha);
+
 
     /**---------------------------------------------------------------------------------------
     
@@ -184,11 +265,13 @@ public:
        Calculate Amoeba Hal vdw ixns
     
        @param numParticles            number of particles
+       @param lambda                  lambda value
        @param particlePositions       Cartesian coordinates of particles
        @param indexIVs                position index for associated reducing particle
        @param sigmas                  particle sigmas 
        @param epsilons                particle epsilons
        @param reductions              particle reduction factors
+       @param isAlchemical            particle alchemical flag
        @param vdwExclusions           particle exclusions
        @param forces                  add forces to this vector
     
@@ -196,10 +279,11 @@ public:
     
        --------------------------------------------------------------------------------------- */
     
-    double calculateForceAndEnergy(int numParticles, const std::vector<OpenMM::Vec3>& particlePositions,
+    double calculateForceAndEnergy(int numParticles, double lambda, const std::vector<OpenMM::Vec3>& particlePositions,
                                    const std::vector<int>& indexIVs, 
                                    const std::vector<double>& sigmas, const std::vector<double>& epsilons,
                                    const std::vector<double>& reductions,
+                                   const std::vector<bool>& isAlchemical,
                                    const std::vector< std::set<int> >& vdwExclusions,
                                    std::vector<OpenMM::Vec3>& forces) const;
          
@@ -208,11 +292,13 @@ public:
        Calculate Vdw ixn using neighbor list
     
        @param numParticles            number of particles
+       @param lambda                  lambda value
        @param particlePositions       Cartesian coordinates of particles
        @param indexIVs                position index for associated reducing particle
        @param sigmas                  particle sigmas 
        @param epsilons                particle epsilons
        @param reductions              particle reduction factors
+       @param isAlchemical            particle alchemical flag
        @param neighborList            neighbor list
        @param forces                  add forces to this vector
     
@@ -220,17 +306,16 @@ public:
     
        --------------------------------------------------------------------------------------- */
     
-    double calculateForceAndEnergy(int numParticles, const std::vector<OpenMM::Vec3>& particlePositions, 
+    double calculateForceAndEnergy(int numParticles, double lambda, const std::vector<OpenMM::Vec3>& particlePositions, 
                                    const std::vector<int>& indexIVs, 
                                    const std::vector<double>& sigmas, const std::vector<double>& epsilons,
                                    const std::vector<double>& reductions,
+                                   const std::vector<bool>& isAlchemical,
                                    const NeighborList& neighborList,
                                    std::vector<OpenMM::Vec3>& forces) const;
          
 private:
-
     // taper coefficient indices
-
     static const int C3=0;
     static const int C4=1;
     static const int C5=2;
@@ -238,6 +323,9 @@ private:
     std::string _sigmaCombiningRule;
     std::string _epsilonCombiningRule;
     NonbondedMethod _nonbondedMethod;
+    AlchemicalMethod _alchemicalMethod;
+    double _n;
+    double _alpha;
     double _cutoff;
     double _taperCutoffFactor;
     double _taperCutoff;
@@ -245,14 +333,13 @@ private:
     Vec3 _periodicBoxVectors[3];
     CombiningFunction _combineSigmas;
     double arithmeticSigmaCombiningRule(double sigmaI, double sigmaJ) const;
-    double  geometricSigmaCombiningRule(double sigmaI, double sigmaJ) const;
-    double  cubicMeanSigmaCombiningRule(double sigmaI, double sigmaJ) const;
-
+    double geometricSigmaCombiningRule(double sigmaI, double sigmaJ) const;
+    double cubicMeanSigmaCombiningRule(double sigmaI, double sigmaJ) const;
     CombiningFunction _combineEpsilons;
     double arithmeticEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
-    double  geometricEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
-    double  harmonicEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
-    double  hhgEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
+    double geometricEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
+    double harmonicEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
+    double hhgEpsilonCombiningRule(double epsilonI, double epsilonJ) const;
 
     /**---------------------------------------------------------------------------------------
     
@@ -308,6 +395,7 @@ private:
     
        @param  combindedSigma       combined sigmas
        @param  combindedEpsilon     combined epsilons
+       @param  softcore             softcore offset parameter
        @param  particleIPosition    particle I position 
        @param  particleJPosition    particle J position 
        @param  force                output force
@@ -316,7 +404,7 @@ private:
 
        --------------------------------------------------------------------------------------- */
     
-    double calculatePairIxn(double combindedSigma, double combindedEpsilon,
+    double calculatePairIxn(double combindedSigma, double combindedEpsilon, double softcore,
                             const Vec3& particleIPosition, const Vec3& particleJPosition,
                             Vec3& force) const;
 

--- a/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaVdwForce.cpp
+++ b/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaVdwForce.cpp
@@ -200,17 +200,26 @@ void testVdw() {
     ASSERT_EQUAL_TOL(state1.getPotentialEnergy(), state2.getPotentialEnergy(), tolerance);
 }
 
-void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule, double cutoff,
-                                       double boxDimension, std::vector<Vec3>& forces, double& energy) {
+
+void setupAndGetForcesEnergyVdwAmmonia2(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule, double cutoff,
+                                       double boxDimension, std::vector<Vec3>& forces, double& energy, 
+                                       AmoebaVdwForce::AlchemicalMethod alchemicalMethod, int softcorePower, double softcoreAlpha, double vdwLambda){
 
     // beginning of Vdw setup
 
     System system;
-    AmoebaVdwForce* amoebaVdwForce        = new AmoebaVdwForce();;
+    AmoebaVdwForce* amoebaVdwForce        = new AmoebaVdwForce();
     int numberOfParticles                 = 8;
     amoebaVdwForce->setSigmaCombiningRule(sigmaCombiningRule);
     amoebaVdwForce->setEpsilonCombiningRule(epsilonCombiningRule);
     amoebaVdwForce->setCutoff(cutoff);
+    bool alchemical = false;
+    if (alchemicalMethod != AmoebaVdwForce::None) {
+       amoebaVdwForce->setAlchemicalMethod(alchemicalMethod);
+       amoebaVdwForce->setSoftcorePower(softcorePower);
+       amoebaVdwForce->setSoftcoreAlpha(softcoreAlpha);
+       alchemical = true;
+    }
     if (boxDimension > 0.0) {
         Vec3 a(boxDimension, 0.0, 0.0);
         Vec3 b(0.0, boxDimension, 0.0);
@@ -239,16 +248,16 @@ void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, co
     amoebaVdwForce->addParticle(0,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
 
     system.addParticle( 1.4007000e+01);
-    amoebaVdwForce->addParticle(4,   1.8550000e-01,   4.3932000e-01,   0.0000000e+00);
+    amoebaVdwForce->addParticle(4,   1.8550000e-01,   4.3932000e-01,   0.0000000e+00, alchemical);
 
     system.addParticle( 1.0080000e+00);
-    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
+    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01, alchemical);
 
     system.addParticle( 1.0080000e+00);
-    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
+    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01, alchemical);
 
     system.addParticle( 1.0080000e+00);
-    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01);
+    amoebaVdwForce->addParticle(4,   1.3500000e-01,   8.3680000e-02,   9.1000000e-01, alchemical);
 
     // ParticleExclusions
 
@@ -336,10 +345,25 @@ void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, co
     LangevinIntegrator integrator(0.0, 0.1, 0.01);
     Context context(system, integrator, Platform::getPlatformByName(platformName));
 
+    // Load the vdw lambda value into the context.
+    if (alchemicalMethod != AmoebaVdwForce::None) {
+       context.setParameter(AmoebaVdwForce::Lambda(), vdwLambda);
+    }
+
     context.setPositions(positions);
     State state                      = context.getState(State::Forces | State::Energy);
     forces                           = state.getForces();
     energy                           = state.getPotentialEnergy();
+}
+
+void setupAndGetForcesEnergyVdwAmmonia(const std::string& sigmaCombiningRule, const std::string& epsilonCombiningRule, double cutoff,
+                                       double boxDimension, std::vector<Vec3>& forces, double& energy) {
+     AmoebaVdwForce::AlchemicalMethod alchemicalMethod = AmoebaVdwForce::None;
+     int softcorePower = 5;
+     double softcoreAlpha = 0.7;
+     double vdwLambda = 1.0;
+     setupAndGetForcesEnergyVdwAmmonia2(sigmaCombiningRule, epsilonCombiningRule, cutoff, boxDimension, forces, energy,
+                                       alchemicalMethod, softcorePower, softcoreAlpha, vdwLambda);
 }
 
 void compareForcesEnergy(std::string& testName, double expectedEnergy, double energy,
@@ -380,6 +404,43 @@ void testVdwAmmoniaCubicMeanHhg() {
     double tolerance          = 1.0e-04;
     compareForcesEnergy(testName, expectedEnergy, energy, expectedForces, forces, tolerance);
 }
+
+// test alchemical VDW 
+
+void testVdwAlchemical(int power, double alpha, double lambda, AmoebaVdwForce::AlchemicalMethod method) {
+
+    std::string testName      = "testVdwAlchemical";
+
+    int numberOfParticles     = 8;
+    double boxDimension       = -1.0;
+    double cutoff             = 9000000.0;
+    std::vector<Vec3> forces;
+    double energy;
+
+    setupAndGetForcesEnergyVdwAmmonia2("CUBIC-MEAN", "HHG", cutoff, boxDimension, forces, energy,
+                                      method, power, alpha, lambda);
+    std::vector<Vec3> expectedForces(numberOfParticles);
+
+    double expectedEnergy     =  4.8012258e+00;
+    expectedForces[0]         = Vec3( 2.9265247e+02,  -1.4507808e-02,  -6.9562123e+00);
+    expectedForces[1]         = Vec3(-2.2451693e+00,   4.8143073e-01,  -2.0041494e-01);
+    expectedForces[2]         = Vec3(-2.2440698e+00,  -4.7905450e-01,  -2.0125284e-01);
+    expectedForces[3]         = Vec3(-1.0840394e+00,  -5.8531253e-04,   2.6934135e-01);
+    expectedForces[4]         = Vec3(-5.6305662e+01,   1.4733908e-03,  -1.8083306e-01);
+    expectedForces[5]         = Vec3( 1.6750145e+00,  -3.2448374e-01,  -1.8030914e-01);
+    expectedForces[6]         = Vec3(-2.3412420e+02,   1.0754069e-02,   7.6287492e+00);
+    expectedForces[7]         = Vec3( 1.6756544e+00,   3.2497316e-01,  -1.7906832e-01);
+
+    double scale = pow(lambda, power);
+    expectedEnergy *= scale; 
+    for (int i=0; i<8; i++) {
+        expectedForces[i] *= scale;
+    }
+
+    double tolerance          = 1.0e-04;
+    compareForcesEnergy(testName, expectedEnergy, energy, expectedForces, forces, tolerance);
+}
+
 
 // test VDW w/ sigmaRule=Arithmetic and epsilonRule=Arithmetic
 
@@ -2076,6 +2137,25 @@ int main(int numberOfArguments, char* argv[]) {
         
         testTriclinic();
 
+        // Set lambda and the softcore power (n) to any values (softcore alpha set to 0). 
+        // The energy and forces are equal to scaling testVdwAmmoniaCubicMeanHhg by lambda^n;
+        int n = 5;
+        double alpha = 0.0;
+        double lambda = 0.9;
+        AmoebaVdwForce::AlchemicalMethod method = AmoebaVdwForce::Annihilate;
+        testVdwAlchemical(n, alpha, lambda, method);
+
+        // Test the Decouple alchemical method.
+        lambda = 0.5;
+        method = AmoebaVdwForce::Decouple;
+        testVdwAlchemical(n, alpha, lambda, method);
+        
+        // Test alpha > 0.
+        // This requires lambda = 0, since the energy and forces are not simply scaled by lambda^n.
+        lambda = 0.0;
+        alpha = 0.7;
+        testVdwAlchemical(n, alpha, lambda, method);
+    
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaVdwForce.cpp
+++ b/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaVdwForce.cpp
@@ -142,10 +142,11 @@ void testVdw() {
     for (int ii = 0; ii < amoebaVdwForce->getNumParticles();  ii++) {
         int indexIV;
         double sigma, epsilon, reduction;
-        amoebaVdwForce->getParticleParameters(ii, indexIV, sigma, epsilon, reduction);
+        bool isAlchemical;
+        amoebaVdwForce->getParticleParameters(ii, indexIV, sigma, epsilon, reduction, isAlchemical);
         sigma        *= AngstromToNm;
         epsilon      *= CalToJoule;
-        amoebaVdwForce->setParticleParameters(ii, indexIV, sigma, epsilon, reduction);
+        amoebaVdwForce->setParticleParameters(ii, indexIV, sigma, epsilon, reduction, isAlchemical);
     }
     platformName = "Reference";
     Context context(system, integrator, Platform::getPlatformByName(platformName));
@@ -173,8 +174,9 @@ void testVdw() {
     for (int i = 0; i < numberOfParticles; i++) {
         int indexIV;
         double mass, sigma, epsilon, reduction;
-        amoebaVdwForce->getParticleParameters(i, indexIV, sigma, epsilon, reduction);
-        amoebaVdwForce->setParticleParameters(i, indexIV, 0.9*sigma, 2.0*epsilon, 0.95*reduction);
+        bool isAlchemical;
+        amoebaVdwForce->getParticleParameters(i, indexIV, sigma, epsilon, reduction, isAlchemical);
+        amoebaVdwForce->setParticleParameters(i, indexIV, 0.9*sigma, 2.0*epsilon, 0.95*reduction, isAlchemical);
     }
     LangevinIntegrator integrator2(0.0, 0.1, 0.01);
     Context context2(system, integrator2, Platform::getPlatformByName(platformName));

--- a/plugins/amoeba/serialization/src/AmoebaVdwForceProxy.cpp
+++ b/plugins/amoeba/serialization/src/AmoebaVdwForceProxy.cpp
@@ -49,18 +49,22 @@ void AmoebaVdwForceProxy::serialize(const void* object, SerializationNode& node)
     node.setStringProperty("SigmaCombiningRule", force.getSigmaCombiningRule());
     node.setStringProperty("EpsilonCombiningRule", force.getEpsilonCombiningRule());
     node.setDoubleProperty("VdwCutoff", force.getCutoffDistance());
-
     node.setIntProperty("method", (int) force.getNonbondedMethod());
+
+    node.setDoubleProperty("n", force.getSoftcorePower());
+    node.setDoubleProperty("alpha", force.getSoftcoreAlpha());
+    node.setIntProperty("alchemicalMethod", (int) force.getAlchemicalMethod());
 
     SerializationNode& particles = node.createChildNode("VdwParticles");
     for (unsigned int ii = 0; ii < static_cast<unsigned int>(force.getNumParticles()); ii++) {
 
         int ivIndex;
         double sigma, epsilon, reductionFactor;
-        force.getParticleParameters(ii, ivIndex, sigma, epsilon, reductionFactor);
+        bool isAlchemical;
+        force.getParticleParameters(ii, ivIndex, sigma, epsilon, reductionFactor, isAlchemical);
 
         SerializationNode& particle = particles.createChildNode("Particle");
-        particle.setIntProperty("ivIndex", ivIndex).setDoubleProperty("sigma", sigma).setDoubleProperty("epsilon", epsilon).setDoubleProperty("reductionFactor", reductionFactor);
+        particle.setIntProperty("ivIndex", ivIndex).setDoubleProperty("sigma", sigma).setDoubleProperty("epsilon", epsilon).setDoubleProperty("reductionFactor", reductionFactor).setBoolProperty("isAlchemical",isAlchemical);
 
         std::vector< int > exclusions;
         force.getParticleExclusions(ii,  exclusions);
@@ -85,10 +89,14 @@ void* AmoebaVdwForceProxy::deserialize(const SerializationNode& node) const {
         force->setCutoffDistance(node.getDoubleProperty("VdwCutoff"));
         force->setNonbondedMethod((AmoebaVdwForce::NonbondedMethod) node.getIntProperty("method"));
 
+        force->setAlchemicalMethod((AmoebaVdwForce::AlchemicalMethod) node.getIntProperty("alchemicalMethod"));
+        force->setSoftcorePower(node.getDoubleProperty("n"));
+        force->setSoftcoreAlpha(node.getDoubleProperty("alpha"));
+
         const SerializationNode& particles = node.getChildNode("VdwParticles");
         for (unsigned int ii = 0; ii < particles.getChildren().size(); ii++) {
             const SerializationNode& particle = particles.getChildren()[ii];
-            force->addParticle(particle.getIntProperty("ivIndex"), particle.getDoubleProperty("sigma"), particle.getDoubleProperty("epsilon"), particle.getDoubleProperty("reductionFactor"));
+            force->addParticle(particle.getIntProperty("ivIndex"), particle.getDoubleProperty("sigma"), particle.getDoubleProperty("epsilon"), particle.getDoubleProperty("reductionFactor"), particle.getBoolProperty("isAlchemical"));
 
             // exclusions
 

--- a/plugins/amoeba/serialization/tests/TestSerializeAmoebaVdwForce.cpp
+++ b/plugins/amoeba/serialization/tests/TestSerializeAmoebaVdwForce.cpp
@@ -50,10 +50,11 @@ void testSerialization() {
     force1.setEpsilonCombiningRule("GEOMETRIC");
     force1.setCutoff(0.9);
     force1.setNonbondedMethod(AmoebaVdwForce::CutoffPeriodic);
+    force1.setAlchemicalMethod(AmoebaVdwForce::None);
 
-    force1.addParticle(0, 1.0, 2.0, 0.9);
-    force1.addParticle(1, 1.1, 2.1, 0.9);
-    force1.addParticle(2, 1.3, 4.1, 0.9);
+    force1.addParticle(0, 1.0, 2.0, 0.9, false);
+    force1.addParticle(1, 1.1, 2.1, 0.9, true);
+    force1.addParticle(2, 1.3, 4.1, 0.9, false);
     for (unsigned int ii = 0; ii < 3; ii++) {
         std::vector< int > exclusions;
         exclusions.push_back(ii);
@@ -76,6 +77,7 @@ void testSerialization() {
     ASSERT_EQUAL(force1.getEpsilonCombiningRule(),  force2.getEpsilonCombiningRule());
     ASSERT_EQUAL(force1.getCutoff(),                force2.getCutoff());
     ASSERT_EQUAL(force1.getNonbondedMethod(),       force2.getNonbondedMethod());
+    ASSERT_EQUAL(force1.getAlchemicalMethod(),      force2.getAlchemicalMethod());
 
     ASSERT_EQUAL(force1.getNumParticles(),          force2.getNumParticles());
 
@@ -87,13 +89,17 @@ void testSerialization() {
         double sigma1, epsilon1, reductionFactor1;
         double sigma2, epsilon2, reductionFactor2;
 
-        force1.getParticleParameters(ii, ivIndex1, sigma1, epsilon1, reductionFactor1);
-        force2.getParticleParameters(ii, ivIndex2, sigma2, epsilon2, reductionFactor2);
+        bool isAlchemical1;
+        bool isAlchemical2;
+
+        force1.getParticleParameters(ii, ivIndex1, sigma1, epsilon1, reductionFactor1, isAlchemical1);
+        force2.getParticleParameters(ii, ivIndex2, sigma2, epsilon2, reductionFactor2, isAlchemical2);
 
         ASSERT_EQUAL(ivIndex1,          ivIndex2);
         ASSERT_EQUAL(sigma1,            sigma2);
         ASSERT_EQUAL(epsilon1,          epsilon2);
         ASSERT_EQUAL(reductionFactor1,  reductionFactor2);
+        ASSERT_EQUAL(isAlchemical1,  isAlchemical2);
     }
     for (unsigned int ii = 0; ii < static_cast<unsigned int>(force1.getNumParticles()); ii++) {
 

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -309,15 +309,14 @@ UNITS = {
 ("AmoebaTorsionTorsionForce",             "getTorsionTorsionParameters")                   :  ( None, ()),
 ("AmoebaTorsionTorsionForce",             "getTorsionTorsionGrid")                         :  ( None, ()),
 
-# LPW 2012-10 : Is this a duplicate entry?
-#("AmoebaVdwForce",                        "getParticleParameters")                         :  ( None, (None, None, None, 'unit.nanometer', 'unit.kilojoule_per_mole', None)),
 ("AmoebaVdwForce",                        "getSigmaCombiningRule")                         :  ( None, ()),
 ("AmoebaVdwForce",                        "getEpsilonCombiningRule")                       :  ( None, ()),
 ("AmoebaVdwForce",                        "getParticleExclusions")                         :  ( None, ()),
+("AmoebaVdwForce",                        "getAlchemicalMethod")                           :  ( None, ()),
+("AmoebaVdwForce",                        "getSoftcorePower")                              :  ( None, ()),
+("AmoebaVdwForce",                        "getSoftcoreAlpha")                              :  ( None, ()),
 ("AmoebaVdwForce",                        "getCutoff")                                     :  ( 'unit.nanometer', ()),
-# LPW 2012-10 Modified because it no longer returns ivIndex and classIndex.
-# ("AmoebaVdwForce",                        "getParticleParameters")                         :  ( None, (None, None, 'unit.nanometer', 'unit.kilojoule_per_mole', None)),
-("AmoebaVdwForce",                        "getParticleParameters")                         :  ( None, (None, 'unit.nanometer', 'unit.kilojoule_per_mole', None)),
+("AmoebaVdwForce",                        "getParticleParameters")                         :  ( None, (None, 'unit.nanometer', 'unit.kilojoule_per_mole', None, None)),
 
 ("AmoebaWcaDispersionForce",              "getParticleParameters")                         :  ( None, ('unit.nanometer', 'unit.kilojoule_per_mole')),
 ("AmoebaWcaDispersionForce",              "getAwater")                                     :  ( '1/(unit.nanometer*unit.nanometer*unit.nanometer)',()),

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -969,7 +969,7 @@ class TestAPIUnits(unittest.TestCase):
 
         self.assertEqual(force.getNumParticles(), 3)
 
-        p, sig, eps, scale = force.getParticleParameters(0)
+        p, sig, eps, scale, alchemical = force.getParticleParameters(0)
         self.assertEqual(p, 0)
         self.assertEqual(sig, 0.1*nanometers)
         self.assertIs(sig.unit, nanometers)
@@ -977,7 +977,7 @@ class TestAPIUnits(unittest.TestCase):
         self.assertIs(eps.unit, kilojoules_per_mole)
         self.assertEqual(scale, 1.0)
 
-        p, sig, eps, scale = force.getParticleParameters(1)
+        p, sig, eps, scale, alchemical = force.getParticleParameters(1)
         self.assertEqual(p, 1)
         self.assertEqual(sig, 1.0*angstroms)
         self.assertIs(sig.unit, nanometers)
@@ -985,7 +985,7 @@ class TestAPIUnits(unittest.TestCase):
         self.assertIs(eps.unit, kilojoules_per_mole)
         self.assertEqual(scale, 0.5)
 
-        p, sig, eps, scale = force.getParticleParameters(2)
+        p, sig, eps, scale, alchemical = force.getParticleParameters(2)
         self.assertEqual(p, 1)
         self.assertAlmostEqualUnit(sig, 0.8*angstroms)
         self.assertIs(sig.unit, nanometers)


### PR DESCRIPTION
This addresses issue "AMOEBA vdW softcore support #2369":
https://github.com/openmm/openmm/issues/2369

- Each atom is configured with an alchemical flag to indicate if it should be affected by the softcore functional form.
- The softcore form is defined by 1) multiplying interactions by Lambda^N and 2) adding Alpha*(Lambda -1)^2 to the reduced separation distance (rho = rij / rmin).  Both N and Alpha are global parameters of the force (defaults are 5 and 0.7, respectively) and can be set.
- Application of the softcore form is governed by a enum AlchemicalMethod that is "None" by default, or can be set to either Decouple or Annihilate. Decouple does not apply the softcore form between two atoms that are both alchemical, while Annihilate does.
- A single Context parameter "vdwLambda" controls the alchemical state, which avoids the need to perform a relatively slow update of per particle parameters in the Context when/if vdwLambda changes.
