### PR TITLE
Fixed error in BAOAB on CUDA and OpenCL

### DIFF
--- a/openmmapi/src/BAOABLangevinIntegrator.cpp
+++ b/openmmapi/src/BAOABLangevinIntegrator.cpp
@@ -73,6 +73,7 @@ vector<string> BAOABLangevinIntegrator::getKernelNames() {
 }
 
 double BAOABLangevinIntegrator::computeKineticEnergy() {
+    forcesAreValid = false;
     return kernel.getAs<IntegrateBAOABStepKernel>().computeKineticEnergy(*context, *this);
 }
 
@@ -84,7 +85,8 @@ void BAOABLangevinIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");  
     for (int i = 0; i < steps; ++i) {
-        context->updateContextState();
+        if (context->updateContextState())
+            forcesAreValid = false;
         kernel.getAs<IntegrateBAOABStepKernel>().execute(*context, *this, forcesAreValid);
     }
 }


### PR DESCRIPTION
This error was introduced by #2447.  Unfortunately, the fix removes much of the benefit of that optimization, since after you call `getState()` to query the energy, the next step you take requires two force evaluations.  I might see if I can do a better fix in the future, but for the moment it's more important that the results be correct.