### PR TITLE
Lepton: define M_PI if needed with MingW (in addition to MSVC)

### DIFF
--- a/libraries/lepton/src/MSVC_erfc.h
+++ b/libraries/lepton/src/MSVC_erfc.h
@@ -8,9 +8,13 @@
  * (VC11 has _MSC_VER=1700).
  */
 
-#if defined(_MSC_VER) 
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#if !defined(M_PI)
 #define M_PI 3.14159265358979323846264338327950288
+#endif
+#endif
 
+#if defined(_MSC_VER)
 #if _MSC_VER <= 1700 // 1700 is VC11, 1800 is VC12 
 /***************************
 *   erf.cpp


### PR DESCRIPTION
This small proposed change enables using MingW to build Lepton when it is linked with LAMMPS.

A PR affecting the LAMMPS copy is already open (see below) and this PR is needed to avoid deviations from the original.  Any improvements to this PR will be applied verbatim to the copies as well.

https://github.com/lammps/lammps/pull/1992