### PR TITLE
Improved behavior of rigidWater option

### DIFF
--- a/wrappers/python/simtk/openmm/app/data/amoeba2009.xml
+++ b/wrappers/python/simtk/openmm/app/data/amoeba2009.xml
@@ -2983,7 +2983,7 @@
    <ExternalBond from="14" />
    <ExternalBond from="0" />
  </Residue>
-  <Residue name="HOH">
+  <Residue name="HOH" rigidWater="false">
    <Atom name="H1" type="403" />
    <Atom name="H2" type="403" />
    <Atom name="O" type="402" />

--- a/wrappers/python/simtk/openmm/app/data/amoeba2013.xml
+++ b/wrappers/python/simtk/openmm/app/data/amoeba2013.xml
@@ -1756,7 +1756,7 @@
    <ExternalBond from="14" />
    <ExternalBond from="0" />
  </Residue>
-  <Residue name="HOH">
+  <Residue name="HOH" rigidWater="false">
    <Atom name="H1" type="248" />
    <Atom name="H2" type="248" />
    <Atom name="O" type="247" />

--- a/wrappers/python/simtk/openmm/app/data/iamoeba.xml
+++ b/wrappers/python/simtk/openmm/app/data/iamoeba.xml
@@ -4,7 +4,7 @@
   <Type name="381" class="74" element="H" mass="1.008"/>
  </AtomTypes>
  <Residues>
-  <Residue name="HOH">
+  <Residue name="HOH" rigidWater="false">
    <Atom name="H1" type="381"/>
    <Atom name="H2" type="381"/>
    <Atom name="O" type="380"/>

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -165,12 +165,12 @@ class TestForceField(unittest.TestCase):
 
         topology = self.pdb1.topology
         for constraints_value in [None, HBonds, AllBonds, HAngles]:
-            for rigidWater_value in [True, False]:
+            for rigidWater_value in [True, False, None]:
                 system = self.forcefield1.createSystem(topology,
                                                        constraints=constraints_value,
                                                        rigidWater=rigidWater_value)
                 validateConstraints(self, topology, system,
-                                    constraints_value, rigidWater_value)
+                                    constraints_value, rigidWater_value != False)
 
     def test_flexibleConstraints(self):
         """ Test the flexibleConstraints keyword """
@@ -1061,6 +1061,15 @@ class AmoebaTestForceField(unittest.TestCase):
         self.assertAlmostEqual(constraints[(0,1)], hoDist)
         self.assertAlmostEqual(constraints[(0,2)], hoDist)
         self.assertAlmostEqual(constraints[(1,2)], hohDist)
+        
+        # Check that all values of rigidWater are interpreted correctly.
+        
+        numWaters = 215
+        self.assertEqual(3*numWaters, system.getNumConstraints())
+        system = self.forcefield1.createSystem(self.pdb1.topology, rigidWater=False)
+        self.assertEqual(0, system.getNumConstraints())
+        system = self.forcefield1.createSystem(self.pdb1.topology, rigidWater=None)
+        self.assertEqual(0, system.getNumConstraints())
 
     def test_Forces(self):
         """Compute forces and compare them to ones generated with a previous version of OpenMM to ensure they haven't changed."""


### PR DESCRIPTION
By default `ForceField.createSystem()` makes all water molecules rigid.  This is correct for most water models, but AMOEBA water is supposed to be flexible.  If the user doesn't realize they need to specify `rigidWater=False`, they'll incorrectly get rigid water.  See #2506 fox example.

I made two changes.  First, the force field definition can add the attribute `rigidWater="false"` to the water template to indicate that it should be flexible.  Second, the default value for the `rigidWater` option on `createSystem()` is now `None` instead of `True`.  This tells it to use whatever behavior is appropriate for the water model: rigid models are rigid and flexible models are flexible.  If you explicitly specify `True` or `False` instead, that overrides the default and forces all water to be rigid or flexible respectively.