### PR TITLE
Replaced alternative spelling of not-operator with '!'

### DIFF
--- a/plugins/drude/serialization/src/DrudeNoseHooverIntegratorProxy.cpp
+++ b/plugins/drude/serialization/src/DrudeNoseHooverIntegratorProxy.cpp
@@ -49,7 +49,7 @@ void DrudeNoseHooverIntegratorProxy::serialize(const void* object, Serialization
     node.setDoubleProperty("stepSize", integrator.getStepSize());
     node.setDoubleProperty("constraintTolerance", integrator.getConstraintTolerance());
     node.setDoubleProperty("maximumPairDistance", integrator.getMaximumPairDistance());
-    assert(not integrator.hasSubsystemThermostats());
+    assert(!integrator.hasSubsystemThermostats());
     node.setDoubleProperty("temperature", integrator.getTemperature());
     node.setDoubleProperty("relativeTemperature", integrator.getRelativeTemperature());
     node.setDoubleProperty("collisionFrequency", integrator.getCollisionFrequency());


### PR DESCRIPTION
This is required by msvc when standard conformance mode is not enabled (DrudeNoseHooverIntegratorProxy.cpp(53): error C2065: 'not': undeclared identifier).