### PR TITLE
Fixes writing PDBx/mmCIF files with blank residue insertion codes.

### DIFF
--- a/wrappers/python/simtk/openmm/app/pdbxfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbxfile.py
@@ -397,7 +397,7 @@ class PDBxFile(object):
             for (resIndex, res) in enumerate(residues):
                 if keepIds:
                     resId = res.id
-                    resIC = (res.insertionCode if len(res.insertionCode) > 0 else '.')
+                    resIC = (res.insertionCode if res.insertionCode.strip() else '.')
                 else:
                     resId = resIndex + 1
                     resIC = '.'

--- a/wrappers/python/tests/TestPdbxFile.py
+++ b/wrappers/python/tests/TestPdbxFile.py
@@ -11,7 +11,29 @@ else:
 
 class TestPdbxFile(unittest.TestCase):
     """Test the PDBx/mmCIF file parser"""
- 
+
+    def test_FormatConversion(self):
+        """Test conversion from PDB to PDBx"""
+
+        mol = PDBFile('systems/ala_ala_ala.pdb')
+
+        # Write to 'file'
+        output = StringIO()
+        PDBxFile.writeFile(mol.topology, mol.positions, output,
+                           keepIds=True)
+
+        # Read from 'file'
+        input = StringIO(output.getvalue())
+        try:
+            pdbx = PDBxFile(input)
+        except Exception:
+            self.fail('Parser failed to read PDBx/mmCIF file')
+
+        # Close file handles
+        output.close()
+        input.close()
+
+
     def test_Triclinic(self):
         """Test parsing a file that describes a triclinic box."""
         pdb = PDBxFile('systems/triclinic.pdbx')


### PR DESCRIPTION
Addresses #2422 

Fixes writing invalid PDBx/mmCIF files when residue insertion codes are blank (not empty) in Topology. Replaces the current check `len(res.insertionCode) > 0` with `res.insertionCode.strip()` to account for cases where the insertion code is stored as a single space from reading e.g. PDB files.