### PR TITLE
Switched dlopen flag from RTLD_GLOBAL to RTLD_LOCAL

### DIFF
--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -61,7 +61,7 @@ static bool stringLengthComparator(string i, string j) {
 static int registerPlatforms() {
 
     // Register the Platforms built into the main library.  This should eventually be moved elsewhere.
-    
+
     ReferencePlatform* platform = new ReferencePlatform();
     Platform::registerPlatform(platform);
     return 0;
@@ -117,7 +117,7 @@ void Platform::contextCreated(ContextImpl& context, const map<string, string>& p
 void Platform::linkedContextCreated(ContextImpl& context, ContextImpl& originalContext) const {
     // The default implementation just copies over the properties and calls contextCreated().
     // Subclasses may override this to do something different.
-    
+
     map<string, string> properties;
     for (auto& name : getPropertyNames())
         properties[name] = getPropertyValue(originalContext.getOwner(), name);
@@ -221,8 +221,8 @@ static void initializePlugins(vector<HMODULE>& plugins) {
 static void* loadOneLibrary(const string& file) {
 #ifdef __PNACL__
     throw OpenMMException("Loading dynamic libraries is not supported on PNaCl");
-#else    
-    void *handle = dlopen(file.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+#else
+    void *handle = dlopen(file.c_str(), RTLD_LAZY | RTLD_LOCAL);
     if (handle == NULL) {
         throw OpenMMException("Error loading library "+file+": "+dlerror());
     }
@@ -357,4 +357,3 @@ ContextImpl& Platform::getContextImpl(Context& context) const {
 const ContextImpl& Platform::getContextImpl(const Context& context) const {
     return *context.impl;
 }
-


### PR DESCRIPTION
The `RTLD_GLOBAL` flag causes problems when building with (e.g.) devtoolset-7, which statically links in all newer components of the static library to maintain backward compatibility to CentOS 7. The problem arises when the resulting build is used with another library also built with devtoolset-7: calling `dlopen` with `RTLD_GLOBAL` causes the statically-linked components to be loaded twice. Things still tend to work until the application is closed, at which point there's a crash looking like the one below, due to the symbol tables from the `dlopen`ed libraries getting jumbled up (see https://stackoverflow.com/questions/11005881/static-library-loaded-twice). If I understand correctly, the only real reason for using `RTLD_GLOBAL` used to be to allow passing of exceptions between DLLs, but apparently that is no longer an issue since GCC 4.5 (see https://github.com/aalexand/sharedlib_typeinfo). Since OpenMM is now incompatible with GCC versions earlier than 5, there seems no reason not to switch to `RTLD_LOCAL`. The resulting build runs correctly on my machine (tested simulations in OpenCL and CUDA, and so far passed tests up to 132), and no longer crashes on exit.



```
*** Error in 
`/home/tic20/chimerax-git/chimerax/ChimeraX.app/bin/ChimeraX': double 
free or corruption (!prev): 0x00000000057bd4f0 ***

#0  0x00007ffff74d9337 in __GI_raise (sig=sig@entry=6) at 
../nptl/sysdeps/unix/sysv/linux/raise.c:55
#1  0x00007ffff74daa28 in __GI_abort () at abort.c:90
#2  0x00007ffff751be87 in __libc_message (do_abort=do_abort@entry=2, 
fmt=fmt@entry=0x7ffff762e3b8 "*** Error in `%s': %s: 0x%s ***\n")
     at ../sysdeps/unix/sysv/linux/libc_fatal.c:196
#3  0x00007ffff7524679 in _int_free (ar_ptr=0x7ffff786a760 <main_arena>, 
ptr=<optimized out>, str=0x7ffff762e4e0 "double free or corruption 
(!prev)", action=3)
     at malloc.c:4967
#4  0x00007ffff7524679 in _int_free (av=0x7ffff786a760 <main_arena>, 
p=<optimized out>, have_lock=0) at malloc.c:3843
#5  0x00007fffe6c38b63 in std::basic_string<char, 
std::char_traits<char>, std::allocator<char> >::~basic_string() 
(__a=..., this=<optimized out>)
     at 
/usr/src/debug/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/include/bits/basic_string.h:539
#6  0x00007fffe6c38b63 in std::basic_string<char, 
std::char_traits<char>, std::allocator<char> >::~basic_string() 
(this=<optimized out>, __in_chrg=<optimized out>)
     at 
/usr/src/debug/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/x86_64-redhat-linux/libstdc++-v3/include/bits/basic_string.h:539
#7  0x00007ffff74dcc99 in __run_exit_handlers (status=status@entry=0, 
listp=0x7ffff786a6c8 <__exit_funcs>, 
run_list_atexit=run_list_atexit@entry=true) at exit.c:77
#8  0x00007ffff74dcce7 in __GI_exit (status=status@entry=0) at exit.c:99
#9  0x00007ffff7a26d39 in Py_Exit (sts=sts@entry=0) at 
Python/pylifecycle.c:2292
#10 0x00007ffff78d93be in handle_system_exit () at 
Python/pythonrun.c:636
#11 0x00007ffff7a30b17 in PyErr_PrintEx () at Python/pythonrun.c:715
#12 0x00007ffff7a30b17 in PyErr_PrintEx 
(set_sys_last_vars=set_sys_last_vars@entry=1) at Python/pythonrun.c:646
#13 0x00007ffff7a30b2a in PyErr_Print () at Python/pythonrun.c:542
#14 0x00007ffff7a5122d in pymain_run_module (modname=<optimized out>, 
set_argv0=set_argv0@entry=1) at Modules/main.c:323
#15 0x00007ffff7a56e19 in pymain_main (pymain=0x7fffffffd700) at 
Modules/main.c:2865
#16 0x00007ffff7a56e19 in pymain_main 
(pymain=pymain@entry=0x7fffffffd700) at Modules/main.c:3029
#17 0x00007ffff7a572d2 in Py_Main (argc=<optimized out>, argv=<optimized 
out>) at Modules/main.c:3052
#18 0x00000000004008b7 in main ()
```