### PR TITLE
Remove unused variables

### DIFF
--- a/platforms/cpu/src/CpuCustomGBForce.cpp
+++ b/platforms/cpu/src/CpuCustomGBForce.cpp
@@ -246,7 +246,6 @@ void CpuCustomGBForce::calculateIxn(int numberOfAtoms, float* posq, vector<vecto
 void CpuCustomGBForce::threadComputeForce(ThreadPool& threads, int threadIndex) {
     // Compute this thread's subset of interactions.
 
-    int numThreads = threads.getNumThreads();
     threadEnergy[threadIndex] = 0;
     double& energy = threadEnergy[threadIndex];
     float* forces = &(*threadForce)[threadIndex][0];

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -1249,7 +1249,6 @@ void CpuCalcCustomManyParticleForceKernel::initialize(const System& system, cons
     // Build the arrays.
 
     numParticles = system.getNumParticles();
-    int numParticleParameters = force.getNumPerParticleParameters();
     particleParamArray.resize(numParticles);
     for (int i = 0; i < numParticles; ++i) {
         int type;

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1576,7 +1576,6 @@ void CudaCalcCustomCVForceKernel::initialize(const System& system, const CustomC
     
     // Create arrays for storing information.
     
-    int elementSize = (cu.getUseDoublePrecision() || cu.getUseMixedPrecision() ? sizeof(double) : sizeof(float));
     cvForces.resize(numCVs);
     for (int i = 0; i < numCVs; i++)
         cvForces[i].initialize<long long>(cu, 3*cu.getPaddedNumAtoms(), "cvForce");

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -1973,7 +1973,6 @@ void ReferenceCalcCustomManyParticleForceKernel::initialize(const System& system
     // Build the arrays.
 
     numParticles = system.getNumParticles();
-    int numParticleParameters = force.getNumPerParticleParameters();
     particleParamArray.resize(numParticles);
     for (int i = 0; i < numParticles; ++i) {
         int type;

--- a/platforms/reference/src/SimTKReference/ReferenceObc.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceObc.cpp
@@ -382,9 +382,6 @@ double ReferenceObc::computeBornEnergyForces(const vector<Vec3>& atomCoordinates
     const vector<double>& obcChain            = getObcChain();
     const vector<double>& atomicRadii         = _obcParameters->getAtomicRadii();
 
-    const double alphaObc                   = _obcParameters->getAlphaObc();
-    const double betaObc                    = _obcParameters->getBetaObc();
-    const double gammaObc                   = _obcParameters->getGammaObc();
     const vector<double>& scaledRadiusFactor  = _obcParameters->getScaledRadiusFactors();
 
     // compute factor that depends only on the outer loop index

--- a/plugins/amoeba/serialization/src/AmoebaTorsionTorsionForceProxy.cpp
+++ b/plugins/amoeba/serialization/src/AmoebaTorsionTorsionForceProxy.cpp
@@ -83,7 +83,6 @@ void AmoebaTorsionTorsionForceProxy::serialize(const void* object, Serialization
         const std::vector< std::vector< std::vector<double> > > grid = force.getTorsionTorsionGrid(kk);
 
         unsigned int gridCount = 0;
-        unsigned int gridYsize =  grid[0].size();
         for (unsigned int ii = 0; ii < grid.size(); ii++) {
             gridCount += grid[ii].size();
         }


### PR DESCRIPTION
This dead code was identified with the help of [scan-build](https://clang-analyzer.llvm.org/scan-build.html). Every variable that I am proposing to remove is initialized to the result of some function call, making it very unlikely that the compiler's optimizer will automatically eliminate the unnecessary code.