### PR TITLE
Catch exception when cl::Platform::get() fails.

### DIFF
--- a/platforms/opencl/src/OpenCLPlatform.cpp
+++ b/platforms/opencl/src/OpenCLPlatform.cpp
@@ -144,9 +144,14 @@ bool OpenCLPlatform::isPlatformSupported() {
     // Make sure at least one OpenCL implementation is installed.
 
     std::vector<cl::Platform> platforms;
-    cl::Platform::get(&platforms);
-    if (platforms.size() == 0)
+    try {
+        cl::Platform::get(&platforms);
+        if (platforms.size() == 0)
+            return false;
+    }
+    catch (...) {
         return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
Fixes #2433.