### PR TITLE
Fixed inconsistency between plaforms in constraints with CustomIntegrator

### DIFF
--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -6265,10 +6265,8 @@ void CommonIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context
             for (int step = numSteps-1; step >= 0; step--) {
                 if (stepType[step] == CustomIntegrator::ConstrainPositions)
                     beforeConstrain = true;
-                else if (stepType[step] == CustomIntegrator::ComputePerDof && variable[step] == "x" && beforeConstrain) {
+                else if (stepType[step] == CustomIntegrator::ComputePerDof && variable[step] == "x" && beforeConstrain)
                     storePosAsDelta[step] = true;
-                    beforeConstrain = false;
-                }
             }
             bool storedAsDelta = false;
             for (int step = 0; step < numSteps; step++) {


### PR DESCRIPTION
Constraints are applied relative to a base configuration that determines which directions the constraint forces are applied along.  Different platforms were using different base configurations when you executed the following sequence of steps:

1. Update positions
2. Update positions again
3. Apply constraints

The Reference and CPU platforms used the positions at the start of step 1 as the base.  The CUDA and OpenCL platforms used the positions at the start of step 2.  I changed them to behave the same as Reference.