### PR TITLE
Switch openmmforcefields channel to omnia

### DIFF
--- a/docs-source/usersguide/application.rst
+++ b/docs-source/usersguide/application.rst
@@ -810,7 +810,7 @@ You can install this via conda with:
 
 .. code-block:: bash
 
-    $ conda install -c conda-forge openmmforcefields
+    $ conda install -c omnia openmmforcefields
 
 You can then add a small molecule residue template generator using the Open Force
 Field Initiative small molecule force fields using the following example:


### PR DESCRIPTION
I don't believe the `openmmforcefields` package is available on `conda-forge`. This switches the docs back to `omnia` for `openmmforcefields`.