### PR TITLE
Replace NULL with nullptr when adding kernel arguments

### DIFF
--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -6957,7 +6957,7 @@ void CommonIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context
                 if (cc.getUseMixedPrecision())
                     kernel->addArg(cc.getPosqCorrection());
                 else
-                    kernel->addArg(NULL);
+                    kernel->addArg(nullptr);
                 kernel->addArg(integration.getPosDelta());
                 kernel->addArg(cc.getVelm());
                 kernel->addArg(cc.getLongForceBuffer());
@@ -6992,7 +6992,7 @@ void CommonIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context
                 if (cc.getUseMixedPrecision())
                     kernel->addArg(cc.getPosqCorrection());
                 else
-                    kernel->addArg(NULL);
+                    kernel->addArg(nullptr);
                 kernel->addArg(integration.getPosDelta());
             }
         }
@@ -7048,7 +7048,7 @@ void CommonIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context
         if (cc.getUseMixedPrecision())
             kineticEnergyKernel->addArg(cc.getPosqCorrection());
         else
-            kineticEnergyKernel->addArg(NULL);
+            kineticEnergyKernel->addArg(nullptr);
         kineticEnergyKernel->addArg(integration.getPosDelta());
         kineticEnergyKernel->addArg(cc.getVelm());
         kineticEnergyKernel->addArg(cc.getLongForceBuffer());

--- a/platforms/common/src/IntegrationUtilities.cpp
+++ b/platforms/common/src/IntegrationUtilities.cpp
@@ -549,7 +549,7 @@ IntegrationUtilities::IntegrationUtilities(ComputeContext& context, const System
     if (context.getUseMixedPrecision())
         vsitePositionKernel->addArg(context.getPosqCorrection());
     else
-        vsitePositionKernel->addArg(NULL);
+        vsitePositionKernel->addArg(nullptr);
     vsitePositionKernel->addArg(vsite2AvgAtoms);
     vsitePositionKernel->addArg(vsite2AvgWeights);
     vsitePositionKernel->addArg(vsite3AvgAtoms);
@@ -565,7 +565,7 @@ IntegrationUtilities::IntegrationUtilities(ComputeContext& context, const System
     if (context.getUseMixedPrecision())
         vsiteForceKernel->addArg(context.getPosqCorrection());
     else
-        vsiteForceKernel->addArg(NULL);
+        vsiteForceKernel->addArg(nullptr);
     vsiteForceKernel->addArg(); // Skip argument 2: the force array hasn't been created yet.
     vsiteForceKernel->addArg(vsite2AvgAtoms);
     vsiteForceKernel->addArg(vsite2AvgWeights);

--- a/plugins/drude/platforms/common/src/CommonDrudeKernels.cpp
+++ b/plugins/drude/platforms/common/src/CommonDrudeKernels.cpp
@@ -282,7 +282,7 @@ void CommonIntegrateDrudeLangevinStepKernel::execute(ContextImpl& context, const
         if (cc.getUseMixedPrecision())
             kernel2->addArg(cc.getPosqCorrection());
         else
-            kernel2->addArg(NULL);
+            kernel2->addArg(nullptr);
         kernel2->addArg(integration.getPosDelta());
         kernel2->addArg(cc.getVelm());
         kernel2->addArg(integration.getStepSize());
@@ -290,7 +290,7 @@ void CommonIntegrateDrudeLangevinStepKernel::execute(ContextImpl& context, const
         if (cc.getUseMixedPrecision())
             hardwallKernel->addArg(cc.getPosqCorrection());
         else
-            hardwallKernel->addArg(NULL);
+            hardwallKernel->addArg(nullptr);
         hardwallKernel->addArg(cc.getVelm());
         hardwallKernel->addArg(pairParticles);
         hardwallKernel->addArg(integration.getStepSize());


### PR DESCRIPTION
This ensures that the correct argument size is used when calling clSetKernelArg.