### PR TITLE
Fix 4GB memory check

### DIFF
--- a/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
@@ -144,7 +144,7 @@ bool canRunHugeTest() {
 
     // Only run the huge test if the device has at least 4 GB of memory.
 
-    return (memory >= 4*(1<<30));
+    return (memory >= 4*(long long)(1<<30));
 }
 
 void runPlatformTests() {


### PR DESCRIPTION
4*(1<<30) evaluates to 0 so the check returns true on 2GB cards. Test runs fine on 2GB cards but requires over 4GB of system memory.