### PR TITLE
Prefer runtime compiler over nvcc

### DIFF
--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -132,16 +132,6 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
     isNvccAvailable = (res == 0 && stat(tempDir.c_str(), &info) == 0);
     int cudaDriverVersion;
     cuDriverGetVersion(&cudaDriverVersion);
-    static bool hasShownNvccWarning = false;
-    if (hasCompilerKernel && !isNvccAvailable && !hasShownNvccWarning && cudaDriverVersion < 8000) {
-        hasShownNvccWarning = true;
-        printf("Could not find nvcc.  Using runtime compiler, which may produce slower performance.  ");
-#ifdef WIN32
-        printf("Set CUDA_BIN_PATH to specify where nvcc is located.\n");
-#else
-        printf("Set OPENMM_CUDA_COMPILER to specify where nvcc is located.\n");
-#endif
-    }
     if (hostCompiler.size() > 0)
         this->compiler = compiler+" --compiler-bindir "+hostCompiler;
     if (!hasInitializedCuda) {
@@ -575,7 +565,7 @@ CUmodule CudaContext::createModule(const string source, const map<string, string
 
     // If the runtime compiler plugin is available, use it.
 
-    if (hasCompilerKernel && !isNvccAvailable) {
+    if (hasCompilerKernel) {
         string ptx = compilerKernel.getAs<CudaCompilerKernel>().createModule(src.str(), "-arch=compute_"+gpuArchitecture+" "+options, *this);
 
         // If possible, write the PTX out to a temporary file so we can cache it for later use.


### PR DESCRIPTION
A long time ago, the CUDA runtime compiler had a bug that caused it to ignore optimization flags, leading to slower performance.  To work around that, we made it prefer nvcc over the runtime compiler when both were available.  The bug was fixed a long time ago (I think in CUDA 8.0?), but we never switched it back.

Using the runtime compiler has fewer opportunities for things to go wrong, since it doesn't require locating nvcc on disk, having a host compiler, and having a temp directory we can write to.  So this switches it back.