### PR TITLE
Updated benchmark script

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -88,12 +88,13 @@ def runOneTest(testName, options):
             dt = 0.005*unit.picoseconds
             constraints = app.AllBonds
             hydrogenMass = 4*unit.amu
+            integ = mm.LangevinIntegrator(300*unit.kelvin, friction, dt)
         else:
-            dt = 0.002*unit.picoseconds
+            dt = 0.004*unit.picoseconds
             constraints = app.HBonds
             hydrogenMass = None
+            integ = mm.LangevinMiddleIntegrator(300*unit.kelvin, friction, dt)
         system = ff.createSystem(pdb.topology, nonbondedMethod=method, nonbondedCutoff=cutoff, constraints=constraints, hydrogenMass=hydrogenMass)
-        integ = mm.LangevinIntegrator(300*unit.kelvin, friction, dt)
     print('Step Size: %g fs' % dt.value_in_unit(unit.femtoseconds))
     properties = {}
     initialSteps = 5


### PR DESCRIPTION
This updates the benchmarking script to use LangevinMiddleIntegrator and a larger time step where possible.  Here are the speeds I get for the PME benchmark with different possible combinations of settings.

LangevinIntegrator, 2 fs, HBonds constraints: 417
LangevinMiddleIntegrator, 4 fs, HBonds constraints: 740
LangevinMiddleIntegrator, 5 fs, AllBonds constraints, HMR: 568
Langevintegrator, 5 fs, AllBonds constraints, HMR: 775

The ordering is the same for most benchmarks.  Using LangevinMiddleIntegrator with the larger step size produces a big speed improvement compared to LangevinIntegrator.  But the very fastest combination is to use LangevinIntegrator with HMR and more constraints.  Since LangevinMiddleIntegrator needs to apply constraints more often, it takes a big hit from using AllBonds constraints.

Therefore if you specify `--heavy-hydrogens`, I made the script continue to use LangevinIntegrator in place of LangevinMiddleIntegrator.