### PR TITLE
Use Python 3.6 for Mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,11 +128,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew cask uninstall oclint;
       brew install fftw;
-      brew install python3;
+      brew upgrade python;
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
-      pip3 install virtualenv;
-      virtualenv -p python3 ~/venv;
-      source ~/venv/bin/activate;
       sudo pip install -U pytest --ignore-installed six;
     fi
   # The cmake version installed by apt on ARM and PPC is very old,

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,11 +128,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew cask uninstall oclint;
       brew install fftw;
-      brew install python3
+      brew install python3;
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
-      pip3 install virtualenv
-      virtualenv -p python3 ~/venv
-      source ~/venv/bin/activate
+      pip3 install virtualenv;
+      virtualenv -p python3 ~/venv;
+      source ~/venv/bin/activate;
       sudo pip install -U pytest --ignore-installed six;
     fi
   # The cmake version installed by apt on ARM and PPC is very old,

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ before_install:
       brew install fftw;
       brew upgrade python;
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
-      pip3 install virtualenv;
+      pip3 install virtualenv numpy;
       virtualenv -p python3 ~/venv;
       source ~/venv/bin/activate;
       sudo pip install -U pytest --ignore-installed six;

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,10 +130,10 @@ before_install:
       brew install fftw;
       brew upgrade python;
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
-      pip3 install virtualenv numpy;
+      pip3 install virtualenv;
       virtualenv -p python3 ~/venv;
       source ~/venv/bin/activate;
-      sudo pip install -U pytest --ignore-installed six;
+      sudo pip install -U pytest numpy --ignore-installed six;
     fi
   # The cmake version installed by apt on ARM and PPC is very old,
   # so download a newer version.

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ jobs:
     - language: objective-c
       os: osx
       osx_image: xcode9.3
-      python: "3.8"
       name: "Mac OS"
       env: OPENCL=false
            CUDA=false
@@ -129,7 +128,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew cask uninstall oclint;
       brew install fftw;
+      brew install python3
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
+      pip3 install virtualenv
+      virtualenv -p python3 ~/venv
+      source ~/venv/bin/activate
       sudo pip install -U pytest --ignore-installed six;
     fi
   # The cmake version installed by apt on ARM and PPC is very old,

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,9 @@ before_install:
       brew install fftw;
       brew upgrade python;
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
+      pip3 install virtualenv;
+      virtualenv -p python3 ~/venv;
+      source ~/venv/bin/activate;
       sudo pip install -U pytest --ignore-installed six;
     fi
   # The cmake version installed by apt on ARM and PPC is very old,

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ jobs:
     - language: objective-c
       os: osx
       osx_image: xcode9.3
+      python: "3.8"
       name: "Mac OS"
       env: OPENCL=false
            CUDA=false


### PR DESCRIPTION
The travis file didn't specify what Python to use for the Mac build, and it was defaulting to 2.7.