### PR TITLE
cuFFT execution error checking

### DIFF
--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1292,10 +1292,15 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
             cu.executeKernel(pmeFinishSpreadChargeKernel, finishSpreadArgs, gridSizeX*gridSizeY*gridSizeZ, 256);
 
             if (useCudaFFT) {
-                if (cu.getUseDoublePrecision())
-                    cufftExecD2Z(fftForward, (double*) pmeGrid1.getDevicePointer(), (double2*) pmeGrid2.getDevicePointer());
-                else
-                    cufftExecR2C(fftForward, (float*) pmeGrid1.getDevicePointer(), (float2*) pmeGrid2.getDevicePointer());
+                if (cu.getUseDoublePrecision()) {
+                    cufftResult result = cufftExecD2Z(fftForward, (double*) pmeGrid1.getDevicePointer(), (double2*) pmeGrid2.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+		} else {
+                    cufftResult result = cufftExecR2C(fftForward, (float*) pmeGrid1.getDevicePointer(), (float2*) pmeGrid2.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+		}
             }
             else {
                 fft->execFFT(pmeGrid1, pmeGrid2, true);
@@ -1314,10 +1319,15 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
             cu.executeKernel(pmeConvolutionKernel, convolutionArgs, gridSizeX*gridSizeY*gridSizeZ, 256);
 
             if (useCudaFFT) {
-                if (cu.getUseDoublePrecision())
-                    cufftExecZ2D(fftBackward, (double2*) pmeGrid2.getDevicePointer(), (double*) pmeGrid1.getDevicePointer());
-                else
-                    cufftExecC2R(fftBackward, (float2*) pmeGrid2.getDevicePointer(), (float*)  pmeGrid1.getDevicePointer());
+                if (cu.getUseDoublePrecision()) {
+                    cufftResult result = cufftExecZ2D(fftBackward, (double2*) pmeGrid2.getDevicePointer(), (double*) pmeGrid1.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+	        } else {
+                    cufftResult result = cufftExecC2R(fftBackward, (float2*) pmeGrid2.getDevicePointer(), (float*)  pmeGrid1.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+		}
             }
             else {
                 fft->execFFT(pmeGrid2, pmeGrid1, false);
@@ -1352,10 +1362,15 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
             cu.executeKernel(pmeDispersionFinishSpreadChargeKernel, finishSpreadArgs, dispersionGridSizeX*dispersionGridSizeY*dispersionGridSizeZ, 256);
 
             if (useCudaFFT) {
-                if (cu.getUseDoublePrecision())
-                    cufftExecD2Z(dispersionFftForward, (double*) pmeGrid1.getDevicePointer(), (double2*) pmeGrid2.getDevicePointer());
-                else
-                    cufftExecR2C(dispersionFftForward, (float*) pmeGrid1.getDevicePointer(), (float2*) pmeGrid2.getDevicePointer());
+                if (cu.getUseDoublePrecision()) {
+                    cufftResult result = cufftExecD2Z(dispersionFftForward, (double*) pmeGrid1.getDevicePointer(), (double2*) pmeGrid2.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+	        } else {
+                    cufftResult result = cufftExecR2C(dispersionFftForward, (float*) pmeGrid1.getDevicePointer(), (float2*) pmeGrid2.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+		}
             }
             else {
                 dispersionFft->execFFT(pmeGrid1, pmeGrid2, true);
@@ -1374,10 +1389,15 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
             cu.executeKernel(pmeDispersionConvolutionKernel, convolutionArgs, dispersionGridSizeX*dispersionGridSizeY*dispersionGridSizeZ, 256);
 
             if (useCudaFFT) {
-                if (cu.getUseDoublePrecision())
-                    cufftExecZ2D(dispersionFftBackward, (double2*) pmeGrid2.getDevicePointer(), (double*) pmeGrid1.getDevicePointer());
-                else
-                    cufftExecC2R(dispersionFftBackward, (float2*) pmeGrid2.getDevicePointer(), (float*)  pmeGrid1.getDevicePointer());
+                if (cu.getUseDoublePrecision()) {
+                    cufftResult result = cufftExecZ2D(dispersionFftBackward, (double2*) pmeGrid2.getDevicePointer(), (double*) pmeGrid1.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+		} else {
+                    cufftResult result = cufftExecC2R(dispersionFftBackward, (float2*) pmeGrid2.getDevicePointer(), (float*)  pmeGrid1.getDevicePointer());
+                    if (result != CUFFT_SUCCESS)
+                        throw OpenMMException("Error executing FFT: "+cu.intToString(result));
+		}
             }
             else {
                 dispersionFft->execFFT(pmeGrid2, pmeGrid1, false);

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1296,11 +1296,11 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
                     cufftResult result = cufftExecD2Z(fftForward, (double*) pmeGrid1.getDevicePointer(), (double2*) pmeGrid2.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-		} else {
+                } else {
                     cufftResult result = cufftExecR2C(fftForward, (float*) pmeGrid1.getDevicePointer(), (float2*) pmeGrid2.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-		}
+                }
             }
             else {
                 fft->execFFT(pmeGrid1, pmeGrid2, true);
@@ -1323,11 +1323,11 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
                     cufftResult result = cufftExecZ2D(fftBackward, (double2*) pmeGrid2.getDevicePointer(), (double*) pmeGrid1.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-	        } else {
+                } else {
                     cufftResult result = cufftExecC2R(fftBackward, (float2*) pmeGrid2.getDevicePointer(), (float*)  pmeGrid1.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-		}
+                }
             }
             else {
                 fft->execFFT(pmeGrid2, pmeGrid1, false);
@@ -1366,11 +1366,11 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
                     cufftResult result = cufftExecD2Z(dispersionFftForward, (double*) pmeGrid1.getDevicePointer(), (double2*) pmeGrid2.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-	        } else {
+                } else {
                     cufftResult result = cufftExecR2C(dispersionFftForward, (float*) pmeGrid1.getDevicePointer(), (float2*) pmeGrid2.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-		}
+                }
             }
             else {
                 dispersionFft->execFFT(pmeGrid1, pmeGrid2, true);
@@ -1393,11 +1393,11 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
                     cufftResult result = cufftExecZ2D(dispersionFftBackward, (double2*) pmeGrid2.getDevicePointer(), (double*) pmeGrid1.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-		} else {
+                } else {
                     cufftResult result = cufftExecC2R(dispersionFftBackward, (float2*) pmeGrid2.getDevicePointer(), (float*)  pmeGrid1.getDevicePointer());
                     if (result != CUFFT_SUCCESS)
                         throw OpenMMException("Error executing FFT: "+cu.intToString(result));
-		}
+                }
             }
             else {
                 dispersionFft->execFFT(pmeGrid2, pmeGrid1, false);
@@ -1783,7 +1783,7 @@ void CudaApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, d
     float scalefZ = (float) scaleZ;
     void* args[] = {&scalefX, &scalefY, &scalefZ, &numMolecules, cu.getPeriodicBoxSizePointer(), cu.getInvPeriodicBoxSizePointer(),
                     cu.getPeriodicBoxVecXPointer(), cu.getPeriodicBoxVecYPointer(), cu.getPeriodicBoxVecZPointer(),
-		    &cu.getPosq().getDevicePointer(), &moleculeAtoms.getDevicePointer(), &moleculeStartIndex.getDevicePointer()};
+                    &cu.getPosq().getDevicePointer(), &moleculeAtoms.getDevicePointer(), &moleculeStartIndex.getDevicePointer()};
     cu.executeKernel(kernel, args, cu.getNumAtoms());
     for (auto& offset : cu.getPosCellOffsets())
         offset = mm_int4(0, 0, 0, 0);

--- a/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
@@ -144,7 +144,7 @@ bool canRunHugeTest() {
 
     // Only run the huge test if the device has at least 4 GB of memory.
 
-    return (memory >= 4*(1<<30));
+    return (memory >= 4*(long long)(1<<30));
 }
 
 void runPlatformTests() {


### PR DESCRIPTION
Minor changes to avoid silent failure of cuFFT execution if an error occurs. Previously, if a cuFFT execution call returned a non-zero result, it would not trigger an exception. This would cause the affected unit tests to fail, seemingly for correctness issues, giving something like this:

```
101: exception: Assertion failure at TestEwald.h:191.   Expected [-198.058, -224.745, -102.259], found [-276.679, -263.117, -92.902]
1/1 Test #101: TestCudaEwaldSingle ..............***Failed    1.58 sec
```

I added error checks to the execution step similar to those of the plan creation. If the FFT execution returns a non-zero error code, it is now reflected in the failure message: 

```
101: exception: Error executing FFT: 1
1/1 Test #101: TestCudaEwaldSingle ..............***Failed    1.59 sec
```

I did not measure any impact on performance on the Apoa1 PME benchmark.


Thank you very much for your time!