### PR TITLE
make std::string pass as references, not values

### DIFF
--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -88,7 +88,7 @@ private:
     const AmoebaBondForce& force;
 };
 
-CudaCalcAmoebaBondForceKernel::CudaCalcAmoebaBondForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : 
+CudaCalcAmoebaBondForceKernel::CudaCalcAmoebaBondForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
                 CalcAmoebaBondForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -180,7 +180,7 @@ private:
     const AmoebaAngleForce& force;
 };
 
-CudaCalcAmoebaAngleForceKernel::CudaCalcAmoebaAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
+CudaCalcAmoebaAngleForceKernel::CudaCalcAmoebaAngleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
             CalcAmoebaAngleForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -276,7 +276,7 @@ private:
     const AmoebaInPlaneAngleForce& force;
 };
 
-CudaCalcAmoebaInPlaneAngleForceKernel::CudaCalcAmoebaInPlaneAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : 
+CudaCalcAmoebaInPlaneAngleForceKernel::CudaCalcAmoebaInPlaneAngleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
           CalcAmoebaInPlaneAngleForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -373,7 +373,7 @@ private:
     const AmoebaPiTorsionForce& force;
 };
 
-CudaCalcAmoebaPiTorsionForceKernel::CudaCalcAmoebaPiTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
+CudaCalcAmoebaPiTorsionForceKernel::CudaCalcAmoebaPiTorsionForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
          CalcAmoebaPiTorsionForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -462,7 +462,7 @@ private:
     const AmoebaStretchBendForce& force;
 };
 
-CudaCalcAmoebaStretchBendForceKernel::CudaCalcAmoebaStretchBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
+CudaCalcAmoebaStretchBendForceKernel::CudaCalcAmoebaStretchBendForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
                    CalcAmoebaStretchBendForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -561,7 +561,7 @@ private:
     const AmoebaOutOfPlaneBendForce& force;
 };
 
-CudaCalcAmoebaOutOfPlaneBendForceKernel::CudaCalcAmoebaOutOfPlaneBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
+CudaCalcAmoebaOutOfPlaneBendForceKernel::CudaCalcAmoebaOutOfPlaneBendForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
           CalcAmoebaOutOfPlaneBendForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -656,7 +656,7 @@ private:
     const AmoebaTorsionTorsionForce& force;
 };
 
-CudaCalcAmoebaTorsionTorsionForceKernel::CudaCalcAmoebaTorsionTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
+CudaCalcAmoebaTorsionTorsionForceKernel::CudaCalcAmoebaTorsionTorsionForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
                 CalcAmoebaTorsionTorsionForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -763,7 +763,7 @@ private:
     const AmoebaMultipoleForce& force;
 };
 
-CudaCalcAmoebaMultipoleForceKernel::CudaCalcAmoebaMultipoleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : 
+CudaCalcAmoebaMultipoleForceKernel::CudaCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
         CalcAmoebaMultipoleForceKernel(name, platform), cu(cu), system(system), hasInitializedScaleFactors(false), hasInitializedFFT(false), multipolesAreValid(false), hasCreatedEvent(false),
         gkKernel(NULL) {
 }
@@ -2119,7 +2119,7 @@ private:
     const AmoebaGeneralizedKirkwoodForce& force;
 };
 
-CudaCalcAmoebaGeneralizedKirkwoodForceKernel::CudaCalcAmoebaGeneralizedKirkwoodForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : 
+CudaCalcAmoebaGeneralizedKirkwoodForceKernel::CudaCalcAmoebaGeneralizedKirkwoodForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
            CalcAmoebaGeneralizedKirkwoodForceKernel(name, platform), cu(cu), system(system), hasInitializedKernels(false) {
 }
 
@@ -2352,7 +2352,7 @@ private:
     const AmoebaVdwForce& force;
 };
 
-CudaCalcAmoebaVdwForceKernel::CudaCalcAmoebaVdwForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
+CudaCalcAmoebaVdwForceKernel::CudaCalcAmoebaVdwForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
         CalcAmoebaVdwForceKernel(name, platform), cu(cu), system(system), hasInitializedNonbonded(false), nonbonded(NULL), vdwLambdaPinnedBuffer(NULL) {
 }
 
@@ -2556,7 +2556,7 @@ private:
     const AmoebaWcaDispersionForce& force;
 };
 
-CudaCalcAmoebaWcaDispersionForceKernel::CudaCalcAmoebaWcaDispersionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : 
+CudaCalcAmoebaWcaDispersionForceKernel::CudaCalcAmoebaWcaDispersionForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
            CalcAmoebaWcaDispersionForceKernel(name, platform), cu(cu), system(system) {
 }
 
@@ -2699,7 +2699,7 @@ private:
     CudaCalcHippoNonbondedForceKernel& owner;
 };
 
-CudaCalcHippoNonbondedForceKernel::CudaCalcHippoNonbondedForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : 
+CudaCalcHippoNonbondedForceKernel::CudaCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
         CalcHippoNonbondedForceKernel(name, platform), cu(cu), system(system), sort(NULL), hasInitializedKernels(false), hasInitializedFFT(false), multipolesAreValid(false) {
 }
 

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -45,7 +45,7 @@ class CudaCalcAmoebaGeneralizedKirkwoodForceKernel;
  */
 class CudaCalcAmoebaBondForceKernel : public CalcAmoebaBondForceKernel {
 public:
-    CudaCalcAmoebaBondForceKernel(std::string name, 
+    CudaCalcAmoebaBondForceKernel(const std::string& name,
                                           const Platform& platform,
                                           CudaContext& cu,
                                           const System& system);
@@ -85,7 +85,7 @@ private:
  */
 class CudaCalcAmoebaAngleForceKernel : public CalcAmoebaAngleForceKernel {
 public:
-    CudaCalcAmoebaAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaAngleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -122,7 +122,7 @@ private:
  */
 class CudaCalcAmoebaInPlaneAngleForceKernel : public CalcAmoebaInPlaneAngleForceKernel {
 public:
-    CudaCalcAmoebaInPlaneAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaInPlaneAngleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -159,7 +159,7 @@ private:
  */
 class CudaCalcAmoebaPiTorsionForceKernel : public CalcAmoebaPiTorsionForceKernel {
 public:
-    CudaCalcAmoebaPiTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaPiTorsionForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -196,7 +196,7 @@ private:
  */
 class CudaCalcAmoebaStretchBendForceKernel : public CalcAmoebaStretchBendForceKernel {
 public:
-    CudaCalcAmoebaStretchBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaStretchBendForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -234,7 +234,7 @@ private:
  */
 class CudaCalcAmoebaOutOfPlaneBendForceKernel : public CalcAmoebaOutOfPlaneBendForceKernel {
 public:
-    CudaCalcAmoebaOutOfPlaneBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaOutOfPlaneBendForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -271,7 +271,7 @@ private:
  */
 class CudaCalcAmoebaTorsionTorsionForceKernel : public CalcAmoebaTorsionTorsionForceKernel {
 public:
-    CudaCalcAmoebaTorsionTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaTorsionTorsionForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -304,7 +304,7 @@ private:
  */
 class CudaCalcAmoebaMultipoleForceKernel : public CalcAmoebaMultipoleForceKernel {
 public:
-    CudaCalcAmoebaMultipoleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     ~CudaCalcAmoebaMultipoleForceKernel();
     /**
      * Initialize the kernel.
@@ -466,7 +466,7 @@ private:
  */
 class CudaCalcAmoebaGeneralizedKirkwoodForceKernel : public CalcAmoebaGeneralizedKirkwoodForceKernel {
 public:
-    CudaCalcAmoebaGeneralizedKirkwoodForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaGeneralizedKirkwoodForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -541,7 +541,7 @@ private:
  */
 class CudaCalcAmoebaVdwForceKernel : public CalcAmoebaVdwForceKernel {
 public:
-    CudaCalcAmoebaVdwForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaVdwForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     ~CudaCalcAmoebaVdwForceKernel();
     /**
      * Initialize the kernel.
@@ -598,7 +598,7 @@ private:
  */
 class CudaCalcAmoebaWcaDispersionForceKernel : public CalcAmoebaWcaDispersionForceKernel {
 public:
-    CudaCalcAmoebaWcaDispersionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcAmoebaWcaDispersionForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     /**
      * Initialize the kernel.
      * 
@@ -636,7 +636,7 @@ private:
  */
 class CudaCalcHippoNonbondedForceKernel : public CalcHippoNonbondedForceKernel {
 public:
-    CudaCalcHippoNonbondedForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
+    CudaCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system);
     ~CudaCalcHippoNonbondedForceKernel();
     /**
      * Initialize the kernel.

--- a/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaMultipoleForce.cpp
+++ b/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaMultipoleForce.cpp
@@ -880,7 +880,7 @@ static void testQuadrupoleValidation() {
 
 static void setupAndGetForcesEnergyMultipoleIonsAndWater(AmoebaMultipoleForce::NonbondedMethod nonbondedMethod,
                                                           AmoebaMultipoleForce::PolarizationType polarizationType,
-                                                          double cutoff, int inputPmeGridDimension, std::string testName,
+                                                          double cutoff, int inputPmeGridDimension, const std::string& testName,
                                                           std::vector<Vec3>& forces, double& energy) {
 
     // beginning of Multipole setup

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
@@ -83,7 +83,7 @@ static Vec3* extractBoxVectors(ContextImpl& context) {
 
 // ***************************************************************************
 
-ReferenceCalcAmoebaBondForceKernel::ReferenceCalcAmoebaBondForceKernel(std::string name, const Platform& platform, const System& system) : 
+ReferenceCalcAmoebaBondForceKernel::ReferenceCalcAmoebaBondForceKernel(const std::string& name, const Platform& platform, const System& system) :
                 CalcAmoebaBondForceKernel(name, platform), system(system) {
 }
 
@@ -140,7 +140,7 @@ void ReferenceCalcAmoebaBondForceKernel::copyParametersToContext(ContextImpl& co
 
 // ***************************************************************************
 
-ReferenceCalcAmoebaAngleForceKernel::ReferenceCalcAmoebaAngleForceKernel(std::string name, const Platform& platform, const System& system) :
+ReferenceCalcAmoebaAngleForceKernel::ReferenceCalcAmoebaAngleForceKernel(const std::string& name, const Platform& platform, const System& system) :
             CalcAmoebaAngleForceKernel(name, platform), system(system) {
 }
 
@@ -196,7 +196,7 @@ void ReferenceCalcAmoebaAngleForceKernel::copyParametersToContext(ContextImpl& c
     }
 }
 
-ReferenceCalcAmoebaInPlaneAngleForceKernel::ReferenceCalcAmoebaInPlaneAngleForceKernel(std::string name, const Platform& platform, const System& system) : 
+ReferenceCalcAmoebaInPlaneAngleForceKernel::ReferenceCalcAmoebaInPlaneAngleForceKernel(const std::string& name, const Platform& platform, const System& system) :
           CalcAmoebaInPlaneAngleForceKernel(name, platform), system(system) {
 }
 
@@ -254,7 +254,7 @@ void ReferenceCalcAmoebaInPlaneAngleForceKernel::copyParametersToContext(Context
     }
 }
 
-ReferenceCalcAmoebaPiTorsionForceKernel::ReferenceCalcAmoebaPiTorsionForceKernel(std::string name, const Platform& platform, const System& system) :
+ReferenceCalcAmoebaPiTorsionForceKernel::ReferenceCalcAmoebaPiTorsionForceKernel(const std::string& name, const Platform& platform, const System& system) :
          CalcAmoebaPiTorsionForceKernel(name, platform), system(system) {
 }
 
@@ -309,7 +309,7 @@ void ReferenceCalcAmoebaPiTorsionForceKernel::copyParametersToContext(ContextImp
     }
 }
 
-ReferenceCalcAmoebaStretchBendForceKernel::ReferenceCalcAmoebaStretchBendForceKernel(std::string name, const Platform& platform, const System& system) :
+ReferenceCalcAmoebaStretchBendForceKernel::ReferenceCalcAmoebaStretchBendForceKernel(const std::string& name, const Platform& platform, const System& system) :
                    CalcAmoebaStretchBendForceKernel(name, platform), system(system) {
 }
 
@@ -367,7 +367,7 @@ void ReferenceCalcAmoebaStretchBendForceKernel::copyParametersToContext(ContextI
     }
 }
 
-ReferenceCalcAmoebaOutOfPlaneBendForceKernel::ReferenceCalcAmoebaOutOfPlaneBendForceKernel(std::string name, const Platform& platform, const System& system) :
+ReferenceCalcAmoebaOutOfPlaneBendForceKernel::ReferenceCalcAmoebaOutOfPlaneBendForceKernel(const std::string& name, const Platform& platform, const System& system) :
           CalcAmoebaOutOfPlaneBendForceKernel(name, platform), system(system) {
 }
 
@@ -428,7 +428,7 @@ void ReferenceCalcAmoebaOutOfPlaneBendForceKernel::copyParametersToContext(Conte
     }
 }
 
-ReferenceCalcAmoebaTorsionTorsionForceKernel::ReferenceCalcAmoebaTorsionTorsionForceKernel(std::string name, const Platform& platform, const System& system) :
+ReferenceCalcAmoebaTorsionTorsionForceKernel::ReferenceCalcAmoebaTorsionTorsionForceKernel(const std::string& name, const Platform& platform, const System& system) :
                 CalcAmoebaTorsionTorsionForceKernel(name, platform), system(system) {
 }
 
@@ -510,7 +510,7 @@ double ReferenceCalcAmoebaTorsionTorsionForceKernel::execute(ContextImpl& contex
  *                             AmoebaMultipole                                *
  * -------------------------------------------------------------------------- */
 
-ReferenceCalcAmoebaMultipoleForceKernel::ReferenceCalcAmoebaMultipoleForceKernel(std::string name, const Platform& platform, const System& system) : 
+ReferenceCalcAmoebaMultipoleForceKernel::ReferenceCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, const System& system) :
          CalcAmoebaMultipoleForceKernel(name, platform), system(system), numMultipoles(0), mutualInducedMaxIterations(60), mutualInducedTargetEpsilon(1.0e-03),
                                                          usePme(false),alphaEwald(0.0), cutoffDistance(1.0) {  
 
@@ -871,7 +871,7 @@ void ReferenceCalcAmoebaMultipoleForceKernel::getPMEParameters(double& alpha, in
  *                       AmoebaGeneralizedKirkwood                            *
  * -------------------------------------------------------------------------- */
 
-ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel::ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel(std::string name, const Platform& platform, const System& system) : 
+ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel::ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel(const std::string& name, const Platform& platform, const System& system) :
            CalcAmoebaGeneralizedKirkwoodForceKernel(name, platform), system(system) {
 }
 
@@ -992,7 +992,7 @@ void ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel::copyParametersToContext(
     }
 }
 
-ReferenceCalcAmoebaVdwForceKernel::ReferenceCalcAmoebaVdwForceKernel(std::string name, const Platform& platform, const System& system) :
+ReferenceCalcAmoebaVdwForceKernel::ReferenceCalcAmoebaVdwForceKernel(const std::string& name, const Platform& platform, const System& system) :
        CalcAmoebaVdwForceKernel(name, platform), system(system) {
     useCutoff = 0;
     usePBC = 0;
@@ -1113,7 +1113,7 @@ void ReferenceCalcAmoebaVdwForceKernel::copyParametersToContext(ContextImpl& con
  *                           AmoebaWcaDispersion                              *
  * -------------------------------------------------------------------------- */
 
-ReferenceCalcAmoebaWcaDispersionForceKernel::ReferenceCalcAmoebaWcaDispersionForceKernel(std::string name, const Platform& platform, const System& system) : 
+ReferenceCalcAmoebaWcaDispersionForceKernel::ReferenceCalcAmoebaWcaDispersionForceKernel(const std::string& name, const Platform& platform, const System& system) :
            CalcAmoebaWcaDispersionForceKernel(name, platform), system(system) {
 }
 
@@ -1176,7 +1176,7 @@ void ReferenceCalcAmoebaWcaDispersionForceKernel::copyParametersToContext(Contex
  *                              HippoNonbonded                                *
  * -------------------------------------------------------------------------- */
 
-ReferenceCalcHippoNonbondedForceKernel::ReferenceCalcHippoNonbondedForceKernel(std::string name, const Platform& platform, const System& system) : 
+ReferenceCalcHippoNonbondedForceKernel::ReferenceCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, const System& system) :
          CalcHippoNonbondedForceKernel(name, platform), ixn(NULL) {
 }
 

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
@@ -43,7 +43,7 @@ namespace OpenMM {
  */
 class ReferenceCalcAmoebaBondForceKernel : public CalcAmoebaBondForceKernel {
 public:
-    ReferenceCalcAmoebaBondForceKernel(std::string name, 
+    ReferenceCalcAmoebaBondForceKernel(const std::string& name,
                                                const Platform& platform,
                                                const System& system);
     ~ReferenceCalcAmoebaBondForceKernel();
@@ -87,7 +87,7 @@ private:
  */
 class ReferenceCalcAmoebaAngleForceKernel : public CalcAmoebaAngleForceKernel {
 public:
-    ReferenceCalcAmoebaAngleForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaAngleForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaAngleForceKernel();
     /**
      * Initialize the kernel.
@@ -132,7 +132,7 @@ private:
  */
 class ReferenceCalcAmoebaInPlaneAngleForceKernel : public CalcAmoebaInPlaneAngleForceKernel {
 public:
-    ReferenceCalcAmoebaInPlaneAngleForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaInPlaneAngleForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaInPlaneAngleForceKernel();
     /**
      * Initialize the kernel.
@@ -178,7 +178,7 @@ private:
  */
 class ReferenceCalcAmoebaPiTorsionForceKernel : public CalcAmoebaPiTorsionForceKernel {
 public:
-    ReferenceCalcAmoebaPiTorsionForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaPiTorsionForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaPiTorsionForceKernel();
     /**
      * Initialize the kernel.
@@ -221,7 +221,7 @@ private:
  */
 class ReferenceCalcAmoebaStretchBendForceKernel : public CalcAmoebaStretchBendForceKernel {
 public:
-    ReferenceCalcAmoebaStretchBendForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaStretchBendForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaStretchBendForceKernel();
     /**
      * Initialize the kernel.
@@ -265,7 +265,7 @@ private:
  */
 class ReferenceCalcAmoebaOutOfPlaneBendForceKernel : public CalcAmoebaOutOfPlaneBendForceKernel {
 public:
-    ReferenceCalcAmoebaOutOfPlaneBendForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaOutOfPlaneBendForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaOutOfPlaneBendForceKernel();
     /**
      * Initialize the kernel.
@@ -310,7 +310,7 @@ private:
  */
 class ReferenceCalcAmoebaTorsionTorsionForceKernel : public CalcAmoebaTorsionTorsionForceKernel {
 public:
-    ReferenceCalcAmoebaTorsionTorsionForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaTorsionTorsionForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaTorsionTorsionForceKernel();
     /**
      * Initialize the kernel.
@@ -350,7 +350,7 @@ private:
  */
 class ReferenceCalcAmoebaMultipoleForceKernel : public CalcAmoebaMultipoleForceKernel {
 public:
-    ReferenceCalcAmoebaMultipoleForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaMultipoleForceKernel();
     /**
      * Initialize the kernel.
@@ -470,7 +470,7 @@ private:
  */
 class ReferenceCalcAmoebaVdwForceKernel : public CalcAmoebaVdwForceKernel {
 public:
-    ReferenceCalcAmoebaVdwForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaVdwForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaVdwForceKernel();
     /**
      * Initialize the kernel.
@@ -521,7 +521,7 @@ private:
  */
 class ReferenceCalcAmoebaWcaDispersionForceKernel : public CalcAmoebaWcaDispersionForceKernel {
 public:
-    ReferenceCalcAmoebaWcaDispersionForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaWcaDispersionForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaWcaDispersionForceKernel();
     /**
      * Initialize the kernel.
@@ -568,7 +568,7 @@ private:
  */
 class ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel : public CalcAmoebaGeneralizedKirkwoodForceKernel {
 public:
-    ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcAmoebaGeneralizedKirkwoodForceKernel();
     /**
      * Initialize the kernel.
@@ -702,7 +702,7 @@ private:
  */
 class ReferenceCalcHippoNonbondedForceKernel : public CalcHippoNonbondedForceKernel {
 public:
-    ReferenceCalcHippoNonbondedForceKernel(std::string name, const Platform& platform, const System& system);
+    ReferenceCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, const System& system);
     ~ReferenceCalcHippoNonbondedForceKernel();
     /**
      * Initialize the kernel.

--- a/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaMultipoleForce.cpp
+++ b/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaMultipoleForce.cpp
@@ -828,7 +828,7 @@ static void testQuadrupoleValidation() {
 
 static void setupAndGetForcesEnergyMultipoleIonsAndWater(AmoebaMultipoleForce::NonbondedMethod nonbondedMethod,
                                                          AmoebaMultipoleForce::PolarizationType polarizationType,
-                                                         double cutoff, int inputPmeGridDimension, std::string testName,
+                                                         double cutoff, int inputPmeGridDimension, const std::string& testName,
                                                          std::vector<Vec3>& forces, double& energy) {
 
     // beginning of Multipole setup

--- a/plugins/cpupme/src/CpuPmeKernels.h
+++ b/plugins/cpupme/src/CpuPmeKernels.h
@@ -51,7 +51,7 @@ namespace OpenMM {
 
 class OPENMM_EXPORT_PME CpuCalcPmeReciprocalForceKernel : public CalcPmeReciprocalForceKernel {
 public:
-    CpuCalcPmeReciprocalForceKernel(std::string name, const Platform& platform) : CalcPmeReciprocalForceKernel(name, platform),
+    CpuCalcPmeReciprocalForceKernel(const std::string& name, const Platform& platform) : CalcPmeReciprocalForceKernel(name, platform),
             hasCreatedPlan(false), isDeleted(false), realGrid(NULL), complexGrid(NULL) {
     }
     /**
@@ -144,7 +144,7 @@ private:
 
 class OPENMM_EXPORT_PME CpuCalcDispersionPmeReciprocalForceKernel : public CalcDispersionPmeReciprocalForceKernel {
 public:
-    CpuCalcDispersionPmeReciprocalForceKernel(std::string name, const Platform& platform) : CalcDispersionPmeReciprocalForceKernel(name, platform),
+    CpuCalcDispersionPmeReciprocalForceKernel(const std::string& name, const Platform& platform) : CalcDispersionPmeReciprocalForceKernel(name, platform),
             hasCreatedPlan(false), isDeleted(false), realGrid(NULL), complexGrid(NULL)  {
     }
     /**

--- a/plugins/cudacompiler/src/CudaCompilerKernels.h
+++ b/plugins/cudacompiler/src/CudaCompilerKernels.h
@@ -44,7 +44,7 @@ namespace OpenMM {
  */
 class OPENMM_EXPORT_CUDACOMPILER CudaRuntimeCompilerKernel : public CudaCompilerKernel {
 public:
-    CudaRuntimeCompilerKernel(std::string name, const Platform& platform) : CudaCompilerKernel(name, platform) {
+    CudaRuntimeCompilerKernel(const std::string& name, const Platform& platform) : CudaCompilerKernel(name, platform) {
     }
     /**
      * Compile a kernel to PTX.

--- a/plugins/drude/platforms/cuda/src/CudaDrudeKernels.h
+++ b/plugins/drude/platforms/cuda/src/CudaDrudeKernels.h
@@ -44,7 +44,7 @@ namespace OpenMM {
  */
 class CudaCalcDrudeForceKernel : public CalcDrudeForceKernel {
 public:
-    CudaCalcDrudeForceKernel(std::string name, const Platform& platform, CudaContext& cu) :
+    CudaCalcDrudeForceKernel(const std::string& name, const Platform& platform, CudaContext& cu) :
             CalcDrudeForceKernel(name, platform), cu(cu) {
     }
     /**
@@ -81,7 +81,7 @@ private:
  */
 class CudaIntegrateDrudeLangevinStepKernel : public IntegrateDrudeLangevinStepKernel {
 public:
-    CudaIntegrateDrudeLangevinStepKernel(std::string name, const Platform& platform, CudaContext& cu) :
+    CudaIntegrateDrudeLangevinStepKernel(const std::string& name, const Platform& platform, CudaContext& cu) :
             IntegrateDrudeLangevinStepKernel(name, platform), cu(cu) {
     }
     /**
@@ -119,7 +119,7 @@ private:
  */
 class CudaIntegrateDrudeSCFStepKernel : public IntegrateDrudeSCFStepKernel {
 public:
-    CudaIntegrateDrudeSCFStepKernel(std::string name, const Platform& platform, CudaContext& cu) :
+    CudaIntegrateDrudeSCFStepKernel(const std::string& name, const Platform& platform, CudaContext& cu) :
             IntegrateDrudeSCFStepKernel(name, platform), cu(cu), minimizerPos(NULL) {
     }
     ~CudaIntegrateDrudeSCFStepKernel();

--- a/plugins/drude/platforms/opencl/src/OpenCLDrudeKernels.h
+++ b/plugins/drude/platforms/opencl/src/OpenCLDrudeKernels.h
@@ -44,7 +44,7 @@ namespace OpenMM {
  */
 class OpenCLCalcDrudeForceKernel : public CalcDrudeForceKernel {
 public:
-    OpenCLCalcDrudeForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
+    OpenCLCalcDrudeForceKernel(const std::string& name, const Platform& platform, OpenCLContext& cl) :
             CalcDrudeForceKernel(name, platform), cl(cl) {
     }
     /**
@@ -81,7 +81,7 @@ private:
  */
 class OpenCLIntegrateDrudeLangevinStepKernel : public IntegrateDrudeLangevinStepKernel {
 public:
-    OpenCLIntegrateDrudeLangevinStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
+    OpenCLIntegrateDrudeLangevinStepKernel(const std::string& name, const Platform& platform, OpenCLContext& cl) :
             IntegrateDrudeLangevinStepKernel(name, platform), cl(cl), hasInitializedKernels(false) {
     }
     /**
@@ -120,7 +120,7 @@ private:
  */
 class OpenCLIntegrateDrudeSCFStepKernel : public IntegrateDrudeSCFStepKernel {
 public:
-    OpenCLIntegrateDrudeSCFStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
+    OpenCLIntegrateDrudeSCFStepKernel(const std::string& name, const Platform& platform, OpenCLContext& cl) :
             IntegrateDrudeSCFStepKernel(name, platform), cl(cl), hasInitializedKernels(false), minimizerPos(NULL) {
     }
     ~OpenCLIntegrateDrudeSCFStepKernel();

--- a/plugins/drude/platforms/reference/src/ReferenceDrudeKernels.h
+++ b/plugins/drude/platforms/reference/src/ReferenceDrudeKernels.h
@@ -48,7 +48,7 @@ namespace OpenMM {
  */
 class ReferenceCalcDrudeForceKernel : public CalcDrudeForceKernel {
 public:
-    ReferenceCalcDrudeForceKernel(std::string name, const Platform& platform) : CalcDrudeForceKernel(name, platform) {
+    ReferenceCalcDrudeForceKernel(const std::string& name, const Platform& platform) : CalcDrudeForceKernel(name, platform) {
     }
     /**
      * Initialize the kernel.
@@ -85,7 +85,7 @@ private:
  */
 class ReferenceIntegrateDrudeLangevinStepKernel : public IntegrateDrudeLangevinStepKernel {
 public:
-    ReferenceIntegrateDrudeLangevinStepKernel(std::string name, const Platform& platform, ReferencePlatform::PlatformData& data) :
+    ReferenceIntegrateDrudeLangevinStepKernel(const std::string& name, const Platform& platform, ReferencePlatform::PlatformData& data) :
         IntegrateDrudeLangevinStepKernel(name, platform), data(data) {
     }
     ~ReferenceIntegrateDrudeLangevinStepKernel();
@@ -126,7 +126,7 @@ private:
  */
 class ReferenceIntegrateDrudeSCFStepKernel : public IntegrateDrudeSCFStepKernel {
 public:
-    ReferenceIntegrateDrudeSCFStepKernel(std::string name, const Platform& platform, ReferencePlatform::PlatformData& data) :
+    ReferenceIntegrateDrudeSCFStepKernel(const std::string& name, const Platform& platform, ReferencePlatform::PlatformData& data) :
         IntegrateDrudeSCFStepKernel(name, platform), data(data), minimizerPos(NULL) {
     }
     ~ReferenceIntegrateDrudeSCFStepKernel();

--- a/plugins/rpmd/platforms/cuda/src/CudaRpmdKernels.h
+++ b/plugins/rpmd/platforms/cuda/src/CudaRpmdKernels.h
@@ -45,7 +45,7 @@ namespace OpenMM {
  */
 class CudaIntegrateRPMDStepKernel : public IntegrateRPMDStepKernel {
 public:
-    CudaIntegrateRPMDStepKernel(std::string name, const Platform& platform, CudaContext& cu) :
+    CudaIntegrateRPMDStepKernel(const std::string& name, const Platform& platform, CudaContext& cu) :
             IntegrateRPMDStepKernel(name, platform), cu(cu) {
     }
     /**

--- a/plugins/rpmd/platforms/opencl/src/OpenCLRpmdKernels.h
+++ b/plugins/rpmd/platforms/opencl/src/OpenCLRpmdKernels.h
@@ -44,7 +44,7 @@ namespace OpenMM {
  */
 class OpenCLIntegrateRPMDStepKernel : public IntegrateRPMDStepKernel {
 public:
-    OpenCLIntegrateRPMDStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
+    OpenCLIntegrateRPMDStepKernel(const std::string& name, const Platform& platform, OpenCLContext& cl) :
             IntegrateRPMDStepKernel(name, platform), cl(cl), hasInitializedKernel(false) {
     }
     /**

--- a/plugins/rpmd/platforms/reference/src/ReferenceRpmdKernels.h
+++ b/plugins/rpmd/platforms/reference/src/ReferenceRpmdKernels.h
@@ -45,7 +45,7 @@ namespace OpenMM {
  */
 class ReferenceIntegrateRPMDStepKernel : public IntegrateRPMDStepKernel {
 public:
-    ReferenceIntegrateRPMDStepKernel(std::string name, const Platform& platform) :
+    ReferenceIntegrateRPMDStepKernel(const std::string& name, const Platform& platform) :
             IntegrateRPMDStepKernel(name, platform), fft(NULL) {
     }
     ~ReferenceIntegrateRPMDStepKernel();


### PR DESCRIPTION
there were a number of constructors that didn't have the std::string being passed as a reference which is very expensive, this makes them pass by reference if they don't get chaged