### PR TITLE
Removed name of variadic argument list

### DIFF
--- a/platforms/common/src/kernels/customIntegratorPerDof.cc
+++ b/platforms/common/src/kernels/customIntegratorPerDof.cc
@@ -3,8 +3,8 @@ typedef double TempType;
 typedef double3 TempType3;
 typedef double4 TempType4;
 
-#define make_TempType3(a...) make_double3(a)
-#define make_TempType4(a...) make_double4(a)
+#define make_TempType3(...) make_double3(__VA_ARGS__)
+#define make_TempType4(...) make_double4(__VA_ARGS__)
 #define convertToTempType3(a) make_double3((a).x, (a).y, (a).z)
 #define convertToTempType4(a) make_double4((a).x, (a).y, (a).z, (a).w)
 
@@ -16,8 +16,8 @@ typedef float TempType;
 typedef float3 TempType3;
 typedef float4 TempType4;
 
-#define make_TempType3(a...) make_float3(a)
-#define make_TempType4(a...) make_float4(a)
+#define make_TempType3(...) make_float3(__VA_ARGS__)
+#define make_TempType4(...) make_float4(__VA_ARGS__)
 #define convertToTempType3(a) make_float3((a).x, (a).y, (a).z)
 #define convertToTempType4(a) make_float4((a).x, (a).y, (a).z, (a).w)
 #endif


### PR DESCRIPTION
Naming the argument list of a variadic macro is a GNU extension which is not supported by msvc. Since CUDA uses the system preprocessor this will fail to build kernels on Windows (fixes error C2010: '.': unexpected in macro parameter list).