### PR TITLE
Add benchmarks from Amber20 benchmark suite to standard benchmark script

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -19,15 +19,18 @@ def timeIntegration(context, steps, initialSteps):
     return elapsed.seconds + elapsed.microseconds*1e-6
 
 def downloadAmberSuite():
-    dir = 'Amber20_Benchmark_Suite'
-    if not os.path.exists(dir):
-        os.mkdir(dir)
-        os.chdir(dir)
-        import subprocess
-        subprocess.run('wget https://ambermd.org/Amber20_Benchmark_Suite.tar.gz', shell=True, check=True)
-        subprocess.run('tar xzvf Amber20_Benchmark_Suite.tar.gz', shell=True, check=True)
-        os.chdir('..')
-    return dir
+    """Download and extract Amber benchmark to Amber20_Benchmark_Suite/ in current directory."""
+    dirname = 'Amber20_Benchmark_Suite'
+    url = 'https://ambermd.org/Amber20_Benchmark_Suite.tar.gz'
+    if not os.path.exists(dirname):
+        import urllib.request
+        print('Downloading', url)
+        filename, headers = urllib.request.urlretrieve(url, filename='Amber20_Benchmark_Suite.tar.gz')
+        import tarfile
+        print('Extracting', filename)
+        tarfh = tarfile.open(filename, 'r:gz')
+        tarfh.extractall(path=dirname)
+    return dirname
 
 def runOneTest(testName, options):
     """Perform a single benchmarking simulation."""
@@ -68,9 +71,9 @@ def runOneTest(testName, options):
         dt = 0.002*unit.picoseconds
         integ = mm.MTSIntegrator(dt, [(0,2), (1,1)])
     elif amber:
-        dir = downloadAmberSuite()
-        prmtop = app.AmberPrmtopFile(os.path.join(dir, f'PME/Topologies/{testName}.prmtop'))
-        inpcrd = app.AmberInpcrdFile(os.path.join(dir, f'PME/Coordinates/{testName}.inpcrd'))
+        dirname = downloadAmberSuite()
+        prmtop = app.AmberPrmtopFile(os.path.join(dirname, f'PME/Topologies/{testName}.prmtop'))
+        inpcrd = app.AmberInpcrdFile(os.path.join(dirname, f'PME/Coordinates/{testName}.inpcrd'))
         topology = prmtop.topology
         positions = inpcrd.positions
         dt = 0.004*unit.picoseconds

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -37,7 +37,7 @@ def runOneTest(testName, options):
     explicit = (testName in ('rf', 'pme', 'amoebapme'))
     amoeba = (testName in ('amoebagk', 'amoebapme'))
     apoa1 = testName.startswith('apoa1')
-    amber = (testName in ('JAC', 'Cellulose', 'FactorIX', 'STMV'))
+    amber = (testName.startswith('amber'))
     hydrogenMass = None
     print()
     if amoeba:
@@ -72,8 +72,10 @@ def runOneTest(testName, options):
         integ = mm.MTSIntegrator(dt, [(0,2), (1,1)])
     elif amber:
         dirname = downloadAmberSuite()
-        prmtop = app.AmberPrmtopFile(os.path.join(dirname, f'PME/Topologies/{testName}.prmtop'))
-        inpcrd = app.AmberInpcrdFile(os.path.join(dirname, f'PME/Coordinates/{testName}.inpcrd'))
+        names = {'amber20-dhfr':'JAC',  'amber20-factorix':'FactorIX', 'amber20-cellulose':'Cellulose', 'amber20-stmv':'STMV'}
+        fileName = names[testName]
+        prmtop = app.AmberPrmtopFile(os.path.join(dirname, f'PME/Topologies/{fileName}.prmtop'))
+        inpcrd = app.AmberInpcrdFile(os.path.join(dirname, f'PME/Coordinates/{fileName}.inpcrd'))
         topology = prmtop.topology
         positions = inpcrd.positions
         dt = 0.004*unit.picoseconds
@@ -172,7 +174,8 @@ def runOneTest(testName, options):
 parser = ArgumentParser()
 platformNames = [mm.Platform.getPlatform(i).getName() for i in range(mm.Platform.getNumPlatforms())]
 parser.add_argument('--platform', dest='platform', choices=platformNames, help='name of the platform to benchmark')
-parser.add_argument('--test', dest='test', choices=('gbsa', 'rf', 'pme', 'apoa1rf', 'apoa1pme', 'apoa1ljpme', 'amoebagk', 'amoebapme', 'JAC',  'FactorIX', 'Cellulose', 'STMV'), help='the test to perform: gbsa, rf, pme, apoa1rf, apoa1pme, apoa1ljpme, amoebagk, or amoebapme [default: all]')
+parser.add_argument('--test', dest='test', choices=('gbsa', 'rf', 'pme', 'apoa1rf', 'apoa1pme', 'apoa1ljpme', 'amoebagk', 'amoebapme', 'amber20-dhfr',  'amber20-factorix', 'amber20-cellulose', 'amber20-stmv'), 
+    help='the test to perform: gbsa, rf, pme, apoa1rf, apoa1pme, apoa1ljpme, amoebagk, amoebapme,  amber20-dhfr,  amber20-factorix, amber20-cellulose, amber20-stmv [default: all except amber-*]')
 parser.add_argument('--ensemble', default='NPT', dest='ensemble', choices=('NPT', 'NVE', 'NVT'), help='the ensemble (for Amber tests only) [default: NPT]')
 parser.add_argument('--pme-cutoff', default=0.9, dest='cutoff', type=float, help='direct space cutoff for PME in nm [default: 0.9]')
 parser.add_argument('--seconds', default=60, dest='seconds', type=float, help='target simulation length in seconds [default: 60]')


### PR DESCRIPTION
This pull request makes the standard OpenMM benchmark script be able to run tests from the Amber suite (as well as all the original tests).  The suite is downloaded and unpacked automatically (into the current directory) if it is not already there. The Amber20 benchmark suite is available here: https://ambermd.org/GPUPerformance.php

Rationale: this has some significantly larger systems than the benchmarks already included in OpenMM, up to the 1 million atom STMV system.  It also allows direct comparisons with published Amber benchmarks.  The intention is to make this as close to apples-to-apples as possible (but there are some remaining small issues, see below).

Questions / caveats:

- [x] Is it okay to download the .tar.gz directly from ambermd.org?  Including this here probably won't immediately cause a huge increase in downloads, but it may be good to give them a heads up, and/or mirror it somewhere.  (Note: these tests are not included if running benchmark.py with no arguments - the user needs to select one of the tests specifically before it triggers a download)
- [x] Is it okay to assume wget and tar are available?  (There are pure python replacements if preferred) => Replaced with pure python urllib and tarfile
- [x] The original runs NPT and NVE simulations; the simulation here is NVT (which would probably have a slight speed advantage over NPT).  Can we add a MonteCarloBarostat for NPT to make it an exact comparison? (none of the other tests use that)  How would we do a 4fs time step NVE? (maybe VelocityVerlet? sorry, I'm not familiar with it) => Added --ensemble option, NPT is default for amber tests
- [x] Hydrogen mass: these benchmarks are all intended to use HMR, but I couldn't figure out what the hydrogen mass is supposed to be.  Is this already included in the .prmtop file? (and if yes, is it read in correctly?)  The tleap default is 3amu, so I just set it explicitly to that. => Fixed; don't change hydrogen mass from inputs
- [x] Adding `context.setVelocitiesToTemperature()` causes "particle position is nan" pretty quickly if running one of these systems.  Not sure why; they may have velocities included in the inpcrd file.  That's why this is skipped for these.
- [x] What should the names of the tests be?  => Lowercase, amber20- prefix

Impact: should have no effect on any of the existing benchmarks; just adds new ones.

Testing:
- Tested on T4, V100, A100 GPUs on AWS (will post results as an issue shortly)

Todo:
- Add the implicit solvent tests from the same suite