### PR TITLE
Fixed range error when adding lone pairs from PSF file

### DIFF
--- a/wrappers/python/simtk/openmm/app/charmmpsffile.py
+++ b/wrappers/python/simtk/openmm/app/charmmpsffile.py
@@ -934,7 +934,7 @@ class CharmmPsfFile(object):
                 atom1=lpsite[1]
                 atom2=lpsite[2]
                 atom3=lpsite[3]
-                if atom3 > 0: 
+                if atom3 >= 0: 
                     if lpsite[4] > 0 : # relative lonepair type
                         r = lpsite[4] /10.0 # in nanometer
                         xweights = [-1.0, 0.0, 1.0]


### PR DESCRIPTION
Fixes #2392.

@jing-huang could you check that my fix is correct?  The problem was an off-by-one error introduced in #2317.  CHARMM numbers atoms starting at 1, and it appears that it sets the fourth atom to 0 (or negative?) to indicate a collinear lone pair.  OpenMM numbers atoms starting at 0, so it subtracted 1 from the indices.  That means it should be checking that the last atom is >=0, not >0.

This affected any file that satisfied very specific conditions: it contained a non-collinear lone pair, and the third atom it depended on was the very first atom in the file.