### PR TITLE
Update Azure VM to newer version

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -2,9 +2,9 @@ jobs:
 
   # Configure, build, install, and test job
   - job: 'windows_build'
-    displayName: 'Windows VS2015'
+    displayName: 'Windows VS2017'
     pool:
-      vmImage: 'vs2015-win2012r2'
+      vmImage: 'vs2017-win2016'
     timeoutInMinutes: 360
     variables:
       llvm.version: '7.0.1'
@@ -54,7 +54,7 @@ jobs:
       # Download OpenCL Headers and build the ICD loader
       - script: |
           setlocal EnableDelayedExpansion
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           mkdir opencl
           cd opencl
           wget https://www.khronos.org/registry/cl/specs/opencl-icd-1.2.11.0.tgz -O opencl-icd-1.2.11.0.tgz
@@ -67,7 +67,9 @@ jobs:
           move .\OpenCL-Headers-master\CL\*.h .\inc\CL\
           mkdir lib > $null
           cd lib
-          cmake -G Ninja ..
+          cmake -G Ninja .. ^
+                -DCMAKE_CXX_COMPILER=cl.exe ^
+                -DCMAKE_C_COMPILER=cl.exe
           cmake --build . ^
                 -- -j %NUMBER_OF_PROCESSORS%
         displayName: "Download and install OpenCL"
@@ -75,12 +77,14 @@ jobs:
       # Configure
       - script: |
           setlocal EnableDelayedExpansion
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           mkdir build & cd build
           cmake -G Ninja ^
                 -DOPENCL_INCLUDE_DIR=$(Pipeline.Workspace)/opencl/inc ^
                 -DOPENCL_LIBRARY=$(Pipeline.Workspace)/opencl/lib/OpenCL.lib ^
                 -DCMAKE_BUILD_TYPE=$(cmake.build.type) ^
+                -DCMAKE_CXX_COMPILER=cl.exe ^
+                -DCMAKE_C_COMPILER=cl.exe ^
                 -DCMAKE_INSTALL_PREFIX=../install ^
                 -DOPENMM_BUILD_EXAMPLES=OFF ^
                 -DOPENMM_BUILD_OPENCL_TESTS=OFF ^
@@ -89,7 +93,7 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)
       # Build
       - script: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cmake --build . ^
                 --config $(cmake.build.type) ^
                 -- -j %NUMBER_OF_PROCESSORS%


### PR DESCRIPTION
When I first set up Azure CI I used the oldest VS version, in keeping with the OpenMM ethos of supporting legacy hardware and software stacks where possible.  Recently Microsoft issued the warning

```
On March 23, 2020, Azure Pipelines will remove Windows Server 2012 R2 with Visual Studio 2015(`vs2015-win2012r2`), macOS High Sierra 10.13 (`macOS-10.13`), and Windows Server Core 1803 (`win1803`) from our hosted pools. This includes builds using the `Hosted` agent pool. A series of brownouts to highlight builds and releases using these soon-to-be-removed images will be conducted over the next couple of weeks. During these brownouts, any builds and releases using the vs2015-win2012r2, macOS-10.13, or win1803 images will fail.
```

To address the deprecation, this PR updates the VM to a newer, but not latest, version.