### PR TITLE
Add support to ForceField for handling SMIRNOFF trefoil impropers

### DIFF
--- a/docs-source/usersguide/application.rst
+++ b/docs-source/usersguide/application.rst
@@ -2331,6 +2331,22 @@ second atom has class OS and the third has class P:
 
     <Proper class1="" class2="OS" class3="P" class4="" periodicity1="3" phase1="0.0" k1="1.046"/>
 
+The :code:`<PeriodicTorsionForce>` tag also supports an optional
+:code:`ordering` attribute to provide better compatibility with the way
+impropers are assigned in different simulation packages:
+
+ * :code:`ordering="default"` specifies the default behavior if the attribute
+   is omitted. 
+ * :code:`ordering="amber"` produces behavior that replicates the behavior of
+   AmberTools LEaP
+ * :code:`ordering="charmm"` produces behavior more consistent with CHARMM
+ * :code:`ordering="smirnoff"` allows multiple impropers to be added using
+   exact matching to replicate the beheavior of `SMIRNOFF <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html>`_
+   impropers
+
+Different :code:`<PeriodicTorsionForce>` tags can specify different :code:`ordering`
+values to be used for the sub-elements appearing within their tags.
+
 <RBTorsionForce>
 ================
 

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -632,6 +632,29 @@ class ForceField(object):
             atom = self.getAtomIndexByName(atom_name)
             self.addExternalBond(atom)
 
+        def areParametersIdentical(self, template2, matchingAtoms, matchingAtoms2):
+            """Get whether this template and another one both assign identical atom types and parameters to all atoms.
+
+            Parameters
+            ----------
+            template2: _TemplateData
+                the template to compare this one to
+            matchingAtoms: list
+                the indices of atoms in this template that atoms of the residue are matched to
+            matchingAtoms2: list
+                the indices of atoms in template2 that atoms of the residue are matched to
+            """
+            atoms1 = [self.atoms[m] for m in matchingAtoms]
+            atoms2 = [template2.atoms[m] for m in matchingAtoms2]
+            if any(a1.type != a2.type or a1.parameters != a2.parameters for a1,a2 in zip(atoms1, atoms2)):
+                return False
+            # Properly comparing virtual sites really needs a much more complicated analysis.  This simple check
+            # could easily fail for templates containing vsites, even if they're actually identical.  Since we
+            # currently have no force fields that include both patches and vsites, I'm not going to worry about it now.
+            if self.virtualSites != template2.virtualSites:
+                return False
+            return True
+
     class _TemplateAtomData(object):
         """Inner class used to encapsulate data about an atom in a residue template definition."""
         def __init__(self, name, type, element, parameters={}):
@@ -866,7 +889,7 @@ class ForceField(object):
 
         Returns
         -------
-        template : _ForceFieldTemplate
+        template : _TemplateData
             The matching forcefield residue template, or None if no matches are found.
         matches : list
             a list specifying which atom of the template each atom of the residue
@@ -888,7 +911,13 @@ class ForceField(object):
                 template = allMatches[0][0]
                 matches = allMatches[0][1]
             elif len(allMatches) > 1:
-                raise Exception('Multiple matching templates found for residue %d (%s): %s.' % (res.index+1, res.name, ', '.join(match[0].name for match in allMatches)))
+                # We found multiple matches.  This is OK if and only if they assign identical types and parameters to all atoms.
+                t1, m1 = allMatches[0]
+                for t2, m2 in allMatches[1:]:
+                    if not t1.areParametersIdentical(t2, m1, m2):
+                        raise Exception('Multiple non-identical matching templates found for residue %d (%s): %s.' % (res.index+1, res.name, ', '.join(match[0].name for match in allMatches)))
+                template = allMatches[0][0]
+                matches = allMatches[0][1]
         return [template, matches]
 
     def _buildBondedToAtomList(self, topology):
@@ -4447,7 +4476,7 @@ class AmoebaVdwGenerator(object):
     def createForce(self, sys, data, nonbondedMethod, nonbondedCutoff, args):
 
         sigmaMap = {'ARITHMETIC':1, 'GEOMETRIC':1, 'CUBIC-MEAN':1}
-        epsilonMap = {'ARITHMETIC':1, 'GEOMETRIC':1, 'HARMONIC':1, 'HHG':1}
+        epsilonMap = {'ARITHMETIC':1, 'GEOMETRIC':1, 'HARMONIC':1, 'W-H':1, 'HHG':1}
 
         force = mm.AmoebaVdwForce()
         sys.addForce(force)

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -632,29 +632,6 @@ class ForceField(object):
             atom = self.getAtomIndexByName(atom_name)
             self.addExternalBond(atom)
 
-        def areParametersIdentical(self, template2, matchingAtoms, matchingAtoms2):
-            """Get whether this template and another one both assign identical atom types and parameters to all atoms.
-            
-            Parameters
-            ----------
-            template2: _TemplateData
-                the template to compare this one to
-            matchingAtoms: list
-                the indices of atoms in this template that atoms of the residue are matched to
-            matchingAtoms2: list
-                the indices of atoms in template2 that atoms of the residue are matched to
-            """
-            atoms1 = [self.atoms[m] for m in matchingAtoms]
-            atoms2 = [template2.atoms[m] for m in matchingAtoms2]
-            if any(a1.type != a2.type or a1.parameters != a2.parameters for a1,a2 in zip(atoms1, atoms2)):
-                return False
-            # Properly comparing virtual sites really needs a much more complicated analysis.  This simple check
-            # could easily fail for templates containing vsites, even if they're actually identical.  Since we
-            # currently have no force fields that include both patches and vsites, I'm not going to worry about it now.
-            if self.virtualSites != template2.virtualSites:
-                return False
-            return True
-
     class _TemplateAtomData(object):
         """Inner class used to encapsulate data about an atom in a residue template definition."""
         def __init__(self, name, type, element, parameters={}):
@@ -889,7 +866,7 @@ class ForceField(object):
 
         Returns
         -------
-        template : _TemplateData
+        template : _ForceFieldTemplate
             The matching forcefield residue template, or None if no matches are found.
         matches : list
             a list specifying which atom of the template each atom of the residue
@@ -911,13 +888,7 @@ class ForceField(object):
                 template = allMatches[0][0]
                 matches = allMatches[0][1]
             elif len(allMatches) > 1:
-                # We found multiple matches.  This is OK if and only if they assign identical types and parameters to all atoms.
-                t1, m1 = allMatches[0]
-                for t2, m2 in allMatches[1:]:
-                    if not t1.areParametersIdentical(t2, m1, m2):
-                        raise Exception('Multiple non-identical matching templates found for residue %d (%s): %s.' % (res.index+1, res.name, ', '.join(match[0].name for match in allMatches)))
-                template = allMatches[0][0]
-                matches = allMatches[0][1]
+                raise Exception('Multiple matching templates found for residue %d (%s): %s.' % (res.index+1, res.name, ', '.join(match[0].name for match in allMatches)))
         return [template, matches]
 
     def _buildBondedToAtomList(self, topology):
@@ -1841,6 +1812,16 @@ def _matchImproper(data, torsion, generator):
                                 (a2, a3) = (a3, a2)
                         match = (a2, a3, torsion[0], a4, tordef)
                         break
+                    elif tordef.ordering == 'smirnoff':
+                        # topology atom indexes
+                        a1 = torsion[0]
+                        a2 = torsion[t2[1]]
+                        a3 = torsion[t3[1]]
+                        a4 = torsion[t4[1]]
+                        # enforce exact match
+                        match = (a1, a2, a3, a4, tordef)
+                        break
+
     return match
 
 
@@ -2032,7 +2013,7 @@ class PeriodicTorsionGenerator(object):
     def registerImproperTorsion(self, parameters, ordering='default'):
         torsion = self.ff._parseTorsion(parameters)
         if torsion is not None:
-            if ordering in ['default', 'charmm', 'amber']:
+            if ordering in ['default', 'charmm', 'amber', 'smirnoff']:
                 torsion.ordering = ordering
             else:
                 raise ValueError('Illegal ordering type %s for improper torsion %s' % (ordering, torsion))
@@ -2116,7 +2097,13 @@ class PeriodicTorsionGenerator(object):
                 (a1, a2, a3, a4, tordef) = match
                 for i in range(len(tordef.phase)):
                     if tordef.k[i] != 0:
-                        force.addTorsion(a1, a2, a3, a4, tordef.periodicity[i], tordef.phase[i], tordef.k[i])
+                        if tordef.ordering == 'smirnoff':
+                            # Add all torsions in trefoil
+                            force.addTorsion(a1, a2, a3, a4, tordef.periodicity[i], tordef.phase[i], tordef.k[i])
+                            force.addTorsion(a1, a3, a4, a2, tordef.periodicity[i], tordef.phase[i], tordef.k[i])
+                            force.addTorsion(a1, a4, a2, a3, tordef.periodicity[i], tordef.phase[i], tordef.k[i])
+                        else:
+                            force.addTorsion(a1, a2, a3, a4, tordef.periodicity[i], tordef.phase[i], tordef.k[i])
 parsers["PeriodicTorsionForce"] = PeriodicTorsionGenerator.parseElement
 
 
@@ -4460,7 +4447,7 @@ class AmoebaVdwGenerator(object):
     def createForce(self, sys, data, nonbondedMethod, nonbondedCutoff, args):
 
         sigmaMap = {'ARITHMETIC':1, 'GEOMETRIC':1, 'CUBIC-MEAN':1}
-        epsilonMap = {'ARITHMETIC':1, 'GEOMETRIC':1, 'HARMONIC':1, 'W-H':1, 'HHG':1}
+        epsilonMap = {'ARITHMETIC':1, 'GEOMETRIC':1, 'HARMONIC':1, 'HHG':1}
 
         force = mm.AmoebaVdwForce()
         sys.addForce(force)

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -921,23 +921,6 @@ class TestForceField(unittest.TestCase):
     <Type name="[H]C(=O)[H]$H1#2" element="H" mass="1.007947" class="[H]C(=O)[H]$H1#2"/>
     <Type name="[H]C(=O)[H]$H2#3" element="H" mass="1.007947" class="[H]C(=O)[H]$H2#3"/>
   </AtomTypes>
-  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5">
-    <UseAttributeFromResidue name="charge"/>
-    <Atom sigma="0.3399669508423535" epsilon="0.359824" class="[H]C(=O)[H]$C1#0"/>
-    <Atom sigma="0.2959921901149463" epsilon="0.87864" class="[H]C(=O)[H]$O1#1"/>
-    <Atom sigma="0.2510552587719476" epsilon="0.06276" class="[H]C(=O)[H]$H1#2"/>
-    <Atom sigma="0.2510552587719476" epsilon="0.06276" class="[H]C(=O)[H]$H2#3"/>
-  </NonbondedForce>
-  <HarmonicBondForce>
-    <Bond class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$O1#1" length="0.122768286085" k="475133.08130977117"/>
-    <Bond class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H1#2" length="0.10850661293899999" k="338125.5447433327"/>
-    <Bond class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H2#3" length="0.10850661293899999" k="338125.5447433327"/>
-  </HarmonicBondForce>
-  <HarmonicAngleForce>
-    <Angle class1="[H]C(=O)[H]$O1#1" class2="[H]C(=O)[H]$C1#0" class3="[H]C(=O)[H]$H1#2" angle="2.4141195890059883" k="279.7597371776727"/>
-    <Angle class1="[H]C(=O)[H]$O1#1" class2="[H]C(=O)[H]$C1#0" class3="[H]C(=O)[H]$H2#3" angle="2.4141195890059883" k="279.7597371776727"/>
-    <Angle class1="[H]C(=O)[H]$H1#2" class2="[H]C(=O)[H]$C1#0" class3="[H]C(=O)[H]$H2#3" angle="2.2670423843424943" k="330.7820750751862"/>
-  </HarmonicAngleForce>
   <PeriodicTorsionForce ordering="smirnoff">
     <Improper class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$O1#1" class3="[H]C(=O)[H]$H1#2" class4="[H]C(=O)[H]$H2#3" periodicity1="2" phase1="3.141592653589793" k1="1.5341333333333336"/>
     <Improper class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H1#2" class3="[H]C(=O)[H]$H2#3" class4="[H]C(=O)[H]$O1#1" periodicity1="2" phase1="3.141592653589793" k1="1.5341333333333336"/>

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -907,6 +907,72 @@ class TestForceField(unittest.TestCase):
         self.assertEqual(system1_indexes, [51, 56, 54, 55])
         self.assertEqual(system2_indexes, [51, 55, 54, 56])
 
+    def test_ImpropersOrdering_smirnoff(self):
+        """Test correctness of the ordering of atom indexes in improper torsions
+        and the torsion.ordering parameter when using the 'smirnoff' mode.
+        """
+
+        # SMIRNOFF parameters for formaldehyde
+        xml = """
+<ForceField>
+  <AtomTypes>
+    <Type name="[H]C(=O)[H]$C1#0" element="C" mass="12.01078" class="[H]C(=O)[H]$C1#0"/>
+    <Type name="[H]C(=O)[H]$O1#1" element="O" mass="15.99943" class="[H]C(=O)[H]$O1#1"/>
+    <Type name="[H]C(=O)[H]$H1#2" element="H" mass="1.007947" class="[H]C(=O)[H]$H1#2"/>
+    <Type name="[H]C(=O)[H]$H2#3" element="H" mass="1.007947" class="[H]C(=O)[H]$H2#3"/>
+  </AtomTypes>
+  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom sigma="0.3399669508423535" epsilon="0.359824" class="[H]C(=O)[H]$C1#0"/>
+    <Atom sigma="0.2959921901149463" epsilon="0.87864" class="[H]C(=O)[H]$O1#1"/>
+    <Atom sigma="0.2510552587719476" epsilon="0.06276" class="[H]C(=O)[H]$H1#2"/>
+    <Atom sigma="0.2510552587719476" epsilon="0.06276" class="[H]C(=O)[H]$H2#3"/>
+  </NonbondedForce>
+  <HarmonicBondForce>
+    <Bond class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$O1#1" length="0.122768286085" k="475133.08130977117"/>
+    <Bond class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H1#2" length="0.10850661293899999" k="338125.5447433327"/>
+    <Bond class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H2#3" length="0.10850661293899999" k="338125.5447433327"/>
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle class1="[H]C(=O)[H]$O1#1" class2="[H]C(=O)[H]$C1#0" class3="[H]C(=O)[H]$H1#2" angle="2.4141195890059883" k="279.7597371776727"/>
+    <Angle class1="[H]C(=O)[H]$O1#1" class2="[H]C(=O)[H]$C1#0" class3="[H]C(=O)[H]$H2#3" angle="2.4141195890059883" k="279.7597371776727"/>
+    <Angle class1="[H]C(=O)[H]$H1#2" class2="[H]C(=O)[H]$C1#0" class3="[H]C(=O)[H]$H2#3" angle="2.2670423843424943" k="330.7820750751862"/>
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce ordering="smirnoff">
+    <Improper class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$O1#1" class3="[H]C(=O)[H]$H1#2" class4="[H]C(=O)[H]$H2#3" periodicity1="2" phase1="3.141592653589793" k1="1.5341333333333336"/>
+    <Improper class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H1#2" class3="[H]C(=O)[H]$H2#3" class4="[H]C(=O)[H]$O1#1" periodicity1="2" phase1="3.141592653589793" k1="1.5341333333333336"/>
+    <Improper class1="[H]C(=O)[H]$C1#0" class2="[H]C(=O)[H]$H2#3" class3="[H]C(=O)[H]$O1#1" class4="[H]C(=O)[H]$H1#2" periodicity1="2" phase1="3.141592653589793" k1="1.5341333333333336"/>
+  </PeriodicTorsionForce>
+  <Residues>
+    <Residue name="[H]C(=O)[H]">
+      <Atom name="C1" type="[H]C(=O)[H]$C1#0" charge="0.5632799863815308"/>
+      <Atom name="O1" type="[H]C(=O)[H]$O1#1" charge="-0.514739990234375"/>
+      <Atom name="H1" type="[H]C(=O)[H]$H1#2" charge="-0.02426999807357788"/>
+      <Atom name="H2" type="[H]C(=O)[H]$H2#3" charge="-0.02426999807357788"/>
+      <Bond atomName1="C1" atomName2="O1"/>
+      <Bond atomName1="C1" atomName2="H1"/>
+      <Bond atomName1="C1" atomName2="H2"/>
+    </Residue>
+  </Residues>
+</ForceField>
+"""
+        pdb = PDBFile('systems/formaldehyde.pdb')
+        # ff1 uses default ordering of impropers, ff2 uses "amber" for the one
+        # problematic improper
+        ff = ForceField(StringIO(xml))
+
+        system = ff.createSystem(pdb.topology)
+
+        # Check that impropers are applied in the correct three-fold trefoil pattern
+        forces = { force.__class__.__name__ : force for force in system.getForces() }
+        force = forces['PeriodicTorsionForce']
+        created_torsions = set()
+        for index in range(force.getNumTorsions()):
+            i,j,k,l,_,_,_ = force.getTorsionParameters(index)
+            created_torsions.add((i,j,k,l))
+        expected_torsions = set((0,3,1,2), (0,1,2,3), (0,2,3,1))
+        self.assertEqual(expected_torsions, created_torsions)
+
     def test_Disulfides(self):
         """Test that various force fields handle disulfides correctly."""
         pdb = PDBFile('systems/bpti.pdb')

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -970,7 +970,7 @@ class TestForceField(unittest.TestCase):
         for index in range(force.getNumTorsions()):
             i,j,k,l,_,_,_ = force.getTorsionParameters(index)
             created_torsions.add((i,j,k,l))
-        expected_torsions = set((0,3,1,2), (0,1,2,3), (0,2,3,1))
+        expected_torsions = set([(0,3,1,2), (0,1,2,3), (0,2,3,1)])
         self.assertEqual(expected_torsions, created_torsions)
 
     def test_Disulfides(self):

--- a/wrappers/python/tests/systems/formaldehyde.pdb
+++ b/wrappers/python/tests/systems/formaldehyde.pdb
@@ -1,0 +1,11 @@
+REMARK   1 CREATED WITH OPENMM 7.4, 2020-01-04
+HETATM    1          A   1       0.095   0.011   0.000  1.00  0.00           C  
+HETATM    2          A   1       0.513  -1.098  -0.004  1.00  0.00           O  
+HETATM    3          A   1      -1.098   0.149   0.015  1.00  0.00           H  
+HETATM    4          A   1       0.590   0.938  -0.011  1.00  0.00           H  
+TER       5          A   1
+CONECT    1    2    3    4
+CONECT    2    1
+CONECT    3    1
+CONECT    4    1
+END


### PR DESCRIPTION
This PR adds a new `ordering='smirnoff'` mode to improper torsion handling in `PeriodicTorsionGenerator` to make it possible to get exact agreement with [SMIRNOFF small molecule force fields](https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html), which use trefoil-style torsions to avoid improper torsion ambiguity issues that plague GAFF, AMBER, and CHARMM. 

This feature will be used by the [`SMIRNOFFTemplateGenerator`](https://github.com/choderalab/openmm-forcefields/tree/update-amber#examples-using-smirnofftemplategenerator-to-generate-small-molecule-smirnoff-parameters) that provides support for parameterizing small molecules on the fly with the [`openforcefield` toolkit](http://openforcefield.org).

Fixes #2509
