### PR TITLE
Update travis to test more recent Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
 
     - sudo: false
       dist: trusty
-      python: 2.7_with_system_site_packages
+      python: 3.6
       env: ==STATIC_LIB==
            OPENCL=false
            CUDA=false
@@ -85,8 +85,8 @@ matrix:
 
     - sudo: false
       dist: trusty
-      python: 2.7_with_system_site_packages
-      env: ==PYTHON_2==
+      python: 3.6
+      env: ==PYTHON_3_6==
            OPENCL=false
            CUDA=false
            CC=$CCACHE/clang
@@ -96,8 +96,8 @@ matrix:
 
     - sudo: false
       dist: trusty
-      python: 3.4
-      env: ==PYTHON_3==
+      python: 3.8
+      env: ==PYTHON_3_8==
            OPENCL=false
            CUDA=false
            CC=$CCACHE/gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
            CMAKE_FLAGS="-DOPENMM_GENERATE_API_DOCS=ON"
 
     - sudo: false
-      dist: trusty
+      dist: xenial
       python: 3.8
       env: ==PYTHON_3_8==
            OPENCL=false


### PR DESCRIPTION
This makes travis test python 3.6 and 3.8.  And yes, I'm dropping the tests for 2.7.  It's time to move on.