### PR TITLE
Added hartree unit (addresses #2419)

### DIFF
--- a/wrappers/python/simtk/unit/unit_definitions.py
+++ b/wrappers/python/simtk/unit/unit_definitions.py
@@ -237,7 +237,7 @@ joules = joule = Unit({joule_base_unit: 1.0})
 define_prefixed_units(joule_base_unit, module = sys.modules[__name__])
 erg_base_unit = ScaledUnit(1.0, dyne * centimeter, "erg", "erg")
 erg = ergs = Unit({erg_base_unit: 1.0})
-hartree_base_unit = ScaledUnit(4.3597447222071e-18, joule_base_unit, "hartree", "Ha")
+hartree_base_unit = ScaledUnit(4.3597447222071e-18, joule, "hartree", "Ha")
 hartree = hartrees = Unit({hartree_base_unit: 1.0})
 
 # In molecular simulations, "kilojoules" are in microscopic units

--- a/wrappers/python/simtk/unit/unit_definitions.py
+++ b/wrappers/python/simtk/unit/unit_definitions.py
@@ -237,6 +237,8 @@ joules = joule = Unit({joule_base_unit: 1.0})
 define_prefixed_units(joule_base_unit, module = sys.modules[__name__])
 erg_base_unit = ScaledUnit(1.0, dyne * centimeter, "erg", "erg")
 erg = ergs = Unit({erg_base_unit: 1.0})
+hartree_base_unit = ScaledUnit(4.3597447222071e-18, joule_base_unit, "hartree", "Ha")
+hartree = hartrees = Unit({hartree_base_unit: 1.0})
 
 # In molecular simulations, "kilojoules" are in microscopic units
 # And you really only want to use kilojoules/mole.


### PR DESCRIPTION
This PR adds the `hartree` unit to `simtk.unit`. This addresses #2419.

This is of immediate need to QCEngine, in particular MolSSI/QCEngine#151.