### PR TITLE
Signature modification to Modeller.addExtraParticles()

### DIFF
--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -1004,7 +1004,7 @@ class Modeller(object):
         del context
         return actualVariants
 
-    def addExtraParticles(self, forcefield):
+    def addExtraParticles(self, forcefield, ignoreExternalBonds=False):
         """Add missing extra particles to the model that are required by a force
         field.
 
@@ -1090,7 +1090,7 @@ class Modeller(object):
                 signature = _createResidueSignature([atom.element for atom in residue.atoms()])
                 if signature in forcefield._templateSignatures:
                     for t in forcefield._templateSignatures[signature]:
-                        if compiled.matchResidueToTemplate(residue, t, bondedToAtom, False) is not None:
+                        if compiled.matchResidueToTemplate(residue, t, bondedToAtom, ignoreExternalBonds) is not None:
                             matchFound = True
                 if matchFound:
                     # Just copy the residue over.
@@ -1109,7 +1109,7 @@ class Modeller(object):
                     if signature in forcefield._templateSignatures:
                         for t in forcefield._templateSignatures[signature]:
                             if t in templatesNoEP:
-                                matches = compiled.matchResidueToTemplate(residueNoEP, templatesNoEP[t], bondedToAtomNoEP, False)
+                                matches = compiled.matchResidueToTemplate(residueNoEP, templatesNoEP[t], bondedToAtomNoEP, ignoreExternalBonds)
                                 if matches is not None:
                                     template = t;
                                     # Record the corresponding atoms.

--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -1023,6 +1023,10 @@ class Modeller(object):
         ----------
         forcefield : ForceField
             the ForceField defining what extra particles should be present
+        ignoreExternalBonds : boolean=False
+            If true, ignore external bonds when matching residues to templates.
+            This is useful when the Topology represents one piece of a larger
+            molecule, so chains are not terminated properly.
         """
         # Create copies of all residue templates that have had all extra points removed.
 


### PR DESCRIPTION
Within Modeller.addExtraParticles(), add the ability to pass down
an option to modify compiled.matchResidueToTemplate() 's
ignoreExternalBonds parameter.

https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=11264&p=0&start=0&view=&sid=e384beeb08f3bfd767dcfb546006ad63