### PR TITLE
error in _mbondi3_radii

### DIFF
--- a/wrappers/python/simtk/openmm/app/internal/customgbforces.py
+++ b/wrappers/python/simtk/openmm/app/internal/customgbforces.py
@@ -342,12 +342,19 @@ def _mbondi3_radii(topology, all_bonds = None):
         all_bonds = _get_bonded_atom_list(topology)
     radii = _mbondi2_radii(topology, all_bonds=all_bonds)
     for i, atom in enumerate(topology.atoms()):
-        # carboxylate and HH/HE (ARG)
-        if _is_carboxylateO(atom, all_bonds):
-            radii[i] = 1.4
+        if atom.residue.name in ('GLU', 'ASP', 'GL4', 'AS4'):
+            if atom.name.startswith('OE') or atom.name.startswith('OD'):
+                radii[i] = 1.4
         elif atom.residue.name == 'ARG':
             if atom.name.startswith('HH') or atom.name.startswith('HE'):
                 radii[i] = 1.17
+        
+        # Adjust carboxylate O radii on C-Termini. Don't just do the end
+        # residue, since we can have C-termini in the middle as well
+        # (i.e., 2-chain dimers)
+        if atom.name == 'OXT':
+            radii[i] = 1.4
+            radii[i-1] = 1.4
     return radii  # Converted to nanometers above
 
 


### PR DESCRIPTION
_mbondi3_radii did not set the GLU and ASP oxygen radii

As described in this [forum post](https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=12300&p=0&start=0&view=&sid=2ca8b267a6c47694ea1822f218f80375), I made a system with tleap, that included `set default PBRadii mbondi3` in the in file.

However OpenMM complained about incorrect radii for type O2. The value in the topology file is the correct 1.4.
I have tracked the error to `_mbondi3_radii` in costomgbforces.py.  I have updated that part of the code to read like it's [parmed counterpart](https://parmed.github.io/ParmEd/html/_modules/parmed/tools/changeradii.html#mbondi3).