### PR TITLE
Get and scale velocities using numpy during simulated tempering

### DIFF
--- a/wrappers/python/simtk/openmm/app/simulatedtempering.py
+++ b/wrappers/python/simtk/openmm/app/simulatedtempering.py
@@ -48,6 +48,11 @@ try:
     have_gzip = True
 except: have_gzip = False
 
+try:
+    import numpy
+    have_numpy = True
+except: have_numpy = False
+
 class SimulatedTempering(object):
     """SimulatedTempering implements the simulated tempering algorithm for accelerated sampling.
     
@@ -214,7 +219,10 @@ class SimulatedTempering(object):
                     # Rescale the velocities.
                     
                     scale = math.sqrt(self.temperatures[j]/self.temperatures[self.currentTemperature])
-                    velocities = [v*scale for v in state.getVelocities().value_in_unit(unit.nanometers/unit.picoseconds)]
+                    if have_numpy:
+                        velocities = scale*state.getVelocities(asNumpy=True).value_in_unit(unit.nanometers/unit.picoseconds)
+                    else:
+                        velocities = [v*scale for v in state.getVelocities().value_in_unit(unit.nanometers/unit.picoseconds)]
                     self.simulation.context.setVelocities(velocities)
 
                     # Select this temperature.


### PR DESCRIPTION
This improves the speed of _attemptTemperatureChange during simulated tempering, for those using numpy. List comprehension is required for those not using numpy, hence the if/else.