### PR TITLE
Add arguments needed by the new CUDA agents

### DIFF
--- a/devtools/Jenkinsfile
+++ b/devtools/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
                         docker {
                             image "swails/openmm-all:latest"
                             label "cuda && docker"
+                            args '--gpus all'
                             alwaysPull true
                         }
                     }
@@ -26,6 +27,7 @@ pipeline {
                         docker {
                             image "swails/openmm-all:latest"
                             label "cuda && docker"
+                            args '--gpus all'
                             alwaysPull true
                         }
                     }


### PR DESCRIPTION
Jenkins has more power!  Amber has graciously donated 4 more machines for me to add to the Jenkins array (2 with GTX 780s and 1 with a GTX 1660).  Builds should go a lot smoother and faster now with newer, faster machines (and 20+ more executors so no more bottlenecks).

[Here are the Ansible playbooks I used to configure the nodes](https://github.com/swails/cluster-setup/tree/master/ubuntu-nodes) and they are already connected to Jenkins and waiting for jobs.

New docker doesn't expose GPUs the same way they used to, though, so we need to add `--gpus all` to the docker arguments for the builds to keep passing on the new executors.