### PR TITLE
Improve selection of architecture to compile for

### DIFF
--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -530,9 +530,10 @@ private:
     int contextIndex;
     int numAtomBlocks;
     int numThreadBlocks;
+    int gpuArchitecture;
     bool useBlockingSync, useDoublePrecision, useMixedPrecision, contextIsValid, boxIsTriclinic, hasCompilerKernel, isNvccAvailable, hasAssignedPosqCharges;
     bool isLinkedContext;
-    std::string compiler, tempDir, cacheDir, gpuArchitecture;
+    std::string compiler, tempDir, cacheDir;
     float4 periodicBoxVecXFloat, periodicBoxVecYFloat, periodicBoxVecZFloat, periodicBoxSizeFloat, invPeriodicBoxSizeFloat;
     double4 periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ, periodicBoxSize, invPeriodicBoxSize;
     std::string defaultOptimizationOptions;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -62,6 +62,10 @@ public:
      * @param cu         the CudaContext for which the kernel is being compiled
      */
     virtual std::string createModule(const std::string& source, const std::string& flags, CudaContext& cu) = 0;
+    /**
+     * Get the maximum architecture version the compiler supports.
+     */
+    virtual int getMaxSupportedArchitecture() const = 0;
 };
 
 /**

--- a/plugins/cudacompiler/src/CudaCompilerKernels.cpp
+++ b/plugins/cudacompiler/src/CudaCompilerKernels.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Portions copyright (c) 2015-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -46,6 +46,16 @@ using namespace std;
 
 static string getErrorString(nvrtcResult result) {
     return nvrtcGetErrorString(result);
+}
+
+CudaRuntimeCompilerKernel::CudaRuntimeCompilerKernel(const std::string& name, const Platform& platform) : CudaCompilerKernel(name, platform) {
+    // Find the maximum architecture the compiler supports.
+    
+    int numArchs;
+    CHECK_RESULT(nvrtcGetNumSupportedArchs(&numArchs), "Error querying supported architectures");
+    vector<int> archs(numArchs);
+    CHECK_RESULT(nvrtcGetSupportedArchs(archs.data()), "Error querying supported architectures");
+    maxSupportedArchitecture = archs.back();
 }
 
 string CudaRuntimeCompilerKernel::createModule(const string& source, const string& flags, CudaContext& cu) {

--- a/plugins/cudacompiler/src/CudaCompilerKernels.cpp
+++ b/plugins/cudacompiler/src/CudaCompilerKernels.cpp
@@ -51,11 +51,17 @@ static string getErrorString(nvrtcResult result) {
 CudaRuntimeCompilerKernel::CudaRuntimeCompilerKernel(const std::string& name, const Platform& platform) : CudaCompilerKernel(name, platform) {
     // Find the maximum architecture the compiler supports.
     
+#if CUDA_VERSION < 11000
+    // CUDA versions before 11 can't query the compiler to see what it supports.
+    
+    maxSupportedArchitecture = 75;
+#else
     int numArchs;
     CHECK_RESULT(nvrtcGetNumSupportedArchs(&numArchs), "Error querying supported architectures");
     vector<int> archs(numArchs);
     CHECK_RESULT(nvrtcGetSupportedArchs(archs.data()), "Error querying supported architectures");
     maxSupportedArchitecture = archs.back();
+#endif
 }
 
 string CudaRuntimeCompilerKernel::createModule(const string& source, const string& flags, CudaContext& cu) {

--- a/plugins/cudacompiler/src/CudaCompilerKernels.h
+++ b/plugins/cudacompiler/src/CudaCompilerKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Portions copyright (c) 2015-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -44,8 +44,7 @@ namespace OpenMM {
  */
 class OPENMM_EXPORT_CUDACOMPILER CudaRuntimeCompilerKernel : public CudaCompilerKernel {
 public:
-    CudaRuntimeCompilerKernel(const std::string& name, const Platform& platform) : CudaCompilerKernel(name, platform) {
-    }
+    CudaRuntimeCompilerKernel(const std::string& name, const Platform& platform);
     /**
      * Compile a kernel to PTX.
      *
@@ -54,6 +53,14 @@ public:
      * @param cu         the CudaContext for which the kernel is being compiled
      */
     std::string createModule(const std::string& source, const std::string& flags, CudaContext& cu);
+    /**
+     * Get the maximum architecture version the compiler supports.
+     */
+    int getMaxSupportedArchitecture() const {
+        return maxSupportedArchitecture;
+    }
+private:
+    int maxSupportedArchitecture;
 };
 
 } // namespace OpenMM


### PR DESCRIPTION
In 7.5 we changed the behavior of compiling CUDA kernels, so it would prefer the runtime compiler over the command line compiler.  This was supposed avoid problems, but it ended up creating some new problems.  One of them is that conda would sometimes make a bad choice of what toolkit to install, and you would get a compiler too old to support your GPU's architecture.

This PR addresses the problem by querying the runtime compiler to find the maximum architecture it supports.  It then tells the compiler to target the highest architecture that is supported by both the compiler and the GPU.