### PR TITLE
Fix Lepton optimization with -ffast-math

### DIFF
--- a/libraries/lepton/include/lepton/ParsedExpression.h
+++ b/libraries/lepton/include/lepton/ParsedExpression.h
@@ -116,6 +116,7 @@ private:
     static ExpressionTreeNode precalculateConstantSubexpressions(const ExpressionTreeNode& node);
     static ExpressionTreeNode substituteSimplerExpression(const ExpressionTreeNode& node);
     static ExpressionTreeNode differentiate(const ExpressionTreeNode& node, const std::string& variable);
+    static bool isConstant(const ExpressionTreeNode& node);
     static double getConstantValue(const ExpressionTreeNode& node);
     static ExpressionTreeNode renameNodeVariables(const ExpressionTreeNode& node, const std::map<std::string, std::string>& replacements);
     ExpressionTreeNode rootNode;


### PR DESCRIPTION
Lepton::ParsedExpression::getConstantValue() used to return NaN to indicate non-constant
expressions. This can break with -ffast-math optimization where NaN comparisons are
not defined.

This patch defines isConstant() to test whether an expression is constant before
calling getConstantValue(). getConstantValue() now throws an exception if called on a
non-constant expression.