### PR TITLE
bug fix for simulation.runForClockTime()

### DIFF
--- a/wrappers/python/simtk/openmm/app/simulation.py
+++ b/wrappers/python/simtk/openmm/app/simulation.py
@@ -197,7 +197,6 @@ class Simulation(object):
                 self.integrator.step(10) # Only take 10 steps at a time, to give Python more chances to respond to a control-c.
                 self.currentStep += 10
                 stepsToGo -= 10
-                self.currentStep += 10
                 if endTime is not None and datetime.now() >= endTime:
                     break
             else:

--- a/wrappers/python/simtk/openmm/app/simulation.py
+++ b/wrappers/python/simtk/openmm/app/simulation.py
@@ -195,13 +195,16 @@ class Simulation(object):
             stepsToGo = nextSteps
             while stepsToGo > 10:
                 self.integrator.step(10) # Only take 10 steps at a time, to give Python more chances to respond to a control-c.
+                self.currentStep += 10
                 stepsToGo -= 10
                 self.currentStep += 10
                 if endTime is not None and datetime.now() >= endTime:
-                    return
-            self.integrator.step(stepsToGo)
-            self.currentStep += stepsToGo
-            if anyReport:
+                    break
+            else:
+                self.integrator.step(stepsToGo)
+                self.currentStep += stepsToGo
+                stepsToGo = 0
+            if anyReport and stepsToGo == 0:
                 # One or more reporters are ready to generate reports.  Organize them into three
                 # groups: ones that want wrapped positions, ones that want unwrapped positions,
                 # and ones that don't care about positions.

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -153,6 +153,10 @@ class TestSimulation(unittest.TestCase):
         expectedTime = simulation.currentStep*integrator.getStepSize().value_in_unit(picoseconds)
         self.assertAlmostEqual(expectedTime, time)
 
+        # Verify the simulation.currentStep is correctly updated.
+
+        self.assertAlmostEqual(simulation.currentStep*0.001, simulation.context.getState().getTime().value_in_unit(picoseconds))
+
         # Load the checkpoint and state and make sure they are both correct.
 
         velocities = simulation.context.getState(getVelocities=True).getVelocities()


### PR DESCRIPTION
The `simulation.runForClockTime()` is not working correctly. Specifically, the `simulation.currentStep` is not updated if the time limit is reached. And also, the reporting is skipped if the time limit is reached, even if it is the step to report. Both of them cause the reporters reporting at the incorrect steps.
e.g. here is the report when I use `sim.runForClockTime(3/3600, 'rst.cpt', 'rst.xml', 1/3600)` with 0.01 ps timestep
```
#"Step"	"Time (ps)"	"Elapsed Time (s)"
1000	9.999999999999831	0.0
2000	20.000000000000327	0.2201988697052002
3000	30.00000000000189	0.44005537033081055
4000	40.00000000000061	0.6431639194488525
5000	54.89999999999765	0.961198091506958  <-- incorrect
6000	64.8999999999963	1.164311170578003
7000	74.90000000000141	1.383007526397705
8000	84.90000000000653	1.5874626636505127
9000	102.90000000001574	1.9634485244750977  <-- incorrect
10000	112.90000000002085	2.1678476333618164
11000	122.90000000002597	2.387612819671631
12000	132.9000000000241	2.59072208404541
```