### PR TITLE
CCMA with a small number of constraints uses a single kernel

### DIFF
--- a/platforms/common/include/openmm/common/IntegrationUtilities.h
+++ b/platforms/common/include/openmm/common/IntegrationUtilities.h
@@ -148,6 +148,7 @@ protected:
     ComputeArray randomSeed;
     ComputeArray stepSize;
     ComputeArray ccmaAtoms;
+    ComputeArray ccmaConstraintAtoms;
     ComputeArray ccmaDistance;
     ComputeArray ccmaReducedMass;
     ComputeArray ccmaAtomConstraints;

--- a/platforms/common/include/openmm/common/IntegrationUtilities.h
+++ b/platforms/common/include/openmm/common/IntegrationUtilities.h
@@ -136,7 +136,7 @@ protected:
     ComputeKernel settlePosKernel, settleVelKernel;
     ComputeKernel shakePosKernel, shakeVelKernel;
     ComputeKernel ccmaDirectionsKernel, ccmaPosForceKernel, ccmaVelForceKernel;
-    ComputeKernel ccmaMultiplyKernel, ccmaUpdateKernel;
+    ComputeKernel ccmaMultiplyKernel, ccmaUpdateKernel, ccmaFullKernel;
     ComputeKernel vsitePositionKernel, vsiteForceKernel, vsiteSaveForcesKernel;
     ComputeKernel randomKernel, timeShiftKernel;
     ComputeArray posDelta;

--- a/platforms/common/src/IntegrationUtilities.cpp
+++ b/platforms/common/src/IntegrationUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2020 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -532,11 +532,12 @@ IntegrationUtilities::IntegrationUtilities(ComputeContext& context, const System
     settleVelKernel = program->createKernel("applySettleToVelocities");
     shakePosKernel = program->createKernel("applyShakeToPositions");
     shakeVelKernel = program->createKernel("applyShakeToVelocities");
-    ccmaDirectionsKernel = program->createKernel("computeCCMAConstraintDirections");
-    ccmaPosForceKernel = program->createKernel("computeCCMAPositionConstraintForce");
-    ccmaVelForceKernel = program->createKernel("computeCCMAVelocityConstraintForce");
-    ccmaMultiplyKernel = program->createKernel("multiplyByCCMAConstraintMatrix");
-    ccmaUpdateKernel = program->createKernel("updateCCMAAtomPositions");
+    ccmaDirectionsKernel = program->createKernel("computeCCMAConstraintDirectionsKernel");
+    ccmaPosForceKernel = program->createKernel("computeCCMAPositionConstraintForceKernel");
+    ccmaVelForceKernel = program->createKernel("computeCCMAVelocityConstraintForceKernel");
+    ccmaMultiplyKernel = program->createKernel("multiplyByCCMAConstraintMatrixKernel");
+    ccmaUpdateKernel = program->createKernel("updateCCMAAtomPositionsKernel");
+    ccmaFullKernel = program->createKernel("runCCMA");
     vsitePositionKernel = program->createKernel("computeVirtualSites");
     vsiteForceKernel = program->createKernel("distributeVirtualSiteForces");
     vsiteSaveForcesKernel = program->createKernel("saveDistributedForces");
@@ -661,6 +662,22 @@ IntegrationUtilities::IntegrationUtilities(ComputeContext& context, const System
         ccmaUpdateKernel->addArg(ccmaDelta2);
         ccmaUpdateKernel->addArg(ccmaConverged);
         ccmaUpdateKernel->addArg();
+        ccmaFullKernel->addArg();
+        ccmaFullKernel->addArg(ccmaNumAtomConstraints);
+        ccmaFullKernel->addArg(ccmaAtomConstraints);
+        ccmaFullKernel->addArg(ccmaAtoms);
+        ccmaFullKernel->addArg(ccmaDistance);
+        ccmaFullKernel->addArg(context.getPosq());
+        ccmaFullKernel->addArg(context.getVelm());
+        ccmaFullKernel->addArg(posDelta);
+        ccmaFullKernel->addArg(ccmaReducedMass);
+        ccmaFullKernel->addArg(ccmaDelta1);
+        ccmaFullKernel->addArg(ccmaDelta2);
+        ccmaFullKernel->addArg(ccmaConstraintMatrixColumn);
+        ccmaFullKernel->addArg(ccmaConstraintMatrixValue);
+        ccmaFullKernel->addArg();
+        if (context.getUseMixedPrecision())
+            ccmaFullKernel->addArg(context.getPosqCorrection());
     }
 
     // Arguments for time shift kernel will be set later.

--- a/platforms/common/src/kernels/integrationUtilities.cc
+++ b/platforms/common/src/kernels/integrationUtilities.cc
@@ -601,7 +601,7 @@ KERNEL void computeCCMAConstraintDirectionsKernel(GLOBAL const int2* RESTRICT co
  */
 DEVICE void computeCCMAPositionConstraintForce(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
         GLOBAL const mixed4* RESTRICT atomPositions, GLOBAL const mixed* RESTRICT reducedMass, GLOBAL mixed* RESTRICT delta1,
-        mixed tol, int iteration, LOCAL int* groupConverged) {
+        mixed tol, int iteration, LOCAL_ARG int* groupConverged) {
     if (LOCAL_ID == 0)
         *groupConverged = 1;
     SYNC_THREADS;
@@ -652,7 +652,7 @@ KERNEL void computeCCMAPositionConstraintForceKernel(GLOBAL const int2* RESTRICT
  */
 DEVICE void computeCCMAVelocityConstraintForce(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
         GLOBAL const mixed4* RESTRICT atomPositions, GLOBAL const mixed* RESTRICT reducedMass, GLOBAL mixed* RESTRICT delta1,
-        mixed tol, int iteration, LOCAL int* groupConverged) {
+        mixed tol, int iteration, LOCAL_ARG int* groupConverged) {
     if (LOCAL_ID == 0)
         *groupConverged = 1;
     SYNC_THREADS;
@@ -761,7 +761,7 @@ KERNEL void updateCCMAAtomPositionsKernel(GLOBAL const int* RESTRICT numAtomCons
  * That makes it faster for small numbers of constraints, but slower for large numbers.
  */
 KERNEL void runCCMA(int constrainVelocities, GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
-        GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL mixed4* RESTRICT constraintDistance, GLOBAL const mixed4* RESTRICT atomPositions,
+        GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL mixed4* RESTRICT constraintDistance, GLOBAL const real4* RESTRICT atomPositions,
         GLOBAL mixed4* RESTRICT velm, GLOBAL mixed4* RESTRICT posDelta, GLOBAL const mixed* RESTRICT reducedMass,
         GLOBAL mixed* RESTRICT delta1, GLOBAL mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
         GLOBAL const mixed* RESTRICT constraintMatrixValue, mixed tol

--- a/platforms/common/src/kernels/integrationUtilities.cc
+++ b/platforms/common/src/kernels/integrationUtilities.cc
@@ -556,8 +556,8 @@ KERNEL void applySettleToVelocities(int numClusters, mixed tol, GLOBAL const rea
 /**
  * Compute the direction each CCMA constraint is pointing in.  This is called once at the beginning of constraint evaluation.
  */
-KERNEL void computeCCMAConstraintDirections(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL mixed4* RESTRICT constraintDistance,
-        GLOBAL const real4* RESTRICT atomPositions, GLOBAL int* RESTRICT converged
+DEVICE void computeCCMAConstraintDirections(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL mixed4* RESTRICT constraintDistance,
+        GLOBAL const real4* RESTRICT atomPositions
 #ifdef USE_MIXED_PRECISION
         , GLOBAL const real4* RESTRICT posqCorrection
 #endif
@@ -577,6 +577,19 @@ KERNEL void computeCCMAConstraintDirections(GLOBAL const int2* RESTRICT constrai
         dir.z = oldPos1.z-oldPos2.z;
         constraintDistance[index] = dir;
     }
+}
+
+KERNEL void computeCCMAConstraintDirectionsKernel(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL mixed4* RESTRICT constraintDistance,
+        GLOBAL const real4* RESTRICT atomPositions, GLOBAL int* RESTRICT converged
+#ifdef USE_MIXED_PRECISION
+        , GLOBAL const real4* RESTRICT posqCorrection
+#endif
+        ) {
+#ifdef USE_MIXED_PRECISION
+    computeCCMAConstraintDirections(constraintAtoms, constraintDistance, atomPositions, posqCorrection);
+#else
+    computeCCMAConstraintDirections(constraintAtoms, constraintDistance, atomPositions);
+#endif
     if (GLOBAL_ID == 0) {
         converged[0] = 1;
         converged[1] = 0;
@@ -586,19 +599,11 @@ KERNEL void computeCCMAConstraintDirections(GLOBAL const int2* RESTRICT constrai
 /**
  * Compute the force applied by each CCMA position constraint.
  */
-KERNEL void computeCCMAPositionConstraintForce(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
+DEVICE void computeCCMAPositionConstraintForce(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
         GLOBAL const mixed4* RESTRICT atomPositions, GLOBAL const mixed* RESTRICT reducedMass, GLOBAL mixed* RESTRICT delta1,
-        GLOBAL int* RESTRICT converged, GLOBAL int* RESTRICT hostConvergedFlag, mixed tol, int iteration) {
-    LOCAL int groupConverged;
-    if (converged[1-iteration%2]) {
-        if (GLOBAL_ID == 0) {
-            converged[iteration%2] = 1;
-            hostConvergedFlag[0] = 1;
-        }
-        return; // The constraint iteration has already converged.
-    }
+        mixed tol, int iteration, LOCAL int* groupConverged) {
     if (LOCAL_ID == 0)
-        groupConverged = 1;
+        *groupConverged = 1;
     SYNC_THREADS;
     mixed lowerTol = 1-2*tol+tol*tol;
     mixed upperTol = 1+2*tol+tol*tol;
@@ -620,8 +625,23 @@ KERNEL void computeCCMAPositionConstraintForce(GLOBAL const int2* RESTRICT const
         delta1[index] = (rrpr > d_ij2*1e-6f ? reducedMass[index]*diff/rrpr : 0.0f);
         threadConverged &= (rp2 > lowerTol*dist2 && rp2 < upperTol*dist2);
     }
-    if (groupConverged && !threadConverged)
-        groupConverged = 0;
+    if (*groupConverged && !threadConverged)
+        *groupConverged = 0;
+}
+
+KERNEL void computeCCMAPositionConstraintForceKernel(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
+        GLOBAL const mixed4* RESTRICT atomPositions, GLOBAL const mixed* RESTRICT reducedMass, GLOBAL mixed* RESTRICT delta1,
+        GLOBAL int* RESTRICT converged, GLOBAL int* RESTRICT hostConvergedFlag, mixed tol, int iteration) {
+    LOCAL int groupConverged;
+    if (converged[1-iteration%2]) {
+        if (GLOBAL_ID == 0) {
+            converged[iteration%2] = 1;
+            hostConvergedFlag[0] = 1;
+        }
+        return; // The constraint iteration has already converged.
+    }
+    computeCCMAPositionConstraintForce(constraintAtoms, constraintDistance, atomPositions, reducedMass,
+            delta1, tol, iteration, &groupConverged);
     SYNC_THREADS;
     if (LOCAL_ID == 0 && !groupConverged)
         converged[iteration%2] = 0;
@@ -630,7 +650,29 @@ KERNEL void computeCCMAPositionConstraintForce(GLOBAL const int2* RESTRICT const
 /**
  * Compute the force applied by each CCMA velocity constraint.
  */
-KERNEL void computeCCMAVelocityConstraintForce(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
+DEVICE void computeCCMAVelocityConstraintForce(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
+        GLOBAL const mixed4* RESTRICT atomPositions, GLOBAL const mixed* RESTRICT reducedMass, GLOBAL mixed* RESTRICT delta1,
+        mixed tol, int iteration, LOCAL int* groupConverged) {
+    if (LOCAL_ID == 0)
+        *groupConverged = 1;
+    SYNC_THREADS;
+    bool threadConverged = true;
+    for (int index = GLOBAL_ID; index < NUM_CCMA_CONSTRAINTS; index += GLOBAL_SIZE) {
+        // Compute the force due to this constraint.
+
+        int2 atoms = constraintAtoms[index];
+        mixed4 dir = constraintDistance[index];
+        mixed4 rp_ij = atomPositions[atoms.x]-atomPositions[atoms.y];
+        mixed rrpr = rp_ij.x*dir.x + rp_ij.y*dir.y + rp_ij.z*dir.z;
+        mixed d_ij2 = dir.x*dir.x + dir.y*dir.y + dir.z*dir.z;
+        delta1[index] = -2*reducedMass[index]*rrpr/d_ij2;
+        threadConverged &= (fabs(delta1[index]) <= tol);
+    }
+    if (*groupConverged && !threadConverged)
+        *groupConverged = 0;
+}
+
+KERNEL void computeCCMAVelocityConstraintForceKernel(GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance,
         GLOBAL const mixed4* RESTRICT atomPositions, GLOBAL const mixed* RESTRICT reducedMass, GLOBAL mixed* RESTRICT delta1,
         GLOBAL int* RESTRICT converged, GLOBAL int* RESTRICT hostConvergedFlag, mixed tol, int iteration) {
     LOCAL int groupConverged;
@@ -641,36 +683,17 @@ KERNEL void computeCCMAVelocityConstraintForce(GLOBAL const int2* RESTRICT const
         }
         return; // The constraint iteration has already converged.
     }
-    if (LOCAL_ID == 0)
-        groupConverged = 1;
-    SYNC_THREADS;
-    for (int index = GLOBAL_ID; index < NUM_CCMA_CONSTRAINTS; index += GLOBAL_SIZE) {
-        // Compute the force due to this constraint.
-
-        int2 atoms = constraintAtoms[index];
-        mixed4 dir = constraintDistance[index];
-        mixed4 rp_ij = atomPositions[atoms.x]-atomPositions[atoms.y];
-        mixed rrpr = rp_ij.x*dir.x + rp_ij.y*dir.y + rp_ij.z*dir.z;
-        mixed d_ij2 = dir.x*dir.x + dir.y*dir.y + dir.z*dir.z;
-        delta1[index] = -2*reducedMass[index]*rrpr/d_ij2;
-
-        // See whether it has converged.
-
-        if (groupConverged && fabs(delta1[index]) > tol) {
-            groupConverged = 0;
-            converged[iteration%2] = 0;
-        }
-    }
+    computeCCMAVelocityConstraintForce(constraintAtoms, constraintDistance, atomPositions, reducedMass,
+            delta1, tol, iteration, &groupConverged);
+    if (LOCAL_ID == 0 && !groupConverged)
+        converged[iteration%2] = 0;
 }
 
 /**
  * Multiply the vector of CCMA constraint forces by the constraint matrix.
  */
-KERNEL void multiplyByCCMAConstraintMatrix(GLOBAL const mixed* RESTRICT delta1, GLOBAL mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
-        GLOBAL const mixed* RESTRICT constraintMatrixValue, GLOBAL const int* RESTRICT converged, int iteration) {
-    if (converged[iteration%2])
-        return; // The constraint iteration has already converged.
-
+DEVICE void multiplyByCCMAConstraintMatrix(GLOBAL const mixed* RESTRICT delta1, GLOBAL mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
+        GLOBAL const mixed* RESTRICT constraintMatrixValue, int iteration) {
     // Multiply by the inverse constraint matrix.
 
     for (int index = GLOBAL_ID; index < NUM_CCMA_CONSTRAINTS; index += GLOBAL_SIZE) {
@@ -686,16 +709,19 @@ KERNEL void multiplyByCCMAConstraintMatrix(GLOBAL const mixed* RESTRICT delta1, 
     }
 }
 
+KERNEL void multiplyByCCMAConstraintMatrixKernel(GLOBAL const mixed* RESTRICT delta1, GLOBAL mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
+        GLOBAL const mixed* RESTRICT constraintMatrixValue, GLOBAL const int* RESTRICT converged, int iteration) {
+    if (converged[iteration%2])
+        return; // The constraint iteration has already converged.
+    multiplyByCCMAConstraintMatrix(delta1, delta2, constraintMatrixColumn, constraintMatrixValue, iteration);
+}
+
 /**
  * Update the atom positions based on CCMA constraint forces.
  */
-KERNEL void updateCCMAAtomPositions(GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
+DEVICE void updateCCMAAtomPositions(GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
         GLOBAL const mixed4* RESTRICT constraintDistance, GLOBAL mixed4* RESTRICT atomPositions, GLOBAL const mixed4* RESTRICT velm,
-        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, GLOBAL int* RESTRICT converged, int iteration) {
-    if (GROUP_ID == 0 && LOCAL_ID == 0)
-        converged[1-iteration%2] = 1;
-    if (converged[iteration%2])
-        return; // The constraint iteration has already converged.
+        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, int iteration) {
     mixed damping = (iteration < 2 ? 0.5f : 1.0f);
     for (int index = GLOBAL_ID; index < NUM_ATOMS; index += GLOBAL_SIZE) {
         // Compute the new position of this atom.
@@ -715,6 +741,60 @@ KERNEL void updateCCMAAtomPositions(GLOBAL const int* RESTRICT numAtomConstraint
             atomPos.z += constraintForce*dir.z;
         }
         atomPositions[index] = atomPos;
+    }
+}
+
+KERNEL void updateCCMAAtomPositionsKernel(GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
+        GLOBAL const mixed4* RESTRICT constraintDistance, GLOBAL mixed4* RESTRICT atomPositions, GLOBAL const mixed4* RESTRICT velm,
+        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, GLOBAL int* RESTRICT converged, int iteration) {
+    if (GROUP_ID == 0 && LOCAL_ID == 0)
+        converged[1-iteration%2] = 1;
+    if (converged[iteration%2])
+        return; // The constraint iteration has already converged.
+    updateCCMAAtomPositions(numAtomConstraints, atomConstraints, constraintDistance, atomPositions, velm,
+            delta1, delta2, iteration);
+}
+
+/**
+ * Run the entire CCMA iteration within a single kernel.  This has far less overhead than
+ * using multiple kernels, but requires the calculation to use only a single workgroup.
+ * That makes it faster for small numbers of constraints, but slower for large numbers.
+ */
+KERNEL void runCCMA(int constrainVelocities, GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
+        GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance, GLOBAL mixed4* RESTRICT atomPositions,
+        GLOBAL const mixed4* RESTRICT velm, GLOBAL mixed4* RESTRICT posDelta, GLOBAL const mixed* RESTRICT reducedMass,
+        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
+        GLOBAL const mixed* RESTRICT constraintMatrixValue, mixed tol
+#ifdef USE_MIXED_PRECISION
+        , GLOBAL const real4* RESTRICT posqCorrection
+#endif
+        ) {
+    LOCAL int groupConverged;
+#ifdef USE_MIXED_PRECISION
+    computeCCMAConstraintDirections(constraintAtoms, constraintDistance, atomPositions, posqCorrection);
+#else
+    computeCCMAConstraintDirections(constraintAtoms, constraintDistance, atomPositions);
+#endif
+    for (int iteration = 0; iteration < 150; iteration++) {
+        SYNC_THREADS
+        if (constrainVelocities)
+            computeCCMAVelocityConstraintForce(constraintAtoms, constraintDistance, velm, reducedMass,
+                    delta1, tol, iteration, &groupConverged);
+        else
+            computeCCMAPositionConstraintForce(constraintAtoms, constraintDistance, posDelta, reducedMass,
+                    delta1, tol, iteration, &groupConverged);
+        SYNC_THREADS
+        multiplyByCCMAConstraintMatrix(delta1, delta2, constraintMatrixColumn, constraintMatrixValue, iteration);
+        SYNC_THREADS
+        if (constrainVelocities)
+            updateCCMAAtomPositions(numAtomConstraints, atomConstraints, constraintDistance, velm, velm,
+                    delta1, delta2, iteration);
+        else
+            updateCCMAAtomPositions(numAtomConstraints, atomConstraints, constraintDistance, posDelta, velm,
+                    delta1, delta2, iteration);
+        SYNC_THREADS
+        if (groupConverged)
+            return;
     }
 }
 

--- a/platforms/common/src/kernels/integrationUtilities.cc
+++ b/platforms/common/src/kernels/integrationUtilities.cc
@@ -761,9 +761,9 @@ KERNEL void updateCCMAAtomPositionsKernel(GLOBAL const int* RESTRICT numAtomCons
  * That makes it faster for small numbers of constraints, but slower for large numbers.
  */
 KERNEL void runCCMA(int constrainVelocities, GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
-        GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL const mixed4* RESTRICT constraintDistance, GLOBAL mixed4* RESTRICT atomPositions,
-        GLOBAL const mixed4* RESTRICT velm, GLOBAL mixed4* RESTRICT posDelta, GLOBAL const mixed* RESTRICT reducedMass,
-        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
+        GLOBAL const int2* RESTRICT constraintAtoms, GLOBAL mixed4* RESTRICT constraintDistance, GLOBAL const mixed4* RESTRICT atomPositions,
+        GLOBAL mixed4* RESTRICT velm, GLOBAL mixed4* RESTRICT posDelta, GLOBAL const mixed* RESTRICT reducedMass,
+        GLOBAL mixed* RESTRICT delta1, GLOBAL mixed* RESTRICT delta2, GLOBAL const int* RESTRICT constraintMatrixColumn,
         GLOBAL const mixed* RESTRICT constraintMatrixValue, mixed tol
 #ifdef USE_MIXED_PRECISION
         , GLOBAL const real4* RESTRICT posqCorrection

--- a/platforms/cuda/src/CudaIntegrationUtilities.cpp
+++ b/platforms/cuda/src/CudaIntegrationUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2020 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -92,28 +92,39 @@ void CudaIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, do
         shakeKernel->execute(shakeAtoms.getSize());
     }
     if (ccmaAtoms.isInitialized()) {
-        ccmaForceKernel->setArg(6, ccmaConvergedDeviceMemory);
-        if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
-            ccmaForceKernel->setArg(7, tol);
-        else
-            ccmaForceKernel->setArg(7, (float) tol);
-        ccmaDirectionsKernel->execute(ccmaAtoms.getSize());
-        const int checkInterval = 4;
-        ccmaConvergedMemory[0] = 0;
-        ccmaUpdateKernel->setArg(3, constrainVelocities ? context.getVelm() : posDelta);
-        for (int i = 0; i < 150; i++) {
-            ccmaForceKernel->setArg(8, i);
-            ccmaForceKernel->execute(ccmaAtoms.getSize());
-            if ((i+1)%checkInterval == 0)
-                CHECK_RESULT2(cuEventRecord(ccmaEvent, 0), "Error recording event for CCMA");
-            ccmaMultiplyKernel->setArg(5, i);
-            ccmaMultiplyKernel->execute(ccmaAtoms.getSize());
-            ccmaUpdateKernel->setArg(8, i);
-            ccmaUpdateKernel->execute(context.getNumAtoms());
-            if ((i+1)%checkInterval == 0) {
-                CHECK_RESULT2(cuEventSynchronize(ccmaEvent), "Error synchronizing on event for CCMA");
-                if (ccmaConvergedMemory[0])
-                    break;
+        if (ccmaAtoms.getSize() <= 1024) {
+            // Use the version of CCMA that runs in a single kernel with one workgroup.
+            ccmaFullKernel->setArg(0, (int) constrainVelocities);
+            if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
+                ccmaFullKernel->setArg(13, tol);
+            else
+                ccmaFullKernel->setArg(13, (float) tol);
+            ccmaFullKernel->execute(128, 128);
+        }
+        else {
+            ccmaForceKernel->setArg(6, ccmaConvergedDeviceMemory);
+            if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
+                ccmaForceKernel->setArg(7, tol);
+            else
+                ccmaForceKernel->setArg(7, (float) tol);
+            ccmaDirectionsKernel->execute(ccmaAtoms.getSize());
+            const int checkInterval = 4;
+            ccmaConvergedMemory[0] = 0;
+            ccmaUpdateKernel->setArg(3, constrainVelocities ? context.getVelm() : posDelta);
+            for (int i = 0; i < 150; i++) {
+                ccmaForceKernel->setArg(8, i);
+                ccmaForceKernel->execute(ccmaAtoms.getSize());
+                if ((i+1)%checkInterval == 0)
+                    CHECK_RESULT2(cuEventRecord(ccmaEvent, 0), "Error recording event for CCMA");
+                ccmaMultiplyKernel->setArg(5, i);
+                ccmaMultiplyKernel->execute(ccmaAtoms.getSize());
+                ccmaUpdateKernel->setArg(8, i);
+                ccmaUpdateKernel->execute(context.getNumAtoms());
+                if ((i+1)%checkInterval == 0) {
+                    CHECK_RESULT2(cuEventSynchronize(ccmaEvent), "Error synchronizing on event for CCMA");
+                    if (ccmaConvergedMemory[0])
+                        break;
+                }
             }
         }
     }

--- a/platforms/cuda/src/CudaIntegrationUtilities.cpp
+++ b/platforms/cuda/src/CudaIntegrationUtilities.cpp
@@ -91,14 +91,14 @@ void CudaIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, do
             shakeKernel->setArg(1, (float) tol);
         shakeKernel->execute(shakeAtoms.getSize());
     }
-    if (ccmaAtoms.isInitialized()) {
-        if (ccmaAtoms.getSize() <= 1024) {
+    if (ccmaConstraintAtoms.isInitialized()) {
+        if (ccmaConstraintAtoms.getSize() <= 1024) {
             // Use the version of CCMA that runs in a single kernel with one workgroup.
             ccmaFullKernel->setArg(0, (int) constrainVelocities);
             if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
-                ccmaFullKernel->setArg(13, tol);
+                ccmaFullKernel->setArg(14, tol);
             else
-                ccmaFullKernel->setArg(13, (float) tol);
+                ccmaFullKernel->setArg(14, (float) tol);
             ccmaFullKernel->execute(128, 128);
         }
         else {
@@ -107,18 +107,18 @@ void CudaIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, do
                 ccmaForceKernel->setArg(7, tol);
             else
                 ccmaForceKernel->setArg(7, (float) tol);
-            ccmaDirectionsKernel->execute(ccmaAtoms.getSize());
+            ccmaDirectionsKernel->execute(ccmaConstraintAtoms.getSize());
             const int checkInterval = 4;
             ccmaConvergedMemory[0] = 0;
-            ccmaUpdateKernel->setArg(3, constrainVelocities ? context.getVelm() : posDelta);
+            ccmaUpdateKernel->setArg(4, constrainVelocities ? context.getVelm() : posDelta);
             for (int i = 0; i < 150; i++) {
                 ccmaForceKernel->setArg(8, i);
-                ccmaForceKernel->execute(ccmaAtoms.getSize());
+                ccmaForceKernel->execute(ccmaConstraintAtoms.getSize());
                 if ((i+1)%checkInterval == 0)
                     CHECK_RESULT2(cuEventRecord(ccmaEvent, 0), "Error recording event for CCMA");
                 ccmaMultiplyKernel->setArg(5, i);
-                ccmaMultiplyKernel->execute(ccmaAtoms.getSize());
-                ccmaUpdateKernel->setArg(8, i);
+                ccmaMultiplyKernel->execute(ccmaConstraintAtoms.getSize());
+                ccmaUpdateKernel->setArg(9, i);
                 ccmaUpdateKernel->execute(context.getNumAtoms());
                 if ((i+1)%checkInterval == 0) {
                     CHECK_RESULT2(cuEventSynchronize(ccmaEvent), "Error synchronizing on event for CCMA");

--- a/platforms/opencl/src/OpenCLIntegrationUtilities.cpp
+++ b/platforms/opencl/src/OpenCLIntegrationUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2020 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -77,43 +77,55 @@ void OpenCLIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, 
         shakeKernel->execute(shakeAtoms.getSize());
     }
     if (ccmaAtoms.isInitialized()) {
-        ccmaForceKernel->setArg(6, ccmaConvergedHostBuffer);
-        if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
-            ccmaForceKernel->setArg(7, tol);
-        else
-            ccmaForceKernel->setArg(7, (float) tol);
-        ccmaDirectionsKernel->execute(ccmaAtoms.getSize());
-        const int checkInterval = 4;
-        OpenCLContext& cl = dynamic_cast<OpenCLContext&>(context);
-        cl::CommandQueue queue = cl.getQueue();
-        int* converged = (int*) context.getPinnedBuffer();
-        int* ccmaConvergedHostMemory = (int*) queue.enqueueMapBuffer(ccmaConvergedHostBuffer.getDeviceBuffer(), CL_TRUE, CL_MAP_WRITE, 0, sizeof(cl_int));
-        ccmaConvergedHostMemory[0] = 0;
-        queue.enqueueUnmapMemObject(ccmaConvergedHostBuffer.getDeviceBuffer(), ccmaConvergedHostMemory);
-        ccmaUpdateKernel->setArg(3, constrainVelocities ? context.getVelm() : posDelta);
-        for (int i = 0; i < 150; i++) {
-            ccmaForceKernel->setArg(8, i);
-            ccmaForceKernel->execute(ccmaAtoms.getSize());
-            cl::Event event;
-            if ((i+1)%checkInterval == 0 && !ccmaUseDirectBuffer)
-                queue.enqueueReadBuffer(cl.unwrap(ccmaConverged).getDeviceBuffer(), CL_FALSE, 0, 2*sizeof(int), converged, NULL, &event);
-            ccmaMultiplyKernel->setArg(5, i);
-            ccmaMultiplyKernel->execute(ccmaAtoms.getSize());
-            ccmaUpdateKernel->setArg(8, i);
-            ccmaUpdateKernel->execute(context.getNumAtoms());
-            if ((i+1)%checkInterval == 0) {
-                if (ccmaUseDirectBuffer) {
-                    ccmaConvergedHostMemory = (int*) queue.enqueueMapBuffer(ccmaConvergedHostBuffer.getDeviceBuffer(), CL_FALSE, CL_MAP_READ, 0, sizeof(cl_int), NULL, &event);
-                    queue.flush();
-                    while (event.getInfo<CL_EVENT_COMMAND_EXECUTION_STATUS>() != CL_COMPLETE)
-                        ;
-                    converged[i%2] = ccmaConvergedHostMemory[0];
-                    queue.enqueueUnmapMemObject(ccmaConvergedHostBuffer.getDeviceBuffer(), ccmaConvergedHostMemory);
+        if (ccmaAtoms.getSize() <= 1024) {
+            // Use the version of CCMA that runs in a single kernel with one workgroup.
+            ccmaFullKernel->setArg(0, (int) constrainVelocities);
+            if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
+                ccmaFullKernel->setArg(13, tol);
+            else
+                ccmaFullKernel->setArg(13, (float) tol);
+            ccmaFullKernel->execute(128, 128);
+        }
+        else {
+            // Use the version of CCMA that uses multiple kernels.
+            ccmaForceKernel->setArg(6, ccmaConvergedHostBuffer);
+            if (context.getUseDoublePrecision() || context.getUseMixedPrecision())
+                ccmaForceKernel->setArg(7, tol);
+            else
+                ccmaForceKernel->setArg(7, (float) tol);
+            ccmaDirectionsKernel->execute(ccmaAtoms.getSize());
+            const int checkInterval = 4;
+            OpenCLContext& cl = dynamic_cast<OpenCLContext&>(context);
+            cl::CommandQueue queue = cl.getQueue();
+            int* converged = (int*) context.getPinnedBuffer();
+            int* ccmaConvergedHostMemory = (int*) queue.enqueueMapBuffer(ccmaConvergedHostBuffer.getDeviceBuffer(), CL_TRUE, CL_MAP_WRITE, 0, sizeof(cl_int));
+            ccmaConvergedHostMemory[0] = 0;
+            queue.enqueueUnmapMemObject(ccmaConvergedHostBuffer.getDeviceBuffer(), ccmaConvergedHostMemory);
+            ccmaUpdateKernel->setArg(3, constrainVelocities ? context.getVelm() : posDelta);
+            for (int i = 0; i < 150; i++) {
+                ccmaForceKernel->setArg(8, i);
+                ccmaForceKernel->execute(ccmaAtoms.getSize());
+                cl::Event event;
+                if ((i+1)%checkInterval == 0 && !ccmaUseDirectBuffer)
+                    queue.enqueueReadBuffer(cl.unwrap(ccmaConverged).getDeviceBuffer(), CL_FALSE, 0, 2*sizeof(int), converged, NULL, &event);
+                ccmaMultiplyKernel->setArg(5, i);
+                ccmaMultiplyKernel->execute(ccmaAtoms.getSize());
+                ccmaUpdateKernel->setArg(8, i);
+                ccmaUpdateKernel->execute(context.getNumAtoms());
+                if ((i+1)%checkInterval == 0) {
+                    if (ccmaUseDirectBuffer) {
+                        ccmaConvergedHostMemory = (int*) queue.enqueueMapBuffer(ccmaConvergedHostBuffer.getDeviceBuffer(), CL_FALSE, CL_MAP_READ, 0, sizeof(cl_int), NULL, &event);
+                        queue.flush();
+                        while (event.getInfo<CL_EVENT_COMMAND_EXECUTION_STATUS>() != CL_COMPLETE)
+                            ;
+                        converged[i%2] = ccmaConvergedHostMemory[0];
+                        queue.enqueueUnmapMemObject(ccmaConvergedHostBuffer.getDeviceBuffer(), ccmaConvergedHostMemory);
+                    }
+                    else
+                        event.wait();
+                    if (converged[i%2])
+                        break;
                 }
-                else
-                    event.wait();
-                if (converged[i%2])
-                    break;
             }
         }
     }


### PR DESCRIPTION
Fixes #2814.  For systems with up to 1024 CCMA constraints, it runs that whole algorithm in a single kernel.  This involves much less overhead than the standard implementation, but also requires it to be run in a single thread block.

I haven't tested this with CUDA yet.  The cutoff of 1024 is roughly where the performance crossover happens on my laptop's GPUs, but higher end GPUs might have different performance.  This will need a lot of testing.