### PR TITLE
Lepton: Add three functions that can be used as activation functions in neural network.

### DIFF
--- a/libraries/lepton/include/lepton/Operation.h
+++ b/libraries/lepton/include/lepton/Operation.h
@@ -64,7 +64,7 @@ public:
      */
     enum Id {CONSTANT, VARIABLE, CUSTOM, ADD, SUBTRACT, MULTIPLY, DIVIDE, POWER, NEGATE, SQRT, EXP, LOG,
              SIN, COS, SEC, CSC, TAN, COT, ASIN, ACOS, ATAN, ATAN2, SINH, COSH, TANH, ERF, ERFC, STEP, DELTA, SQUARE, CUBE, RECIPROCAL,
-             ADD_CONSTANT, MULTIPLY_CONSTANT, POWER_CONSTANT, MIN, MAX, ABS, FLOOR, CEIL, SELECT};
+             ADD_CONSTANT, MULTIPLY_CONSTANT, POWER_CONSTANT, MIN, MAX, ABS, FLOOR, CEIL, SELECT, SELECT2, ELU, RELU};
     /**
      * Get the name of this Operation.
      */
@@ -157,6 +157,9 @@ public:
     class Floor;
     class Ceil;
     class Select;
+    class Select2;
+    class Elu;
+    class Relu;
 };
 
 class LEPTON_EXPORT Operation::Constant : public Operation {
@@ -1184,6 +1187,83 @@ public:
     }
     double evaluate(double* args, const std::map<std::string, double>& variables) const {
         return (args[0] != 0.0 ? args[1] : args[2]);
+    }
+    ExpressionTreeNode differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const;
+};
+
+class LEPTON_EXPORT Operation::Select2 : public Operation {
+public:
+    Select2() {
+    }
+    std::string getName() const {
+        return "select2";
+    }
+    Id getId() const {
+        return SELECT;
+    }
+    int getNumArguments() const {
+        return 3;
+    }
+    Operation* clone() const {
+        return new Select2();
+    }
+    double evaluate(double* args, const std::map<std::string, double>& variables) const {
+        return (args[0] > 0.0 ? args[1] : args[2]);
+    }
+    ExpressionTreeNode differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const;
+};
+
+class LEPTON_EXPORT Operation::Elu : public Operation {
+public:
+    Elu() {
+    }
+    std::string getName() const {
+        return "elu";
+    }
+    Id getId() const {
+        return ELU;
+    }
+    int getNumArguments() const {
+        return 2;
+    }
+    Operation* clone() const {
+        return new Elu();
+    }
+    double evaluate(double* args, const std::map<std::string, double>& variables) const {
+        const double x = args[0];
+        const double alpha = args[1];
+        if (x > 0.0) {
+            return x;
+        } else {
+            return alpha * (std::exp(x) - 1);
+        }
+    }
+    ExpressionTreeNode differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const;
+};
+
+class LEPTON_EXPORT Operation::Relu : public Operation {
+public:
+    Relu() {
+    }
+    std::string getName() const {
+        return "Relu";
+    }
+    Id getId() const {
+        return RELU;
+    }
+    int getNumArguments() const {
+        return 1;
+    }
+    Operation* clone() const {
+        return new Relu();
+    }
+    double evaluate(double* args, const std::map<std::string, double>& variables) const {
+        const double x = args[0];
+        if (x > 0.0) {
+            return x;
+        } else {
+            return 0;
+        }
     }
     ExpressionTreeNode differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const;
 };

--- a/libraries/lepton/src/Operation.cpp
+++ b/libraries/lepton/src/Operation.cpp
@@ -343,3 +343,40 @@ ExpressionTreeNode Operation::Select::differentiate(const std::vector<Expression
     derivChildren.push_back(childDerivs[2]);
     return ExpressionTreeNode(new Operation::Select(), derivChildren);
 }
+
+ExpressionTreeNode Operation::Select2::differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const {
+    vector<ExpressionTreeNode> derivChildren;
+    derivChildren.push_back(children[0]);
+    derivChildren.push_back(childDerivs[1]);
+    derivChildren.push_back(childDerivs[2]);
+    return ExpressionTreeNode(new Operation::Select2(), derivChildren);
+}
+
+ExpressionTreeNode Operation::Elu::differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const {
+    vector<ExpressionTreeNode> derivChildren;
+    derivChildren.reserve(3);
+    derivChildren.push_back(children[0]);
+    derivChildren.push_back(ExpressionTreeNode(new Operation::Add(), childDerivs[0],
+                                               ExpressionTreeNode(new Operation::MultiplyConstant(0.0), childDerivs[1])));
+    derivChildren.push_back(ExpressionTreeNode(new Operation::Add(),
+                                               ExpressionTreeNode(new Operation::Multiply,
+                                                                  ExpressionTreeNode(new Operation::Multiply,
+                                                                                     children[1],
+                                                                                     ExpressionTreeNode(new Operation::Exp,
+                                                                                                        children[0])),
+                                                                  childDerivs[0]),
+                                               ExpressionTreeNode(new Operation::Multiply,
+                                                                  ExpressionTreeNode(new Operation::AddConstant(-1.0),
+                                                                                     ExpressionTreeNode(new Operation::Exp,
+                                                                                                        children[0])),
+                                                                  childDerivs[1])));
+    return ExpressionTreeNode(new Operation::Select2(), derivChildren);
+}
+
+ExpressionTreeNode Operation::Relu::differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const {
+    vector<ExpressionTreeNode> derivChildren;
+    derivChildren.push_back(children[0]);
+    derivChildren.push_back(childDerivs[0]);
+    derivChildren.push_back(ExpressionTreeNode(new Operation::Constant(0.0)));
+    return ExpressionTreeNode(new Operation::Select2(), derivChildren);
+}

--- a/libraries/lepton/src/Parser.cpp
+++ b/libraries/lepton/src/Parser.cpp
@@ -330,6 +330,9 @@ Operation* Parser::getFunctionOperation(const std::string& name, const map<strin
         opMap["floor"] = Operation::FLOOR;
         opMap["ceil"] = Operation::CEIL;
         opMap["select"] = Operation::SELECT;
+        opMap["select2"] = Operation::SELECT2;
+        opMap["elu"] = Operation::ELU;
+        opMap["relu"] = Operation::RELU;
     }
     string trimmed = name.substr(0, name.size()-1);
 
@@ -403,6 +406,12 @@ Operation* Parser::getFunctionOperation(const std::string& name, const map<strin
             return new Operation::Ceil();
         case Operation::SELECT:
             return new Operation::Select();
+        case Operation::SELECT2:
+            return new Operation::Select2();
+        case Operation::ELU:
+            return new Operation::Elu();
+        case Operation::RELU:
+            return new Operation::Relu();
         default:
             throw Exception("unknown function");
     }


### PR DESCRIPTION
I am implementing the forward propagation of the dense neural network as
a CV in Colvars, and this implementation allows to use a custom
activation function defined by Lepton. However, it's hard to write an
expression doing the same things as ReLU and ELU by combining the
existing functions, so in this commit, three additional functions are
added:

1. select2(x, expr1, expr2): Evaluate expr1 when x>0, otherwise
evaluate expr2. Basically this is a helper operation for ELU and RELU.

2. elu(x, alpha): Exponential linear unit. Evaluate alpha*(exp(x)-1)
when x>0, otherwise evaluate x.

3. relu(x): Rectified linear unit. Evaluate x when x>0, otherwise return
0.

The test cases can be found at https://gist.github.com/HanatoK/0390457acf199b2b5bc0c794f271d59f