### PR TITLE
Silence warning about casting 'int' to 'void*' on x64 for msvc

### DIFF
--- a/libraries/pthreads/include/pthread.h
+++ b/libraries/pthreads/include/pthread.h
@@ -53,6 +53,7 @@
 #include <errno.h>
 #include <sys/timeb.h>
 #include <process.h>
+#include <stdint.h>
 
 #ifndef ETIMEDOUT
 #define ETIMEDOUT	110
@@ -78,7 +79,7 @@
 
 #define PTHREAD_DEFAULT_ATTR (PTHREAD_CANCEL_ENABLE)
 
-#define PTHREAD_CANCELED ((void *) 0xDEADBEEF)
+#define PTHREAD_CANCELED ((void *)(uintptr_t) 0xDEADBEEF)
 
 #define PTHREAD_ONCE_INIT 0
 #define PTHREAD_MUTEX_INITIALIZER {(void*)-1,-1,0,0,0,0}
@@ -1090,7 +1091,7 @@ static int pthread_barrierattr_destroy(void **attr)
 
 static int pthread_barrierattr_setpshared(void **attr, int s)
 {
-	*attr = (void *) s;
+	*attr = (void *)(intptr_t) s;
 	return 0;
 }
 


### PR DESCRIPTION
Cast 'int' to an integer with the same size as a pointer before casting to a 'void*'
(fixes warning C4312: 'type cast': conversion from 'int' to 'void *' of greater size).