### PR TITLE
Made ordering of impropers more deterministic

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -608,6 +608,7 @@ class ForceField(object):
                 self.bondedToAtom[bond.atom2].add(bond.atom1)
                 self.atomBonds[bond.atom1].append(i)
                 self.atomBonds[bond.atom2].append(i)
+            self.bondedToAtom = [sorted(b) for b in self.bondedToAtom]
 
         def addConstraint(self, system, atom1, atom2, distance):
             """Add a constraint to the system, avoiding duplicate constraints."""
@@ -989,8 +990,8 @@ class ForceField(object):
 
         Returns
         -------
-        bondedToAtom : list of set of int
-            bondedToAtom[index] is the set of atom indices bonded to atom `index`
+        bondedToAtom : list of set list int
+            bondedToAtom[index] is the list of atom indices bonded to atom `index`
 
         """
         bondedToAtom = []
@@ -999,6 +1000,7 @@ class ForceField(object):
         for (atom1, atom2) in topology.bonds():
             bondedToAtom[atom1.index].add(atom2.index)
             bondedToAtom[atom2.index].add(atom1.index)
+        bondedToAtom = [sorted(b) for b in bondedToAtom]
         return bondedToAtom
 
     def getUnmatchedResidues(self, topology):

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -990,7 +990,7 @@ class ForceField(object):
 
         Returns
         -------
-        bondedToAtom : list of set list int
+        bondedToAtom : list of list of int
             bondedToAtom[index] is the list of atom indices bonded to atom `index`
 
         """

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -935,7 +935,7 @@ class TestForceField(unittest.TestCase):
         system1_indexes = [imp1[0], imp1[1], imp1[2], imp1[3]]
         system2_indexes = [imp2[0], imp2[1], imp2[2], imp2[3]]
 
-        self.assertEqual(system1_indexes, [51, 56, 54, 55])
+        self.assertEqual(system1_indexes, [51, 55, 54, 56])
         self.assertEqual(system2_indexes, [51, 55, 54, 56])
 
     def test_ImpropersOrdering_smirnoff(self):


### PR DESCRIPTION
See https://github.com/conda-forge/openmm-feedstock/pull/46.  This accounts for a difference between CPython and Pypy in how they order the elements of sets.