### PR TITLE
Improved documentation for LangevinMiddleIntegrator

### DIFF
--- a/openmmapi/include/openmm/LangevinMiddleIntegrator.h
+++ b/openmmapi/include/openmm/LangevinMiddleIntegrator.h
@@ -40,7 +40,7 @@ namespace OpenMM {
 
 /**
  * This is an Integrator which simulates a System using Langevin dynamics, with
- * the LFMiddle discretization (J. Phys. Chem. A 2019, 123, 28, 6056–6079).
+ * the LFMiddle discretization (J. Phys. Chem. A 2019, 123, 28, 6056-6079).
  * This method tend to produce more accurate configurational sampling than other
  * discretizations, such as the one used in LangevinIntegrator.
  * 

--- a/openmmapi/include/openmm/LangevinMiddleIntegrator.h
+++ b/openmmapi/include/openmm/LangevinMiddleIntegrator.h
@@ -40,9 +40,15 @@ namespace OpenMM {
 
 /**
  * This is an Integrator which simulates a System using Langevin dynamics, with
- * the LFMiddle discretization (http://dx.doi.org/10.1021/acs.jpca.9b02771).
+ * the LFMiddle discretization (J. Phys. Chem. A 2019, 123, 28, 6056–6079).
  * This method tend to produce more accurate configurational sampling than other
  * discretizations, such as the one used in LangevinIntegrator.
+ * 
+ * The algorithm is closely related to the BAOAB discretization
+ * (Proc. R. Soc. A. 472: 20160138).  Both methods produce identical trajectories,
+ * but LFMiddle returns half step (leapfrog) velocities, while BAOAB returns
+ * on-step velocities.  The former provide a much more accurate sampling of the
+ * thermal ensemble. 
  */
 
 class OPENMM_EXPORT LangevinMiddleIntegrator : public Integrator {


### PR DESCRIPTION
Fixes #2832.

I gave up on including a URL and just used conventional citations.  The comments first get processed by Doxygen, then by a Python script, and finally by Sphinx.  Trying to figure out how to get a URL safely through that whole process was more trouble than it was worth.