### PR TITLE
Point based geometric functions for custom forces

### DIFF
--- a/openmmapi/include/openmm/CustomCentroidBondForce.h
+++ b/openmmapi/include/openmm/CustomCentroidBondForce.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -107,6 +107,15 @@ namespace OpenMM {
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, atan2, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
  * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
  * select(x,y,z) = z if x = 0, y otherwise.
+ * 
+ * This class also supports the functions pointdistance(x1, y1, z1, x2, y2, z2),
+ * pointangle(x1, y1, z1, x2, y2, z2, x3, y3, z3), and pointdihedral(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4).
+ * These functions are similar to distance(), angle(), and dihedral(), but the arguments are the
+ * coordinates of points to perform the calculation based on rather than the names of groups.
+ * This enables more flexible geometric calculations.  For example, the following computes the distance
+ * from group g1 to the midpoint between groups g2 and g3.
+ * 
+ * <tt>CustomCentroidBondForce* force = new CustomCentroidBondForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2");</tt>
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomCentroidBondForce.h
+++ b/openmmapi/include/openmm/CustomCentroidBondForce.h
@@ -115,7 +115,7 @@ namespace OpenMM {
  * This enables more flexible geometric calculations.  For example, the following computes the distance
  * from group g1 to the midpoint between groups g2 and g3.
  * 
- * <tt>CustomCentroidBondForce* force = new CustomCentroidBondForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2");</tt>
+ * <tt>CustomCentroidBondForce* force = new CustomCentroidBondForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2)");</tt>
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomCompoundBondForce.h
+++ b/openmmapi/include/openmm/CustomCompoundBondForce.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -96,6 +96,15 @@ namespace OpenMM {
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, atan2, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
  * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
  * select(x,y,z) = z if x = 0, y otherwise.
+ * 
+ * This class also supports the functions pointdistance(x1, y1, z1, x2, y2, z2),
+ * pointangle(x1, y1, z1, x2, y2, z2, x3, y3, z3), and pointdihedral(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4).
+ * These functions are similar to distance(), angle(), and dihedral(), but the arguments are the
+ * coordinates of points to perform the calculation based on rather than the names of particles.
+ * This enables more flexible geometric calculations.  For example, the following computes the distance
+ * from particle p1 to the midpoint between particles p2 and p3.
+ * 
+ * <tt>CustomCompoundBondForce* force = new CustomCompoundBondForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2");</tt>
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomCompoundBondForce.h
+++ b/openmmapi/include/openmm/CustomCompoundBondForce.h
@@ -104,7 +104,7 @@ namespace OpenMM {
  * This enables more flexible geometric calculations.  For example, the following computes the distance
  * from particle p1 to the midpoint between particles p2 and p3.
  * 
- * <tt>CustomCompoundBondForce* force = new CustomCompoundBondForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2");</tt>
+ * <tt>CustomCompoundBondForce* force = new CustomCompoundBondForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2)");</tt>
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomManyParticleForce.h
+++ b/openmmapi/include/openmm/CustomManyParticleForce.h
@@ -162,7 +162,7 @@ namespace OpenMM {
  * This enables more flexible geometric calculations.  For example, the following computes the distance
  * from particle p1 to the midpoint between particles p2 and p3.
  * 
- * <tt>CustomManyParticleForce* force = new CustomManyParticleForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2");</tt>
+ * <tt>CustomManyParticleForce* force = new CustomManyParticleForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2)");</tt>
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomManyParticleForce.h
+++ b/openmmapi/include/openmm/CustomManyParticleForce.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -154,6 +154,15 @@ namespace OpenMM {
  * select(x,y,z) = z if x = 0, y otherwise.  The names of per-particle parameters have the suffix "1", "2", etc. appended to them to indicate the values for
  * the multiple interacting particles. For example, if you define a per-particle parameter called "charge", then the variable "charge2" is the charge of particle p2.
  * As seen above, the expression may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
+ * 
+ * This class also supports the functions pointdistance(x1, y1, z1, x2, y2, z2),
+ * pointangle(x1, y1, z1, x2, y2, z2, x3, y3, z3), and pointdihedral(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4).
+ * These functions are similar to distance(), angle(), and dihedral(), but the arguments are the
+ * coordinates of points to perform the calculation based on rather than the names of particles.
+ * This enables more flexible geometric calculations.  For example, the following computes the distance
+ * from particle p1 to the midpoint between particles p2 and p3.
+ * 
+ * <tt>CustomManyParticleForce* force = new CustomManyParticleForce(3, "pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2");</tt>
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/internal/CustomCentroidBondForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomCentroidBondForceImpl.h
@@ -67,21 +67,14 @@ public:
     std::vector<std::pair<int, int> > getBondedParticles() const;
     void updateParametersInContext(ContextImpl& context);
     /**
-     * This is a utility routine that parses the energy expression, identifies the angles and dihedrals
-     * in it, and replaces them with variables.
+     * This is a utility routine that parses the energy expression, identifies group based functions,
+     * and replaces them with equivalent point based ones.
      *
      * @param force     the CustomCentroidBondForce to process
      * @param functions definitions of custom function that may appear in the expression
-     * @param distances on exit, this will contain an entry for each distance used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
-     * @param angles    on exit, this will contain an entry for each angle used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
-     * @param dihedrals on exit, this will contain an entry for each dihedral used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
      * @return a Parsed expression for the energy
      */
-    static Lepton::ParsedExpression prepareExpression(const CustomCentroidBondForce& force, const std::map<std::string, Lepton::CustomFunction*>& functions, std::map<std::string, std::vector<int> >& distances,
-            std::map<std::string, std::vector<int> >& angles, std::map<std::string, std::vector<int> >& dihedrals);
+    static Lepton::ParsedExpression prepareExpression(const CustomCentroidBondForce& force, const std::map<std::string, Lepton::CustomFunction*>& functions);
     /**
      * Compute the normalized weights to use for each particle in each group.
      *
@@ -92,9 +85,8 @@ public:
     static void computeNormalizedWeights(const CustomCentroidBondForce& force, const System& system, std::vector<std::vector<double> >& weights);
 private:
     class FunctionPlaceholder;
-    static Lepton::ExpressionTreeNode replaceFunctions(const Lepton::ExpressionTreeNode& node, std::map<std::string, int> atoms,
-            std::map<std::string, std::vector<int> >& distances, std::map<std::string, std::vector<int> >& angles,
-            std::map<std::string, std::vector<int> >& dihedrals, std::set<std::string>& variables);
+    static Lepton::ExpressionTreeNode replaceFunctions(const Lepton::ExpressionTreeNode& node, std::map<std::string, int> groups,
+            const std::map<std::string, Lepton::CustomFunction*>& functions, std::set<std::string>& variables);
     void addBondsBetweenGroups(int group1, int group2, std::vector<std::pair<int, int> >& bonds) const;
     const CustomCentroidBondForce& owner;
     Kernel kernel;

--- a/openmmapi/include/openmm/internal/CustomCompoundBondForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomCompoundBondForceImpl.h
@@ -65,26 +65,18 @@ public:
     std::vector<std::string> getKernelNames();
     void updateParametersInContext(ContextImpl& context);
     /**
-     * This is a utility routine that parses the energy expression, identifies the angles and dihedrals
-     * in it, and replaces them with variables.
+     * This is a utility routine that parses the energy expression, identifies particle based functions,
+     * and replaces them with equivalent point based ones.
      *
      * @param force     the CustomCompoundBondForce to process
      * @param functions definitions of custom function that may appear in the expression
-     * @param distances on exit, this will contain an entry for each distance used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
-     * @param angles    on exit, this will contain an entry for each angle used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
-     * @param dihedrals on exit, this will contain an entry for each dihedral used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
      * @return a Parsed expression for the energy
      */
-    static Lepton::ParsedExpression prepareExpression(const CustomCompoundBondForce& force, const std::map<std::string, Lepton::CustomFunction*>& functions, std::map<std::string, std::vector<int> >& distances,
-            std::map<std::string, std::vector<int> >& angles, std::map<std::string, std::vector<int> >& dihedrals);
+    static Lepton::ParsedExpression prepareExpression(const CustomCompoundBondForce& force, const std::map<std::string, Lepton::CustomFunction*>& functions);
 private:
     class FunctionPlaceholder;
     static Lepton::ExpressionTreeNode replaceFunctions(const Lepton::ExpressionTreeNode& node, std::map<std::string, int> atoms,
-            std::map<std::string, std::vector<int> >& distances, std::map<std::string, std::vector<int> >& angles,
-            std::map<std::string, std::vector<int> >& dihedrals, std::set<std::string>& variables);
+            const std::map<std::string, Lepton::CustomFunction*>& functions, std::set<std::string>& variables);
     const CustomCompoundBondForce& owner;
     Kernel kernel;
 };

--- a/openmmapi/include/openmm/internal/CustomManyParticleForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomManyParticleForceImpl.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -65,21 +65,14 @@ public:
     std::vector<std::string> getKernelNames();
     void updateParametersInContext(ContextImpl& context);
     /**
-     * This is a utility routine that parses the energy expression, identifies the angles and dihedrals
-     * in it, and replaces them with variables.
+     * This is a utility routine that parses the energy expression, identifies particle based functions,
+     * and replaces them with equivalent point based ones.
      *
      * @param force     the CustomManyParticleForce to process
      * @param functions definitions of custom function that may appear in the expression
-     * @param distances on exit, this will contain an entry for each distance used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
-     * @param angles    on exit, this will contain an entry for each angle used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
-     * @param dihedrals on exit, this will contain an entry for each dihedral used in the expression.  The key is the name
-     *                  of the corresponding variable, and the value is the list of particle indices.
      * @return a Parsed expression for the energy
      */
-    static Lepton::ParsedExpression prepareExpression(const CustomManyParticleForce& force, const std::map<std::string, Lepton::CustomFunction*>& functions, std::map<std::string, std::vector<int> >& distances,
-            std::map<std::string, std::vector<int> >& angles, std::map<std::string, std::vector<int> >& dihedrals);
+    static Lepton::ParsedExpression prepareExpression(const CustomManyParticleForce& force, const std::map<std::string, Lepton::CustomFunction*>& functions);
     /**
      * Analyze the type filters for a force and build a set of arrays that can be used for reordering the
      * particles in an interaction.
@@ -98,8 +91,7 @@ public:
 private:
     class FunctionPlaceholder;
     static Lepton::ExpressionTreeNode replaceFunctions(const Lepton::ExpressionTreeNode& node, std::map<std::string, int> atoms,
-            std::map<std::string, std::vector<int> >& distances, std::map<std::string, std::vector<int> >& angles,
-            std::map<std::string, std::vector<int> >& dihedrals, std::set<std::string>& variables);
+            const std::map<std::string, Lepton::CustomFunction*>& functions, std::set<std::string>& variables);
     static void generatePermutations(std::vector<int>& values, int numFixed, std::vector<std::vector<int> >& result);
     const CustomManyParticleForce& owner;
     Kernel kernel;

--- a/openmmapi/src/CustomCentroidBondForceImpl.cpp
+++ b/openmmapi/src/CustomCentroidBondForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -140,14 +140,22 @@ map<string, double> CustomCentroidBondForceImpl::getDefaultParameters() {
 
 ParsedExpression CustomCentroidBondForceImpl::prepareExpression(const CustomCentroidBondForce& force, const map<string, CustomFunction*>& customFunctions, map<string, vector<int> >& distances,
         map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
-    CustomCentroidBondForceImpl::FunctionPlaceholder custom(1);
     CustomCentroidBondForceImpl::FunctionPlaceholder distance(2);
     CustomCentroidBondForceImpl::FunctionPlaceholder angle(3);
     CustomCentroidBondForceImpl::FunctionPlaceholder dihedral(4);
+    CustomCentroidBondForceImpl::FunctionPlaceholder pointdistance(6);
+    CustomCentroidBondForceImpl::FunctionPlaceholder pointangle(9);
+    CustomCentroidBondForceImpl::FunctionPlaceholder pointdihedral(12);
     map<string, CustomFunction*> functions = customFunctions;
     functions["distance"] = &distance;
     functions["angle"] = &angle;
     functions["dihedral"] = &dihedral;
+    if (functions.find("pointdistance") == functions.end())
+        functions["pointdistance"] = &pointdistance;
+    if (functions.find("pointangle") == functions.end())
+        functions["pointangle"] = &pointangle;
+    if (functions.find("pointdihedral") == functions.end())
+        functions["pointdihedral"] = &pointdihedral;
     ParsedExpression expression = Lepton::Parser::parse(force.getEnergyFunction(), functions);
     map<string, int> groups;
     set<string> variables;
@@ -176,7 +184,7 @@ ExpressionTreeNode CustomCentroidBondForceImpl::replaceFunctions(const Expressio
         throw OpenMMException("CustomCentroidBondForce: Unknown variable '"+op.getName()+"'");
     if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral"))
     {
-        // This is not an angle or dihedral, so process its children.
+        // The arguments are not group identifiers, so process its children.
 
         vector<ExpressionTreeNode> children;
         for (auto& child : node.getChildren())

--- a/openmmapi/src/CustomCentroidBondForceImpl.cpp
+++ b/openmmapi/src/CustomCentroidBondForceImpl.cpp
@@ -138,8 +138,7 @@ map<string, double> CustomCentroidBondForceImpl::getDefaultParameters() {
     return parameters;
 }
 
-ParsedExpression CustomCentroidBondForceImpl::prepareExpression(const CustomCentroidBondForce& force, const map<string, CustomFunction*>& customFunctions, map<string, vector<int> >& distances,
-        map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
+ParsedExpression CustomCentroidBondForceImpl::prepareExpression(const CustomCentroidBondForce& force, const map<string, CustomFunction*>& customFunctions) {
     CustomCentroidBondForceImpl::FunctionPlaceholder distance(2);
     CustomCentroidBondForceImpl::FunctionPlaceholder angle(3);
     CustomCentroidBondForceImpl::FunctionPlaceholder dihedral(4);
@@ -174,21 +173,20 @@ ParsedExpression CustomCentroidBondForceImpl::prepareExpression(const CustomCent
         variables.insert(force.getGlobalParameterName(i));
     for (int i = 0; i < force.getNumPerBondParameters(); i++)
         variables.insert(force.getPerBondParameterName(i));
-    return ParsedExpression(replaceFunctions(expression.getRootNode(), groups, distances, angles, dihedrals, variables)).optimize();
+    return ParsedExpression(replaceFunctions(expression.getRootNode(), groups, functions, variables)).optimize();
 }
 
 ExpressionTreeNode CustomCentroidBondForceImpl::replaceFunctions(const ExpressionTreeNode& node, map<string, int> groups,
-        map<string, vector<int> >& distances, map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals, set<string>& variables) {
+        const map<string, CustomFunction*>& functions, set<string>& variables) {
     const Operation& op = node.getOperation();
     if (op.getId() == Operation::VARIABLE && variables.find(op.getName()) == variables.end())
         throw OpenMMException("CustomCentroidBondForce: Unknown variable '"+op.getName()+"'");
-    if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral"))
-    {
+    vector<ExpressionTreeNode> children;
+    if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral")) {
         // The arguments are not group identifiers, so process its children.
 
-        vector<ExpressionTreeNode> children;
         for (auto& child : node.getChildren())
-            children.push_back(replaceFunctions(child, groups, distances, angles, dihedrals, variables));
+            children.push_back(replaceFunctions(child, groups, functions, variables));
         return ExpressionTreeNode(op.clone(), children);
     }
     const Operation::Custom& custom = static_cast<const Operation::Custom&>(op);
@@ -203,29 +201,25 @@ ExpressionTreeNode CustomCentroidBondForceImpl::replaceFunctions(const Expressio
             throw OpenMMException("CustomCentroidBondForce: Unknown group '"+node.getChildren()[i].getOperation().getName()+"'");
         indices[i] = iter->second;
     }
-
-    // Select a name for the variable and add it to the appropriate map.
-
-    stringstream variable;
-    if (numArgs == 2)
-        variable << "distance";
-    else if (numArgs == 3)
-        variable << "angle";
-    else
-        variable << "dihedral";
-    for (int i = 0; i < numArgs; i++)
-        variable << indices[i];
-    string name = variable.str();
-    if (numArgs == 2)
-        distances[name] = indices;
-    else if (numArgs == 3)
-        angles[name] = indices;
-    else
-        dihedrals[name] = indices;
-
-    // Return a new node that represents it as a simple variable.
-
-    return ExpressionTreeNode(new Operation::Variable(name));
+    
+    // Replace it by the corresponding point based function.
+    
+    for (int i = 0; i < numArgs; i++) {
+        stringstream x, y, z;
+        x << 'x' << (indices[i]+1);
+        y << 'y' << (indices[i]+1);
+        z << 'z' << (indices[i]+1);
+        children.push_back(ExpressionTreeNode(new Operation::Variable(x.str())));
+        children.push_back(ExpressionTreeNode(new Operation::Variable(y.str())));
+        children.push_back(ExpressionTreeNode(new Operation::Variable(z.str())));
+    }
+    if (op.getName() == "distance")
+        return ExpressionTreeNode(new Operation::Custom("pointdistance", functions.at("pointdistance")->clone()), children);
+    if (op.getName() == "angle")
+        return ExpressionTreeNode(new Operation::Custom("pointangle", functions.at("pointangle")->clone()), children);
+    if (op.getName() == "dihedral")
+        return ExpressionTreeNode(new Operation::Custom("pointdihedral", functions.at("pointdihedral")->clone()), children);
+    throw OpenMMException("Internal error.  Unexpected function '"+op.getName()+"'");
 }
 
 vector<pair<int, int> > CustomCentroidBondForceImpl::getBondedParticles() const {

--- a/openmmapi/src/CustomCompoundBondForceImpl.cpp
+++ b/openmmapi/src/CustomCompoundBondForceImpl.cpp
@@ -124,8 +124,7 @@ map<string, double> CustomCompoundBondForceImpl::getDefaultParameters() {
     return parameters;
 }
 
-ParsedExpression CustomCompoundBondForceImpl::prepareExpression(const CustomCompoundBondForce& force, const map<string, CustomFunction*>& customFunctions, map<string, vector<int> >& distances,
-        map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
+ParsedExpression CustomCompoundBondForceImpl::prepareExpression(const CustomCompoundBondForce& force, const map<string, CustomFunction*>& customFunctions) {
     CustomCompoundBondForceImpl::FunctionPlaceholder distance(2);
     CustomCompoundBondForceImpl::FunctionPlaceholder angle(3);
     CustomCompoundBondForceImpl::FunctionPlaceholder dihedral(4);
@@ -160,21 +159,20 @@ ParsedExpression CustomCompoundBondForceImpl::prepareExpression(const CustomComp
         variables.insert(force.getGlobalParameterName(i));
     for (int i = 0; i < force.getNumPerBondParameters(); i++)
         variables.insert(force.getPerBondParameterName(i));
-    return ParsedExpression(replaceFunctions(expression.getRootNode(), atoms, distances, angles, dihedrals, variables)).optimize();
+    return ParsedExpression(replaceFunctions(expression.getRootNode(), atoms, functions, variables)).optimize();
 }
 
 ExpressionTreeNode CustomCompoundBondForceImpl::replaceFunctions(const ExpressionTreeNode& node, map<string, int> atoms,
-        map<string, vector<int> >& distances, map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals, set<string>& variables) {
+        const map<string, CustomFunction*>& functions, set<string>& variables) {
     const Operation& op = node.getOperation();
     if (op.getId() == Operation::VARIABLE && variables.find(op.getName()) == variables.end())
         throw OpenMMException("CustomCompoundBondForce: Unknown variable '"+op.getName()+"'");
-    if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral"))
-    {
+    vector<ExpressionTreeNode> children;
+    if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral")) {
         // The arguments are not particle identifiers, so process its children.
 
-        vector<ExpressionTreeNode> children;
         for (auto& child : node.getChildren())
-            children.push_back(replaceFunctions(child, atoms, distances, angles, dihedrals, variables));
+            children.push_back(replaceFunctions(child, atoms, functions, variables));
         return ExpressionTreeNode(op.clone(), children);
     }
     const Operation::Custom& custom = static_cast<const Operation::Custom&>(op);
@@ -189,29 +187,25 @@ ExpressionTreeNode CustomCompoundBondForceImpl::replaceFunctions(const Expressio
             throw OpenMMException("CustomCompoundBondForce: Unknown particle '"+node.getChildren()[i].getOperation().getName()+"'");
         indices[i] = iter->second;
     }
-    
-    // Select a name for the variable and add it to the appropriate map.
-    
-    stringstream variable;
-    if (numArgs == 2)
-        variable << "distance";
-    else if (numArgs == 3)
-        variable << "angle";
-    else
-        variable << "dihedral";
-    for (int i = 0; i < numArgs; i++)
-        variable << indices[i];
-    string name = variable.str();
-    if (numArgs == 2)
-        distances[name] = indices;
-    else if (numArgs == 3)
-        angles[name] = indices;
-    else
-        dihedrals[name] = indices;
-    
-    // Return a new node that represents it as a simple variable.
-    
-    return ExpressionTreeNode(new Operation::Variable(name));
+
+    // Replace it by the corresponding point based function.
+
+    for (int i = 0; i < numArgs; i++) {
+        stringstream x, y, z;
+        x << 'x' << (indices[i]+1);
+        y << 'y' << (indices[i]+1);
+        z << 'z' << (indices[i]+1);
+        children.push_back(ExpressionTreeNode(new Operation::Variable(x.str())));
+        children.push_back(ExpressionTreeNode(new Operation::Variable(y.str())));
+        children.push_back(ExpressionTreeNode(new Operation::Variable(z.str())));
+    }
+    if (op.getName() == "distance")
+        return ExpressionTreeNode(new Operation::Custom("pointdistance", functions.at("pointdistance")->clone()), children);
+    if (op.getName() == "angle")
+        return ExpressionTreeNode(new Operation::Custom("pointangle", functions.at("pointangle")->clone()), children);
+    if (op.getName() == "dihedral")
+        return ExpressionTreeNode(new Operation::Custom("pointdihedral", functions.at("pointdihedral")->clone()), children);
+    throw OpenMMException("Internal error.  Unexpected function '"+op.getName()+"'");
 }
 
 void CustomCompoundBondForceImpl::updateParametersInContext(ContextImpl& context) {

--- a/openmmapi/src/CustomCompoundBondForceImpl.cpp
+++ b/openmmapi/src/CustomCompoundBondForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2012 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *

--- a/openmmapi/src/CustomCompoundBondForceImpl.cpp
+++ b/openmmapi/src/CustomCompoundBondForceImpl.cpp
@@ -126,14 +126,22 @@ map<string, double> CustomCompoundBondForceImpl::getDefaultParameters() {
 
 ParsedExpression CustomCompoundBondForceImpl::prepareExpression(const CustomCompoundBondForce& force, const map<string, CustomFunction*>& customFunctions, map<string, vector<int> >& distances,
         map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
-    CustomCompoundBondForceImpl::FunctionPlaceholder custom(1);
     CustomCompoundBondForceImpl::FunctionPlaceholder distance(2);
     CustomCompoundBondForceImpl::FunctionPlaceholder angle(3);
     CustomCompoundBondForceImpl::FunctionPlaceholder dihedral(4);
+    CustomCompoundBondForceImpl::FunctionPlaceholder pointdistance(6);
+    CustomCompoundBondForceImpl::FunctionPlaceholder pointangle(9);
+    CustomCompoundBondForceImpl::FunctionPlaceholder pointdihedral(12);
     map<string, CustomFunction*> functions = customFunctions;
     functions["distance"] = &distance;
     functions["angle"] = &angle;
     functions["dihedral"] = &dihedral;
+    if (functions.find("pointdistance") == functions.end())
+        functions["pointdistance"] = &pointdistance;
+    if (functions.find("pointangle") == functions.end())
+        functions["pointangle"] = &pointangle;
+    if (functions.find("pointdihedral") == functions.end())
+        functions["pointdihedral"] = &pointdihedral;
     ParsedExpression expression = Lepton::Parser::parse(force.getEnergyFunction(), functions);
     map<string, int> atoms;
     set<string> variables;
@@ -162,7 +170,7 @@ ExpressionTreeNode CustomCompoundBondForceImpl::replaceFunctions(const Expressio
         throw OpenMMException("CustomCompoundBondForce: Unknown variable '"+op.getName()+"'");
     if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral"))
     {
-        // This is not an angle or dihedral, so process its children.
+        // The arguments are not particle identifiers, so process its children.
 
         vector<ExpressionTreeNode> children;
         for (auto& child : node.getChildren())

--- a/openmmapi/src/CustomManyParticleForceImpl.cpp
+++ b/openmmapi/src/CustomManyParticleForceImpl.cpp
@@ -153,8 +153,7 @@ map<string, double> CustomManyParticleForceImpl::getDefaultParameters() {
     return parameters;
 }
 
-ParsedExpression CustomManyParticleForceImpl::prepareExpression(const CustomManyParticleForce& force, const map<string, CustomFunction*>& customFunctions, map<string, vector<int> >& distances,
-        map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
+ParsedExpression CustomManyParticleForceImpl::prepareExpression(const CustomManyParticleForce& force, const map<string, CustomFunction*>& customFunctions) {
     CustomManyParticleForceImpl::FunctionPlaceholder distance(2);
     CustomManyParticleForceImpl::FunctionPlaceholder angle(3);
     CustomManyParticleForceImpl::FunctionPlaceholder dihedral(4);
@@ -192,21 +191,20 @@ ParsedExpression CustomManyParticleForceImpl::prepareExpression(const CustomMany
     }
     for (int i = 0; i < force.getNumGlobalParameters(); i++)
         variables.insert(force.getGlobalParameterName(i));
-    return ParsedExpression(replaceFunctions(expression.getRootNode(), atoms, distances, angles, dihedrals, variables)).optimize();
+    return ParsedExpression(replaceFunctions(expression.getRootNode(), atoms, functions, variables)).optimize();
 }
 
 ExpressionTreeNode CustomManyParticleForceImpl::replaceFunctions(const ExpressionTreeNode& node, map<string, int> atoms,
-        map<string, vector<int> >& distances, map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals, set<string>& variables) {
+        const map<string, CustomFunction*>& functions, set<string>& variables) {
     const Operation& op = node.getOperation();
     if (op.getId() == Operation::VARIABLE && variables.find(op.getName()) == variables.end())
         throw OpenMMException("CustomManyParticleForce: Unknown variable '"+op.getName()+"'");
-    if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral"))
-    {
+    vector<ExpressionTreeNode> children;
+    if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral")) {
         // The arguments are not particle identifiers, so process its children.
 
-        vector<ExpressionTreeNode> children;
         for (auto& child : node.getChildren())
-            children.push_back(replaceFunctions(child, atoms, distances, angles, dihedrals, variables));
+            children.push_back(replaceFunctions(child, atoms, functions, variables));
         return ExpressionTreeNode(op.clone(), children);
     }
     const Operation::Custom& custom = static_cast<const Operation::Custom&>(op);
@@ -221,29 +219,25 @@ ExpressionTreeNode CustomManyParticleForceImpl::replaceFunctions(const Expressio
             throw OpenMMException("CustomManyParticleForce: Unknown particle '"+node.getChildren()[i].getOperation().getName()+"'");
         indices[i] = iter->second;
     }
-    
-    // Select a name for the variable and add it to the appropriate map.
-    
-    stringstream variable;
-    if (numArgs == 2)
-        variable << "distance";
-    else if (numArgs == 3)
-        variable << "angle";
-    else
-        variable << "dihedral";
-    for (int i = 0; i < numArgs; i++)
-        variable << indices[i];
-    string name = variable.str();
-    if (numArgs == 2)
-        distances[name] = indices;
-    else if (numArgs == 3)
-        angles[name] = indices;
-    else
-        dihedrals[name] = indices;
-    
-    // Return a new node that represents it as a simple variable.
-    
-    return ExpressionTreeNode(new Operation::Variable(name));
+
+    // Replace it by the corresponding point based function.
+
+    for (int i = 0; i < numArgs; i++) {
+        stringstream x, y, z;
+        x << 'x' << (indices[i]+1);
+        y << 'y' << (indices[i]+1);
+        z << 'z' << (indices[i]+1);
+        children.push_back(ExpressionTreeNode(new Operation::Variable(x.str())));
+        children.push_back(ExpressionTreeNode(new Operation::Variable(y.str())));
+        children.push_back(ExpressionTreeNode(new Operation::Variable(z.str())));
+    }
+    if (op.getName() == "distance")
+        return ExpressionTreeNode(new Operation::Custom("pointdistance", functions.at("pointdistance")->clone()), children);
+    if (op.getName() == "angle")
+        return ExpressionTreeNode(new Operation::Custom("pointangle", functions.at("pointangle")->clone()), children);
+    if (op.getName() == "dihedral")
+        return ExpressionTreeNode(new Operation::Custom("pointdihedral", functions.at("pointdihedral")->clone()), children);
+    throw OpenMMException("Internal error.  Unexpected function '"+op.getName()+"'");
 }
 
 void CustomManyParticleForceImpl::updateParametersInContext(ContextImpl& context) {

--- a/openmmapi/src/CustomManyParticleForceImpl.cpp
+++ b/openmmapi/src/CustomManyParticleForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -155,14 +155,22 @@ map<string, double> CustomManyParticleForceImpl::getDefaultParameters() {
 
 ParsedExpression CustomManyParticleForceImpl::prepareExpression(const CustomManyParticleForce& force, const map<string, CustomFunction*>& customFunctions, map<string, vector<int> >& distances,
         map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
-    CustomManyParticleForceImpl::FunctionPlaceholder custom(1);
     CustomManyParticleForceImpl::FunctionPlaceholder distance(2);
     CustomManyParticleForceImpl::FunctionPlaceholder angle(3);
     CustomManyParticleForceImpl::FunctionPlaceholder dihedral(4);
+    CustomManyParticleForceImpl::FunctionPlaceholder pointdistance(6);
+    CustomManyParticleForceImpl::FunctionPlaceholder pointangle(9);
+    CustomManyParticleForceImpl::FunctionPlaceholder pointdihedral(12);
     map<string, CustomFunction*> functions = customFunctions;
     functions["distance"] = &distance;
     functions["angle"] = &angle;
     functions["dihedral"] = &dihedral;
+    if (functions.find("pointdistance") == functions.end())
+        functions["pointdistance"] = &pointdistance;
+    if (functions.find("pointangle") == functions.end())
+        functions["pointangle"] = &pointangle;
+    if (functions.find("pointdihedral") == functions.end())
+        functions["pointdihedral"] = &pointdihedral;
     ParsedExpression expression = Lepton::Parser::parse(force.getEnergyFunction(), functions);
     map<string, int> atoms;
     set<string> variables;
@@ -194,7 +202,7 @@ ExpressionTreeNode CustomManyParticleForceImpl::replaceFunctions(const Expressio
         throw OpenMMException("CustomManyParticleForce: Unknown variable '"+op.getName()+"'");
     if (op.getId() != Operation::CUSTOM || (op.getName() != "distance" && op.getName() != "angle" && op.getName() != "dihedral"))
     {
-        // This is not an angle or dihedral, so process its children.
+        // The arguments are not particle identifiers, so process its children.
 
         vector<ExpressionTreeNode> children;
         for (auto& child : node.getChildren())

--- a/platforms/common/include/openmm/common/ExpressionUtilities.h
+++ b/platforms/common/include/openmm/common/ExpressionUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -57,10 +57,12 @@ public:
      * @param functionNames  defines the variable name for each tabulated function that may appear in the expressions
      * @param prefix         a prefix to put in front of temporary variables
      * @param tempType       the type of value to use for temporary variables (defaults to "real")
+     * @param distancesArePeriodic   whether the distances in pointdistance(), pointangle(), and pointdihedral() functions
+     *                               should have periodic boundary conditions applied
      */
     std::string createExpressions(const std::map<std::string, Lepton::ParsedExpression>& expressions, const std::map<std::string, std::string>& variables,
             const std::vector<const TabulatedFunction*>& functions, const std::vector<std::pair<std::string, std::string> >& functionNames,
-            const std::string& prefix, const std::string& tempType="real");
+            const std::string& prefix, const std::string& tempType="real", bool distancesArePeriodic=false);
     /**
      * Generate the source code for calculating a set of expressions.
      *
@@ -71,10 +73,12 @@ public:
      * @param functionNames  defines the variable name for each tabulated function that may appear in the expressions
      * @param prefix         a prefix to put in front of temporary variables
      * @param tempType       the type of value to use for temporary variables (defaults to "real")
+     * @param distancesArePeriodic   whether the distances in pointdistance(), pointangle(), and pointdihedral() functions
+     *                               should have periodic boundary conditions applied
      */
     std::string createExpressions(const std::map<std::string, Lepton::ParsedExpression>& expressions, const std::vector<std::pair<Lepton::ExpressionTreeNode, std::string> >& variables,
             const std::vector<const TabulatedFunction*>& functions, const std::vector<std::pair<std::string, std::string> >& functionNames,
-            const std::string& prefix, const std::string& tempType="real");
+            const std::string& prefix, const std::string& tempType="real", bool distancesArePeriodic=false);
     /**
      * Calculate the spline coefficients for a tabulated function that appears in expressions.
      *
@@ -116,7 +120,8 @@ private:
     void processExpression(std::stringstream& out, const Lepton::ExpressionTreeNode& node,
             std::vector<std::pair<Lepton::ExpressionTreeNode, std::string> >& temps,
             const std::vector<const TabulatedFunction*>& functions, const std::vector<std::pair<std::string, std::string> >& functionNames,
-            const std::string& prefix, const std::vector<std::vector<double> >& functionParams, const std::vector<Lepton::ParsedExpression>& allExpressions, const std::string& tempType);
+            const std::string& prefix, const std::vector<std::vector<double> >& functionParams, const std::vector<Lepton::ParsedExpression>& allExpressions,
+            const std::string& tempType, bool distancesArePeriodic);
     std::string getTempName(const Lepton::ExpressionTreeNode& node, const std::vector<std::pair<Lepton::ExpressionTreeNode, std::string> >& temps);
     void findRelatedCustomFunctions(const Lepton::ExpressionTreeNode& node, const Lepton::ExpressionTreeNode& searchNode,
             std::vector<const Lepton::ExpressionTreeNode*>& nodes);
@@ -124,6 +129,8 @@ private:
             std::map<int, const Lepton::ExpressionTreeNode*>& powers);
     void callFunction(std::stringstream& out, std::string singleFn, std::string doubleFn, const std::string& arg, const std::string& tempType);
     void callFunction2(std::stringstream& out, std::string singleFn, std::string doubleFn, const std::string& arg1, const std::string& arg2, const std::string& tempType);
+    void computeDelta(std::stringstream& out, const std::string& varName, const Lepton::ExpressionTreeNode& node, int index1, int index2, const std::string& tempType,
+            bool periodic, const std::vector<std::pair<Lepton::ExpressionTreeNode, std::string> >& temps);
     std::vector<std::vector<double> > computeFunctionParameters(const std::vector<const TabulatedFunction*>& functions);
     ComputeContext& context;
     FunctionPlaceholder fp1, fp2, fp3, periodicDistance;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -1284,86 +1284,11 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         }
     }
 
-    // Now to generate the kernel.  First, it needs to calculate all distances, angles,
-    // and dihedrals the expression depends on.
+    // Generate the kernel.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpression = CustomCompoundBondForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpression = CustomCompoundBondForceImpl::prepareExpression(force, functions);
     map<string, Lepton::ParsedExpression> forceExpressions;
-    set<string> computedDeltas;
-    vector<string> atomNames, posNames;
-    for (int i = 0; i < particlesPerBond; i++) {
-        string index = cc.intToString(i+1);
-        atomNames.push_back("P"+index);
-        posNames.push_back("pos"+index);
-    }
     stringstream compute;
-    int index = 0;
-    for (auto& distance : distances) {
-        const vector<int>& atoms = distance.second;
-        string deltaName = atomNames[atoms[0]]+atomNames[atoms[1]];
-        if (computedDeltas.count(deltaName) == 0) {
-            compute<<"real4 delta"<<deltaName<<" = delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName);
-        }
-        compute<<"real r_"<<deltaName<<" = SQRT(delta"<<deltaName<<".w);\n";
-        variables[distance.first] = "r_"+deltaName;
-        forceExpressions["real dEdDistance"+cc.intToString(index)+" = "] = energyExpression.differentiate(distance.first).optimize();
-        index++;
-    }
-    index = 0;
-    for (auto& angle : angles) {
-        const vector<int>& atoms = angle.second;
-        string deltaName1 = atomNames[atoms[1]]+atomNames[atoms[0]];
-        string deltaName2 = atomNames[atoms[1]]+atomNames[atoms[2]];
-        string angleName = "angle_"+atomNames[atoms[0]]+atomNames[atoms[1]]+atomNames[atoms[2]];
-        if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[0]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName1);
-        }
-        if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[2]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName2);
-        }
-        compute<<"real "<<angleName<<" = computeAngle(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        variables[angle.first] = angleName;
-        forceExpressions["real dEdAngle"+cc.intToString(index)+" = "] = energyExpression.differentiate(angle.first).optimize();
-        index++;
-    }
-    index = 0;
-    for (auto& dihedral : dihedrals) {
-        const vector<int>& atoms = dihedral.second;
-        string deltaName1 = atomNames[atoms[0]]+atomNames[atoms[1]];
-        string deltaName2 = atomNames[atoms[2]]+atomNames[atoms[1]];
-        string deltaName3 = atomNames[atoms[2]]+atomNames[atoms[3]];
-        string crossName1 = "cross_"+deltaName1+"_"+deltaName2;
-        string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
-        string dihedralName = "dihedral_"+atomNames[atoms[0]]+atomNames[atoms[1]]+atomNames[atoms[2]]+atomNames[atoms[3]];
-        if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName1);
-        }
-        if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName2);
-        }
-        if (computedDeltas.count(deltaName3) == 0) {
-            compute<<"real4 delta"<<deltaName3<<" = delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[3]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName3);
-        }
-        compute<<"real4 "<<crossName1<<" = computeCross(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        compute<<"real4 "<<crossName2<<" = computeCross(delta"<<deltaName2<<", delta"<<deltaName3<<");\n";
-        compute<<"real "<<dihedralName<<" = computeAngle("<<crossName1<<", "<<crossName2<<");\n";
-        compute<<dihedralName<<" *= (delta"<<deltaName1<<".x*"<<crossName2<<".x + delta"<<deltaName1<<".y*"<<crossName2<<".y + delta"<<deltaName1<<".z*"<<crossName2<<".z < 0 ? -1 : 1);\n";
-        variables[dihedral.first] = dihedralName;
-        forceExpressions["real dEdDihedral"+cc.intToString(index)+" = "] = energyExpression.differentiate(dihedral.first).optimize();
-        index++;
-    }
-
-    // Now evaluate the expressions.
-
     for (int i = 0; i < (int) params->getParameterInfos().size(); i++) {
         ComputeParameterInfo& parameter = params->getParameterInfos()[i];
         string argName = cc.getBondedUtilities().addArgument(parameter.getArray(), parameter.getType());
@@ -1376,9 +1301,6 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         Lepton::ParsedExpression derivExpression = energyExpression.differentiate(paramName).optimize();
         forceExpressions[derivVariable+" += "] = derivExpression;
     }
-
-    // Finally, apply forces to atoms.
-
     vector<string> forceNames;
     for (int i = 0; i < particlesPerBond; i++) {
         string istr = cc.intToString(i+1);
@@ -1396,57 +1318,6 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
             forceExpressions[forceName+".z -= "] = forceExpressionZ;
     }
     compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
-    index = 0;
-    for (auto& distance : distances) {
-        const vector<int>& atoms = distance.second;
-        string deltaName = atomNames[atoms[0]]+atomNames[atoms[1]];
-        string value = "(dEdDistance"+cc.intToString(index)+"/r_"+deltaName+")*trimTo3(delta"+deltaName+")";
-        compute<<forceNames[atoms[0]]<<" += "<<"-"<<value<<";\n";
-        compute<<forceNames[atoms[1]]<<" += "<<value<<";\n";
-        index++;
-    }
-    index = 0;
-    for (auto& angle : angles) {
-        const vector<int>& atoms = angle.second;
-        string deltaName1 = atomNames[atoms[1]]+atomNames[atoms[0]];
-        string deltaName2 = atomNames[atoms[1]]+atomNames[atoms[2]];
-        compute<<"{\n";
-        compute<<"real3 crossProd = trimTo3(cross(delta"<<deltaName2<<", delta"<<deltaName1<<"));\n";
-        compute<<"real lengthCross = max(SQRT(dot(crossProd, crossProd)), (real) 1e-6f);\n";
-        compute<<"real3 deltaCross0 = -cross(trimTo3(delta"<<deltaName1<<"), crossProd)*dEdAngle"<<cc.intToString(index)<<"/(delta"<<deltaName1<<".w*lengthCross);\n";
-        compute<<"real3 deltaCross2 = cross(trimTo3(delta"<<deltaName2<<"), crossProd)*dEdAngle"<<cc.intToString(index)<<"/(delta"<<deltaName2<<".w*lengthCross);\n";
-        compute<<"real3 deltaCross1 = -(deltaCross0+deltaCross2);\n";
-        compute<<forceNames[atoms[0]]<<" += deltaCross0;\n";
-        compute<<forceNames[atoms[1]]<<" += deltaCross1;\n";
-        compute<<forceNames[atoms[2]]<<" += deltaCross2;\n";
-        compute<<"}\n";
-        index++;
-    }
-    index = 0;
-    for (auto& dihedral : dihedrals) {
-        const vector<int>& atoms = dihedral.second;
-        string deltaName1 = atomNames[atoms[0]]+atomNames[atoms[1]];
-        string deltaName2 = atomNames[atoms[2]]+atomNames[atoms[1]];
-        string deltaName3 = atomNames[atoms[2]]+atomNames[atoms[3]];
-        string crossName1 = "cross_"+deltaName1+"_"+deltaName2;
-        string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
-        compute<<"{\n";
-        compute<<"real r = SQRT(delta"<<deltaName2<<".w);\n";
-        compute<<"real4 ff;\n";
-        compute<<"ff.x = (-dEdDihedral"<<cc.intToString(index)<<"*r)/"<<crossName1<<".w;\n";
-        compute<<"ff.y = (delta"<<deltaName1<<".x*delta"<<deltaName2<<".x + delta"<<deltaName1<<".y*delta"<<deltaName2<<".y + delta"<<deltaName1<<".z*delta"<<deltaName2<<".z)/delta"<<deltaName2<<".w;\n";
-        compute<<"ff.z = (delta"<<deltaName3<<".x*delta"<<deltaName2<<".x + delta"<<deltaName3<<".y*delta"<<deltaName2<<".y + delta"<<deltaName3<<".z*delta"<<deltaName2<<".z)/delta"<<deltaName2<<".w;\n";
-        compute<<"ff.w = (dEdDihedral"<<cc.intToString(index)<<"*r)/"<<crossName2<<".w;\n";
-        compute<<"real3 internalF0 = ff.x*trimTo3("<<crossName1<<");\n";
-        compute<<"real3 internalF3 = ff.w*trimTo3("<<crossName2<<");\n";
-        compute<<"real3 s = ff.y*internalF0 - ff.z*internalF3;\n";
-        compute<<forceNames[atoms[0]]<<" += internalF0;\n";
-        compute<<forceNames[atoms[1]]<<" += s-internalF0;\n";
-        compute<<forceNames[atoms[2]]<<" += -s-internalF3;\n";
-        compute<<forceNames[atoms[3]]<<" += internalF3;\n";
-        compute<<"}\n";
-        index++;
-    }
     cc.getBondedUtilities().addInteraction(atoms, compute.str(), force.getForceGroup());
     map<string, string> replacements;
     replacements["M_PI"] = cc.doubleToString(M_PI);
@@ -1665,90 +1536,15 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
         }
     }
 
-    // Now to generate the kernel.  First, it needs to calculate all distances, angles,
-    // and dihedrals the expression depends on.
+    // Generate the kernel.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpression = CustomCentroidBondForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpression = CustomCentroidBondForceImpl::prepareExpression(force, functions);
     map<string, Lepton::ParsedExpression> forceExpressions;
-    set<string> computedDeltas;
-    vector<string> atomNames, posNames;
-    for (int i = 0; i < groupsPerBond; i++) {
-        string index = cc.intToString(i+1);
-        atomNames.push_back("P"+index);
-        posNames.push_back("pos"+index);
-    }
     stringstream compute, initParamDerivs, saveParamDerivs;
     for (int i = 0; i < groupsPerBond; i++) {
         compute<<"int group"<<(i+1)<<" = bondGroups[index+"<<(i*numBonds)<<"];\n";
         compute<<"real4 pos"<<(i+1)<<" = centerPositions[group"<<(i+1)<<"];\n";
     }
-    int index = 0;
-    for (auto& distance : distances) {
-        const vector<int>& groups = distance.second;
-        string deltaName = atomNames[groups[0]]+atomNames[groups[1]];
-        if (computedDeltas.count(deltaName) == 0) {
-            compute<<"real4 delta"<<deltaName<<" = delta("<<posNames[groups[0]]<<", "<<posNames[groups[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName);
-        }
-        compute<<"real r_"<<deltaName<<" = sqrt(delta"<<deltaName<<".w);\n";
-        variables[distance.first] = "r_"+deltaName;
-        forceExpressions["real dEdDistance"+cc.intToString(index)+" = "] = energyExpression.differentiate(distance.first).optimize();
-        index++;
-    }
-    index = 0;
-    for (auto& angle : angles) {
-        const vector<int>& groups = angle.second;
-        string deltaName1 = atomNames[groups[1]]+atomNames[groups[0]];
-        string deltaName2 = atomNames[groups[1]]+atomNames[groups[2]];
-        string angleName = "angle_"+atomNames[groups[0]]+atomNames[groups[1]]+atomNames[groups[2]];
-        if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[groups[1]]<<", "<<posNames[groups[0]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName1);
-        }
-        if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[groups[1]]<<", "<<posNames[groups[2]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName2);
-        }
-        compute<<"real "<<angleName<<" = computeAngle(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        variables[angle.first] = angleName;
-        forceExpressions["real dEdAngle"+cc.intToString(index)+" = "] = energyExpression.differentiate(angle.first).optimize();
-        index++;
-    }
-    index = 0;
-    for (auto& dihedral : dihedrals) {
-        const vector<int>& groups = dihedral.second;
-        string deltaName1 = atomNames[groups[0]]+atomNames[groups[1]];
-        string deltaName2 = atomNames[groups[2]]+atomNames[groups[1]];
-        string deltaName3 = atomNames[groups[2]]+atomNames[groups[3]];
-        string crossName1 = "cross_"+deltaName1+"_"+deltaName2;
-        string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
-        string dihedralName = "dihedral_"+atomNames[groups[0]]+atomNames[groups[1]]+atomNames[groups[2]]+atomNames[groups[3]];
-        if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[groups[0]]<<", "<<posNames[groups[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName1);
-        }
-        if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[groups[2]]<<", "<<posNames[groups[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName2);
-        }
-        if (computedDeltas.count(deltaName3) == 0) {
-            compute<<"real4 delta"<<deltaName3<<" = delta("<<posNames[groups[2]]<<", "<<posNames[groups[3]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName3);
-        }
-        compute<<"real4 "<<crossName1<<" = computeCross(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        compute<<"real4 "<<crossName2<<" = computeCross(delta"<<deltaName2<<", delta"<<deltaName3<<");\n";
-        compute<<"real "<<dihedralName<<" = computeAngle("<<crossName1<<", "<<crossName2<<");\n";
-        compute<<dihedralName<<" *= (delta"<<deltaName1<<".x*"<<crossName2<<".x + delta"<<deltaName1<<".y*"<<crossName2<<".y + delta"<<deltaName1<<".z*"<<crossName2<<".z < 0 ? -1 : 1);\n";
-        variables[dihedral.first] = dihedralName;
-        forceExpressions["real dEdDihedral"+cc.intToString(index)+" = "] = energyExpression.differentiate(dihedral.first).optimize();
-        index++;
-    }
-
-    // Now evaluate the expressions.
-
     for (int i = 0; i < (int) params->getParameterInfos().size(); i++) {
         ComputeParameterInfo& parameter = params->getParameterInfos()[i];
         extraArgs<<", GLOBAL const "<<parameter.getType()<<"* RESTRICT globalParams"<<i;
@@ -1770,9 +1566,6 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
                 if (allParamDerivNames[index] == force.getEnergyParameterDerivativeName(i))
                     saveParamDerivs << "energyParamDerivs[GLOBAL_ID*" << numDerivs << "+" << index << "] += energyParamDeriv" << i << ";\n";
     }
-
-    // Finally, apply forces to groups.
-
     vector<string> forceNames;
     for (int i = 0; i < groupsPerBond; i++) {
         string istr = cc.intToString(i+1);
@@ -1790,57 +1583,6 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
             forceExpressions[forceName+".z -= "] = forceExpressionZ;
     }
     compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
-    index = 0;
-    for (auto& distance : distances) {
-        const vector<int>& groups = distance.second;
-        string deltaName = atomNames[groups[0]]+atomNames[groups[1]];
-        string value = "(dEdDistance"+cc.intToString(index)+"/r_"+deltaName+")*trimTo3(delta"+deltaName+")";
-        compute<<forceNames[groups[0]]<<" += "<<"-"<<value<<";\n";
-        compute<<forceNames[groups[1]]<<" += "<<value<<";\n";
-        index++;
-    }
-    index = 0;
-    for (auto& angle : angles) {
-        const vector<int>& groups = angle.second;
-        string deltaName1 = atomNames[groups[1]]+atomNames[groups[0]];
-        string deltaName2 = atomNames[groups[1]]+atomNames[groups[2]];
-        compute<<"{\n";
-        compute<<"real3 crossProd = trimTo3(cross(delta"<<deltaName2<<", delta"<<deltaName1<<"));\n";
-        compute<<"real lengthCross = max(SQRT(dot(crossProd, crossProd)), (real) 1e-6f);\n";
-        compute<<"real3 deltaCross0 = -cross(trimTo3(delta"<<deltaName1<<"), crossProd)*dEdAngle"<<cc.intToString(index)<<"/(delta"<<deltaName1<<".w*lengthCross);\n";
-        compute<<"real3 deltaCross2 = cross(trimTo3(delta"<<deltaName2<<"), crossProd)*dEdAngle"<<cc.intToString(index)<<"/(delta"<<deltaName2<<".w*lengthCross);\n";
-        compute<<"real3 deltaCross1 = -(deltaCross0+deltaCross2);\n";
-        compute<<forceNames[groups[0]]<<" += deltaCross0;\n";
-        compute<<forceNames[groups[1]]<<" += deltaCross1;\n";
-        compute<<forceNames[groups[2]]<<" += deltaCross2;\n";
-        compute<<"}\n";
-        index++;
-    }
-    index = 0;
-    for (auto& dihedral : dihedrals) {
-        const vector<int>& groups = dihedral.second;
-        string deltaName1 = atomNames[groups[0]]+atomNames[groups[1]];
-        string deltaName2 = atomNames[groups[2]]+atomNames[groups[1]];
-        string deltaName3 = atomNames[groups[2]]+atomNames[groups[3]];
-        string crossName1 = "cross_"+deltaName1+"_"+deltaName2;
-        string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
-        compute<<"{\n";
-        compute<<"real r = sqrt(delta"<<deltaName2<<".w);\n";
-        compute<<"real4 ff;\n";
-        compute<<"ff.x = (-dEdDihedral"<<cc.intToString(index)<<"*r)/"<<crossName1<<".w;\n";
-        compute<<"ff.y = (delta"<<deltaName1<<".x*delta"<<deltaName2<<".x + delta"<<deltaName1<<".y*delta"<<deltaName2<<".y + delta"<<deltaName1<<".z*delta"<<deltaName2<<".z)/delta"<<deltaName2<<".w;\n";
-        compute<<"ff.z = (delta"<<deltaName3<<".x*delta"<<deltaName2<<".x + delta"<<deltaName3<<".y*delta"<<deltaName2<<".y + delta"<<deltaName3<<".z*delta"<<deltaName2<<".z)/delta"<<deltaName2<<".w;\n";
-        compute<<"ff.w = (dEdDihedral"<<cc.intToString(index)<<"*r)/"<<crossName2<<".w;\n";
-        compute<<"real3 internalF0 = ff.x*trimTo3("<<crossName1<<");\n";
-        compute<<"real3 internalF3 = ff.w*trimTo3("<<crossName2<<");\n";
-        compute<<"real3 s = ff.y*internalF0 - ff.z*internalF3;\n";
-        compute<<forceNames[groups[0]]<<" += internalF0;\n";
-        compute<<forceNames[groups[1]]<<" += s-internalF0;\n";
-        compute<<forceNames[groups[2]]<<" += -s-internalF3;\n";
-        compute<<forceNames[groups[3]]<<" += internalF3;\n";
-        compute<<"}\n";
-        index++;
-    }
     
     // Save the forces to global memory.
     
@@ -4554,94 +4296,16 @@ void CommonCalcCustomManyParticleForceKernel::initialize(const System& system, c
         neighbors.initialize<int>(cc, maxNeighborPairs, "customManyParticleNeighbors");
     }
 
-    // Now to generate the kernel.  First, it needs to calculate all distances, angles,
-    // and dihedrals the expression depends on.
+    // Generate the kernel.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpression = CustomManyParticleForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpression = CustomManyParticleForceImpl::prepareExpression(force, functions);
     map<string, Lepton::ParsedExpression> forceExpressions;
-    set<string> computedDeltas;
-    vector<string> atomNames, posNames;
-    for (int i = 0; i < particlesPerSet; i++) {
-        string index = cc.intToString(i+1);
-        atomNames.push_back("P"+index);
-        posNames.push_back("pos"+index);
-    }
     stringstream compute;
-    int index = 0;
-    for (auto& distance : distances) {
-        const vector<int>& atoms = distance.second;
-        string deltaName = atomNames[atoms[0]]+atomNames[atoms[1]];
-        if (computedDeltas.count(deltaName) == 0) {
-            compute<<"real4 delta"<<deltaName<<" = delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName);
-        }
-        compute<<"real r_"<<deltaName<<" = sqrt(delta"<<deltaName<<".w);\n";
-        variables.push_back(makeVariable(distance.first, "r_"+deltaName));
-        forceExpressions["real dEdDistance"+cc.intToString(index)+" = "] = energyExpression.differentiate(distance.first).optimize();
-        index++;
-    }
-    index = 0;
-    for (auto& angle : angles) {
-        const vector<int>& atoms = angle.second;
-        string deltaName1 = atomNames[atoms[1]]+atomNames[atoms[0]];
-        string deltaName2 = atomNames[atoms[1]]+atomNames[atoms[2]];
-        string angleName = "angle_"+atomNames[atoms[0]]+atomNames[atoms[1]]+atomNames[atoms[2]];
-        if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[0]]<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName1);
-        }
-        if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[2]]<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName2);
-        }
-        compute<<"real "<<angleName<<" = computeAngle(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        variables.push_back(makeVariable(angle.first, angleName));
-        forceExpressions["real dEdAngle"+cc.intToString(index)+" = "] = energyExpression.differentiate(angle.first).optimize();
-        index++;
-    }
-    index = 0;
-    for (auto& dihedral : dihedrals) {
-        const vector<int>& atoms = dihedral.second;
-        string deltaName1 = atomNames[atoms[0]]+atomNames[atoms[1]];
-        string deltaName2 = atomNames[atoms[2]]+atomNames[atoms[1]];
-        string deltaName3 = atomNames[atoms[2]]+atomNames[atoms[3]];
-        string crossName1 = "cross_"+deltaName1+"_"+deltaName2;
-        string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
-        string dihedralName = "dihedral_"+atomNames[atoms[0]]+atomNames[atoms[1]]+atomNames[atoms[2]]+atomNames[atoms[3]];
-        if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName1);
-        }
-        if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[1]]<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName2);
-        }
-        if (computedDeltas.count(deltaName3) == 0) {
-            compute<<"real4 delta"<<deltaName3<<" = delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[3]]<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
-            computedDeltas.insert(deltaName3);
-        }
-        compute<<"real4 "<<crossName1<<" = computeCross(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        compute<<"real4 "<<crossName2<<" = computeCross(delta"<<deltaName2<<", delta"<<deltaName3<<");\n";
-        compute<<"real "<<dihedralName<<" = computeAngle("<<crossName1<<", "<<crossName2<<");\n";
-        compute<<dihedralName<<" *= (delta"<<deltaName1<<".x*"<<crossName2<<".x + delta"<<deltaName1<<".y*"<<crossName2<<".y + delta"<<deltaName1<<".z*"<<crossName2<<".z < 0 ? -1 : 1);\n";
-        variables.push_back(makeVariable(dihedral.first, dihedralName));
-        forceExpressions["real dEdDihedral"+cc.intToString(index)+" = "] = energyExpression.differentiate(dihedral.first).optimize();
-        index++;
-    }
-
-    // Now evaluate the expressions.
-
     for (int i = 0; i < (int) params->getParameterInfos().size(); i++) {
         ComputeParameterInfo& parameter = params->getParameterInfos()[i];
         compute<<parameter.getType()<<" params"<<(i+1)<<" = global_params"<<(i+1)<<"[index];\n";
     }
     forceExpressions["energy += "] = energyExpression;
-
-    // Apply forces to atoms.
-
     vector<string> forceNames;
     for (int i = 0; i < particlesPerSet; i++) {
         string istr = cc.intToString(i+1);
@@ -4659,57 +4323,6 @@ void CommonCalcCustomManyParticleForceKernel::initialize(const System& system, c
             forceExpressions[forceName+".z -= "] = forceExpressionZ;
     }
     compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
-    index = 0;
-    for (auto& distance : distances) {
-        const vector<int>& atoms = distance.second;
-        string deltaName = atomNames[atoms[0]]+atomNames[atoms[1]];
-        string value = "(dEdDistance"+cc.intToString(index)+"/r_"+deltaName+")*trimTo3(delta"+deltaName+")";
-        compute<<forceNames[atoms[0]]<<" += "<<"-"<<value<<";\n";
-        compute<<forceNames[atoms[1]]<<" += "<<value<<";\n";
-        index++;
-    }
-    index = 0;
-    for (auto& angle : angles) {
-        const vector<int>& atoms = angle.second;
-        string deltaName1 = atomNames[atoms[1]]+atomNames[atoms[0]];
-        string deltaName2 = atomNames[atoms[1]]+atomNames[atoms[2]];
-        compute<<"{\n";
-        compute<<"real3 crossProd = trimTo3(cross(delta"<<deltaName2<<", delta"<<deltaName1<<"));\n";
-        compute<<"real lengthCross = max(SQRT(dot(crossProd, crossProd)), (real) 1e-6f);\n";
-        compute<<"real3 deltaCross0 = -cross(trimTo3(delta"<<deltaName1<<"), crossProd)*dEdAngle"<<cc.intToString(index)<<"/(delta"<<deltaName1<<".w*lengthCross);\n";
-        compute<<"real3 deltaCross2 = cross(trimTo3(delta"<<deltaName2<<"), crossProd)*dEdAngle"<<cc.intToString(index)<<"/(delta"<<deltaName2<<".w*lengthCross);\n";
-        compute<<"real3 deltaCross1 = -(deltaCross0+deltaCross2);\n";
-        compute<<forceNames[atoms[0]]<<" += deltaCross0;\n";
-        compute<<forceNames[atoms[1]]<<" += deltaCross1;\n";
-        compute<<forceNames[atoms[2]]<<" += deltaCross2;\n";
-        compute<<"}\n";
-        index++;
-    }
-    index = 0;
-    for (auto& dihedral : dihedrals) {
-        const vector<int>& atoms = dihedral.second;
-        string deltaName1 = atomNames[atoms[0]]+atomNames[atoms[1]];
-        string deltaName2 = atomNames[atoms[2]]+atomNames[atoms[1]];
-        string deltaName3 = atomNames[atoms[2]]+atomNames[atoms[3]];
-        string crossName1 = "cross_"+deltaName1+"_"+deltaName2;
-        string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
-        compute<<"{\n";
-        compute<<"real r = sqrt(delta"<<deltaName2<<".w);\n";
-        compute<<"real4 ff;\n";
-        compute<<"ff.x = (-dEdDihedral"<<cc.intToString(index)<<"*r)/"<<crossName1<<".w;\n";
-        compute<<"ff.y = (delta"<<deltaName1<<".x*delta"<<deltaName2<<".x + delta"<<deltaName1<<".y*delta"<<deltaName2<<".y + delta"<<deltaName1<<".z*delta"<<deltaName2<<".z)/delta"<<deltaName2<<".w;\n";
-        compute<<"ff.z = (delta"<<deltaName3<<".x*delta"<<deltaName2<<".x + delta"<<deltaName3<<".y*delta"<<deltaName2<<".y + delta"<<deltaName3<<".z*delta"<<deltaName2<<".z)/delta"<<deltaName2<<".w;\n";
-        compute<<"ff.w = (dEdDihedral"<<cc.intToString(index)<<"*r)/"<<crossName2<<".w;\n";
-        compute<<"real3 internalF0 = ff.x*trimTo3("<<crossName1<<");\n";
-        compute<<"real3 internalF3 = ff.w*trimTo3("<<crossName2<<");\n";
-        compute<<"real3 s = ff.y*internalF0 - ff.z*internalF3;\n";
-        compute<<forceNames[atoms[0]]<<" += internalF0;\n";
-        compute<<forceNames[atoms[1]]<<" += s-internalF0;\n";
-        compute<<forceNames[atoms[2]]<<" += -s-internalF3;\n";
-        compute<<forceNames[atoms[3]]<<" += internalF3;\n";
-        compute<<"}\n";
-        index++;
-    }
     
     // Store forces to global memory.
     

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -1305,7 +1305,7 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         const vector<int>& atoms = distance.second;
         string deltaName = atomNames[atoms[0]]+atomNames[atoms[1]];
         if (computedDeltas.count(deltaName) == 0) {
-            compute<<"real4 delta"<<deltaName<<" = ccb_delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
+            compute<<"real4 delta"<<deltaName<<" = delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
             computedDeltas.insert(deltaName);
         }
         compute<<"real r_"<<deltaName<<" = SQRT(delta"<<deltaName<<".w);\n";
@@ -1320,14 +1320,14 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         string deltaName2 = atomNames[atoms[1]]+atomNames[atoms[2]];
         string angleName = "angle_"+atomNames[atoms[0]]+atomNames[atoms[1]]+atomNames[atoms[2]];
         if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = ccb_delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[0]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
+            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[0]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
             computedDeltas.insert(deltaName1);
         }
         if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = ccb_delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[2]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
+            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[atoms[1]]<<", "<<posNames[atoms[2]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
             computedDeltas.insert(deltaName2);
         }
-        compute<<"real "<<angleName<<" = ccb_computeAngle(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
+        compute<<"real "<<angleName<<" = computeAngle(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
         variables[angle.first] = angleName;
         forceExpressions["real dEdAngle"+cc.intToString(index)+" = "] = energyExpression.differentiate(angle.first).optimize();
         index++;
@@ -1342,20 +1342,20 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         string crossName2 = "cross_"+deltaName2+"_"+deltaName3;
         string dihedralName = "dihedral_"+atomNames[atoms[0]]+atomNames[atoms[1]]+atomNames[atoms[2]]+atomNames[atoms[3]];
         if (computedDeltas.count(deltaName1) == 0) {
-            compute<<"real4 delta"<<deltaName1<<" = ccb_delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
+            compute<<"real4 delta"<<deltaName1<<" = delta("<<posNames[atoms[0]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
             computedDeltas.insert(deltaName1);
         }
         if (computedDeltas.count(deltaName2) == 0) {
-            compute<<"real4 delta"<<deltaName2<<" = ccb_delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
+            compute<<"real4 delta"<<deltaName2<<" = delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[1]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
             computedDeltas.insert(deltaName2);
         }
         if (computedDeltas.count(deltaName3) == 0) {
-            compute<<"real4 delta"<<deltaName3<<" = ccb_delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[3]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
+            compute<<"real4 delta"<<deltaName3<<" = delta("<<posNames[atoms[2]]<<", "<<posNames[atoms[3]]<<", "<<force.usesPeriodicBoundaryConditions()<<", periodicBoxSize, invPeriodicBoxSize, periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ);\n";
             computedDeltas.insert(deltaName3);
         }
-        compute<<"real4 "<<crossName1<<" = ccb_computeCross(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
-        compute<<"real4 "<<crossName2<<" = ccb_computeCross(delta"<<deltaName2<<", delta"<<deltaName3<<");\n";
-        compute<<"real "<<dihedralName<<" = ccb_computeAngle("<<crossName1<<", "<<crossName2<<");\n";
+        compute<<"real4 "<<crossName1<<" = computeCross(delta"<<deltaName1<<", delta"<<deltaName2<<");\n";
+        compute<<"real4 "<<crossName2<<" = computeCross(delta"<<deltaName2<<", delta"<<deltaName3<<");\n";
+        compute<<"real "<<dihedralName<<" = computeAngle("<<crossName1<<", "<<crossName2<<");\n";
         compute<<dihedralName<<" *= (delta"<<deltaName1<<".x*"<<crossName2<<".x + delta"<<deltaName1<<".y*"<<crossName2<<".y + delta"<<deltaName1<<".z*"<<crossName2<<".z < 0 ? -1 : 1);\n";
         variables[dihedral.first] = dihedralName;
         forceExpressions["real dEdDihedral"+cc.intToString(index)+" = "] = energyExpression.differentiate(dihedral.first).optimize();
@@ -1770,7 +1770,6 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
                 if (allParamDerivNames[index] == force.getEnergyParameterDerivativeName(i))
                     saveParamDerivs << "energyParamDerivs[GLOBAL_ID*" << numDerivs << "+" << index << "] += energyParamDeriv" << i << ";\n";
     }
-    compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp");
 
     // Finally, apply forces to groups.
 
@@ -1780,21 +1779,17 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
         string forceName = "force"+istr;
         forceNames.push_back(forceName);
         compute<<"real3 "<<forceName<<" = make_real3(0);\n";
-        compute<<"{\n";
         Lepton::ParsedExpression forceExpressionX = energyExpression.differentiate("x"+istr).optimize();
         Lepton::ParsedExpression forceExpressionY = energyExpression.differentiate("y"+istr).optimize();
         Lepton::ParsedExpression forceExpressionZ = energyExpression.differentiate("z"+istr).optimize();
-        map<string, Lepton::ParsedExpression> expressions;
         if (!isZeroExpression(forceExpressionX))
-            expressions[forceName+".x -= "] = forceExpressionX;
+            forceExpressions[forceName+".x -= "] = forceExpressionX;
         if (!isZeroExpression(forceExpressionY))
-            expressions[forceName+".y -= "] = forceExpressionY;
+            forceExpressions[forceName+".y -= "] = forceExpressionY;
         if (!isZeroExpression(forceExpressionZ))
-            expressions[forceName+".z -= "] = forceExpressionZ;
-        if (expressions.size() > 0)
-            compute<<cc.getExpressionUtilities().createExpressions(expressions, variables, functionList, functionDefinitions, "coordtemp");
-        compute<<"}\n";
+            forceExpressions[forceName+".z -= "] = forceExpressionZ;
     }
+    compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
     index = 0;
     for (auto& distance : distances) {
         const vector<int>& groups = distance.second;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -1376,7 +1376,6 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         Lepton::ParsedExpression derivExpression = energyExpression.differentiate(paramName).optimize();
         forceExpressions[derivVariable+" += "] = derivExpression;
     }
-    compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
 
     // Finally, apply forces to atoms.
 
@@ -1386,21 +1385,17 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         string forceName = "force"+istr;
         forceNames.push_back(forceName);
         compute<<"real3 "<<forceName<<" = make_real3(0);\n";
-        compute<<"{\n";
         Lepton::ParsedExpression forceExpressionX = energyExpression.differentiate("x"+istr).optimize();
         Lepton::ParsedExpression forceExpressionY = energyExpression.differentiate("y"+istr).optimize();
         Lepton::ParsedExpression forceExpressionZ = energyExpression.differentiate("z"+istr).optimize();
-        map<string, Lepton::ParsedExpression> expressions;
         if (!isZeroExpression(forceExpressionX))
-            expressions[forceName+".x -= "] = forceExpressionX;
+            forceExpressions[forceName+".x -= "] = forceExpressionX;
         if (!isZeroExpression(forceExpressionY))
-            expressions[forceName+".y -= "] = forceExpressionY;
+            forceExpressions[forceName+".y -= "] = forceExpressionY;
         if (!isZeroExpression(forceExpressionZ))
-            expressions[forceName+".z -= "] = forceExpressionZ;
-        if (expressions.size() > 0)
-            compute<<cc.getExpressionUtilities().createExpressions(expressions, variables, functionList, functionDefinitions, "coordtemp", "real", force.usesPeriodicBoundaryConditions());
-        compute<<"}\n";
+            forceExpressions[forceName+".z -= "] = forceExpressionZ;
     }
+    compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
     index = 0;
     for (auto& distance : distances) {
         const vector<int>& atoms = distance.second;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -1376,7 +1376,7 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         Lepton::ParsedExpression derivExpression = energyExpression.differentiate(paramName).optimize();
         forceExpressions[derivVariable+" += "] = derivExpression;
     }
-    compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp");
+    compute << cc.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp", "real", force.usesPeriodicBoundaryConditions());
 
     // Finally, apply forces to atoms.
 
@@ -1398,7 +1398,7 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         if (!isZeroExpression(forceExpressionZ))
             expressions[forceName+".z -= "] = forceExpressionZ;
         if (expressions.size() > 0)
-            compute<<cc.getExpressionUtilities().createExpressions(expressions, variables, functionList, functionDefinitions, "coordtemp");
+            compute<<cc.getExpressionUtilities().createExpressions(expressions, variables, functionList, functionDefinitions, "coordtemp", "real", force.usesPeriodicBoundaryConditions());
         compute<<"}\n";
     }
     index = 0;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -1321,7 +1321,7 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
     cc.getBondedUtilities().addInteraction(atoms, compute.str(), force.getForceGroup());
     map<string, string> replacements;
     replacements["M_PI"] = cc.doubleToString(M_PI);
-    cc.getBondedUtilities().addPrefixCode(cc.replaceStrings(CommonKernelSources::customCompoundBond, replacements));
+    cc.getBondedUtilities().addPrefixCode(cc.replaceStrings(CommonKernelSources::pointFunctions, replacements));
 }
 
 double CommonCalcCustomCompoundBondForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
@@ -1600,7 +1600,7 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
     replacements["COMPUTE_FORCE"] = compute.str();
     replacements["INIT_PARAM_DERIVS"] = initParamDerivs.str();
     replacements["SAVE_PARAM_DERIVS"] = saveParamDerivs.str();
-    ComputeProgram program = cc.compileProgram(cc.replaceStrings(CommonKernelSources::customCentroidBond, replacements));
+    ComputeProgram program = cc.compileProgram(cc.replaceStrings(CommonKernelSources::pointFunctions+CommonKernelSources::customCentroidBond, replacements));
     computeCentersKernel = program->createKernel("computeGroupCenters");
     computeCentersKernel->addArg(numGroups);
     computeCentersKernel->addArg(cc.getPosq());
@@ -4457,7 +4457,7 @@ void CommonCalcCustomManyParticleForceKernel::initialize(const System& system, c
     defines["TILE_SIZE"] = cc.intToString(32);
     defines["NUM_BLOCKS"] = cc.intToString(numAtomBlocks);
     defines["FIND_NEIGHBORS_WORKGROUP_SIZE"] = cc.intToString(findNeighborsWorkgroupSize);
-    ComputeProgram program = cc.compileProgram(cc.replaceStrings(CommonKernelSources::customManyParticle, replacements), defines);
+    ComputeProgram program = cc.compileProgram(cc.replaceStrings(CommonKernelSources::pointFunctions+CommonKernelSources::customManyParticle, replacements), defines);
     forceKernel = program->createKernel("computeInteraction");
     blockBoundsKernel = program->createKernel("findBlockBounds");
     neighborsKernel = program->createKernel("findNeighbors");

--- a/platforms/common/src/ExpressionUtilities.cpp
+++ b/platforms/common/src/ExpressionUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -37,15 +37,17 @@ ExpressionUtilities::ExpressionUtilities(ComputeContext& context) : context(cont
 }
 
 string ExpressionUtilities::createExpressions(const map<string, ParsedExpression>& expressions, const map<string, string>& variables,
-        const vector<const TabulatedFunction*>& functions, const vector<pair<string, string> >& functionNames, const string& prefix, const string& tempType) {
+        const vector<const TabulatedFunction*>& functions, const vector<pair<string, string> >& functionNames, const string& prefix,
+        const string& tempType, bool distancesArePeriodic) {
     vector<pair<ExpressionTreeNode, string> > variableNodes;
     for (map<string, string>::const_iterator iter = variables.begin(); iter != variables.end(); ++iter)
         variableNodes.push_back(make_pair(ExpressionTreeNode(new Operation::Variable(iter->first)), iter->second));
-    return createExpressions(expressions, variableNodes, functions, functionNames, prefix, tempType);
+    return createExpressions(expressions, variableNodes, functions, functionNames, prefix, tempType, distancesArePeriodic);
 }
 
 string ExpressionUtilities::createExpressions(const map<string, ParsedExpression>& expressions, const vector<pair<ExpressionTreeNode, string> >& variables,
-        const vector<const TabulatedFunction*>& functions, const vector<pair<string, string> >& functionNames, const string& prefix, const string& tempType) {
+        const vector<const TabulatedFunction*>& functions, const vector<pair<string, string> >& functionNames, const string& prefix, const string& tempType,
+        bool distancesArePeriodic) {
     stringstream out;
     vector<ParsedExpression> allExpressions;
     for (map<string, ParsedExpression>::const_iterator iter = expressions.begin(); iter != expressions.end(); ++iter)
@@ -53,7 +55,7 @@ string ExpressionUtilities::createExpressions(const map<string, ParsedExpression
     vector<pair<ExpressionTreeNode, string> > temps = variables;
     vector<vector<double> > functionParams = computeFunctionParameters(functions);
     for (map<string, ParsedExpression>::const_iterator iter = expressions.begin(); iter != expressions.end(); ++iter) {
-        processExpression(out, iter->second.getRootNode(), temps, functions, functionNames, prefix, functionParams, allExpressions, tempType);
+        processExpression(out, iter->second.getRootNode(), temps, functions, functionNames, prefix, functionParams, allExpressions, tempType, distancesArePeriodic);
         out << iter->first << getTempName(iter->second.getRootNode(), temps) << ";\n";
     }
     return out.str();
@@ -61,12 +63,12 @@ string ExpressionUtilities::createExpressions(const map<string, ParsedExpression
 
 void ExpressionUtilities::processExpression(stringstream& out, const ExpressionTreeNode& node, vector<pair<ExpressionTreeNode, string> >& temps,
         const vector<const TabulatedFunction*>& functions, const vector<pair<string, string> >& functionNames, const string& prefix, const vector<vector<double> >& functionParams,
-        const vector<ParsedExpression>& allExpressions, const string& tempType) {
+        const vector<ParsedExpression>& allExpressions, const string& tempType, bool distancesArePeriodic) {
     for (int i = 0; i < (int) temps.size(); i++)
         if (temps[i].first == node)
             return;
     for (int i = 0; i < (int) node.getChildren().size(); i++)
-        processExpression(out, node.getChildren()[i], temps, functions, functionNames, prefix, functionParams, allExpressions, tempType);
+        processExpression(out, node.getChildren()[i], temps, functions, functionNames, prefix, functionParams, allExpressions, tempType, distancesArePeriodic);
     string name = prefix+context.intToString(temps.size());
     bool hasRecordedNode = false;
     bool isVecType = (tempType[tempType.size()-1] == '3');
@@ -109,43 +111,80 @@ void ExpressionUtilities::processExpression(stringstream& out, const ExpressionT
                 temps.push_back(make_pair(*nodes[j], name2));
             }
             out << "{\n";
-            if (node.getOperation().getName() == "periodicdistance") {
-                // This is the periodicdistance() function.
+            if (node.getOperation().getName() == "pointdistance" || node.getOperation().getName() == "periodicdistance") {
+                // This is a pointdistance() or periodicdistance() function.
 
-                out << tempType << "3 periodicDistance_delta = make_real3(";
-                for (int i = 0; i < 3; i++) {
-                    if (i > 0)
-                        out << ", ";
-                    out << getTempName(node.getChildren()[i], temps) << "-" << getTempName(node.getChildren()[i+3], temps);
-                }
-                out << ");\n";
-                out << "APPLY_PERIODIC_TO_DELTA(periodicDistance_delta)\n";
-                out << tempType << " periodicDistance_r2 = periodicDistance_delta.x*periodicDistance_delta.x + periodicDistance_delta.y*periodicDistance_delta.y + periodicDistance_delta.z*periodicDistance_delta.z;\n";
-                out << tempType << " periodicDistance_rinv = RSQRT(periodicDistance_r2);\n";
+                bool periodic = (node.getOperation().getName() == "periodicdistance" || distancesArePeriodic);
+                computeDelta(out, "pointDistance_delta", node, 0, 3, tempType, periodic, temps);
+                out << tempType << " pointDistance_rinv = RSQRT(pointDistance_delta.w);\n";
                 for (int j = 0; j < nodes.size(); j++) {
                     const vector<int>& derivOrder = dynamic_cast<const Operation::Custom*>(&nodes[j]->getOperation())->getDerivOrder();
                     int argIndex = -1;
                     for (int k = 0; k < 6; k++) {
                         if (derivOrder[k] > 0) {
                             if (derivOrder[k] > 1 || argIndex != -1)
-                                throw OpenMMException("Unsupported derivative of periodicdistance"); // Should be impossible for this to happen.
+                                throw OpenMMException("Unsupported derivative of "+node.getOperation().getName()); // Should be impossible for this to happen.
                             argIndex = k;
                         }
                     }
                     if (argIndex == -1)
-                        out << nodeNames[j] << " = RECIP(periodicDistance_rinv);\n";
+                        out << nodeNames[j] << " = RECIP(pointDistance_rinv);\n";
                     else if (argIndex == 0)
-                        out << nodeNames[j] << " = (periodicDistance_r2 > 0 ? periodicDistance_delta.x*periodicDistance_rinv : 0);\n";
+                        out << nodeNames[j] << " = (pointDistance_delta.w > 0 ? pointDistance_delta.x*pointDistance_rinv : 0);\n";
                     else if (argIndex == 1)
-                        out << nodeNames[j] << " = (periodicDistance_r2 > 0 ? periodicDistance_delta.y*periodicDistance_rinv : 0);\n";
+                        out << nodeNames[j] << " = (pointDistance_delta.w > 0 ? pointDistance_delta.y*pointDistance_rinv : 0);\n";
                     else if (argIndex == 2)
-                        out << nodeNames[j] << " = (periodicDistance_r2 > 0 ? periodicDistance_delta.z*periodicDistance_rinv : 0);\n";
+                        out << nodeNames[j] << " = (pointDistance_delta.w > 0 ? pointDistance_delta.z*pointDistance_rinv : 0);\n";
                     else if (argIndex == 3)
-                        out << nodeNames[j] << " = (periodicDistance_r2 > 0 ? -periodicDistance_delta.x*periodicDistance_rinv : 0);\n";
+                        out << nodeNames[j] << " = (pointDistance_delta.w > 0 ? -pointDistance_delta.x*pointDistance_rinv : 0);\n";
                     else if (argIndex == 4)
-                        out << nodeNames[j] << " = (periodicDistance_r2 > 0 ? -periodicDistance_delta.y*periodicDistance_rinv : 0);\n";
+                        out << nodeNames[j] << " = (pointDistance_delta.w > 0 ? -pointDistance_delta.y*pointDistance_rinv : 0);\n";
                     else if (argIndex == 5)
-                        out << nodeNames[j] << " = (periodicDistance_r2 > 0 ? -periodicDistance_delta.z*periodicDistance_rinv : 0);\n";
+                        out << nodeNames[j] << " = (pointDistance_delta.w > 0 ? -pointDistance_delta.z*pointDistance_rinv : 0);\n";
+                }
+            }
+            else if (node.getOperation().getName() == "pointangle") {
+                // This is a pointangle() function.
+
+                bool periodic = (node.getOperation().getName() == "periodicdistance" || distancesArePeriodic);
+                computeDelta(out, "pointAngle_delta21", node, 3, 0, tempType, periodic, temps);
+                computeDelta(out, "pointAngle_delta23", node, 3, 6, tempType, periodic, temps);
+                out << tempType << " pointAngle_theta = ccb_computeAngle(pointAngle_delta21, pointAngle_delta23);\n";
+                out << tempType << "3 pointAngle_crossProd = trimTo3(cross(pointAngle_delta23, pointAngle_delta21));\n";
+                out << "real pointAngle_lengthCross = max(SQRT(dot(pointAngle_crossProd, pointAngle_crossProd)), (real) 1e-6f);\n";
+                out << "real3 pointAngle_deltaCross0 = cross(trimTo3(pointAngle_delta21), pointAngle_crossProd)/(pointAngle_delta21.w*pointAngle_lengthCross);\n";
+                out << "real3 pointAngle_deltaCross2 = -cross(trimTo3(pointAngle_delta23), pointAngle_crossProd)/(pointAngle_delta23.w*pointAngle_lengthCross);\n";
+                out << "real3 pointAngle_deltaCross1 = -(pointAngle_deltaCross0+pointAngle_deltaCross2);\n";
+                for (int j = 0; j < nodes.size(); j++) {
+                    const vector<int>& derivOrder = dynamic_cast<const Operation::Custom*>(&nodes[j]->getOperation())->getDerivOrder();
+                    int argIndex = -1;
+                    for (int k = 0; k < 9; k++) {
+                        if (derivOrder[k] > 0) {
+                            if (derivOrder[k] > 1 || argIndex != -1)
+                                throw OpenMMException("Unsupported derivative of "+node.getOperation().getName()); // Should be impossible for this to happen.
+                            argIndex = k;
+                        }
+                    }
+                    if (argIndex == -1)
+                        out << nodeNames[j] << " = pointAngle_theta;\n";
+                    else if (argIndex == 0)
+                        out << nodeNames[j] << " = pointAngle_deltaCross0.x;\n";
+                    else if (argIndex == 1)
+                        out << nodeNames[j] << " = pointAngle_deltaCross0.y;\n";
+                    else if (argIndex == 2)
+                        out << nodeNames[j] << " = pointAngle_deltaCross0.z;\n";
+                    else if (argIndex == 3)
+                        out << nodeNames[j] << " = pointAngle_deltaCross1.x;\n";
+                    else if (argIndex == 4)
+                        out << nodeNames[j] << " = pointAngle_deltaCross1.y;\n";
+                    else if (argIndex == 5)
+                        out << nodeNames[j] << " = pointAngle_deltaCross1.z;\n";
+                    else if (argIndex == 6)
+                        out << nodeNames[j] << " = pointAngle_deltaCross2.x;\n";
+                    else if (argIndex == 7)
+                        out << nodeNames[j] << " = pointAngle_deltaCross2.y;\n";
+                    else if (argIndex == 8)
+                        out << nodeNames[j] << " = pointAngle_deltaCross2.z;\n";
                 }
             }
             else if (node.getOperation().getName() == "dot") {
@@ -997,4 +1036,20 @@ void ExpressionUtilities::callFunction2(stringstream& out, string singleFn, stri
     }
     else
         out<<fn<<"(("<<tempType<<") "<<arg1<<", ("<<tempType<<") "<<arg2<<")";
+}
+
+void ExpressionUtilities::computeDelta(stringstream& out, const string& varName, const ExpressionTreeNode& node, int index1, int index2, const string& tempType, bool periodic, const vector<pair<ExpressionTreeNode, string> >& temps) {
+    // Compute the (optionally periodic) displacement between two points, storing the distance
+    // into the w component.
+    
+    out << tempType << "4 " << varName << " = make_" << tempType << "4(";
+    for (int i = 0; i < 3; i++) {
+        if (i > 0)
+            out << ", ";
+        out << getTempName(node.getChildren()[index1+i], temps) << "-" << getTempName(node.getChildren()[index2+i], temps);
+    }
+    out << ", 0);\n";
+    if (periodic)
+        out << "APPLY_PERIODIC_TO_DELTA(" << varName << ")\n";
+    out << varName << ".w = " << varName << ".x*" << varName << ".x + " << varName << ".y*" << varName << ".y + " << varName << ".z*" << varName << ".z;\n";
 }

--- a/platforms/common/src/ExpressionUtilities.cpp
+++ b/platforms/common/src/ExpressionUtilities.cpp
@@ -148,7 +148,7 @@ void ExpressionUtilities::processExpression(stringstream& out, const ExpressionT
 
                 computeDelta(out, "angle_delta21", node, 3, 0, tempType, distancesArePeriodic, temps);
                 computeDelta(out, "angle_delta23", node, 3, 6, tempType, distancesArePeriodic, temps);
-                out << tempType << " angle_theta = ccb_computeAngle(angle_delta21, angle_delta23);\n";
+                out << tempType << " angle_theta = computeAngle(angle_delta21, angle_delta23);\n";
                 out << tempType << "3 angle_crossProd = trimTo3(cross(angle_delta23, angle_delta21));\n";
                 out << "real angle_lengthCross = max(SQRT(dot(angle_crossProd, angle_crossProd)), (real) 1e-6f);\n";
                 out << "real3 angle_deltaCross0 = cross(trimTo3(angle_delta21), angle_crossProd)/(angle_delta21.w*angle_lengthCross);\n";
@@ -192,9 +192,9 @@ void ExpressionUtilities::processExpression(stringstream& out, const ExpressionT
                 computeDelta(out, "dihedral_delta12", node, 0, 3, tempType, distancesArePeriodic, temps);
                 computeDelta(out, "dihedral_delta32", node, 6, 3, tempType, distancesArePeriodic, temps);
                 computeDelta(out, "dihedral_delta34", node, 6, 9, tempType, distancesArePeriodic, temps);
-                out << tempType << "4 dihedral_cross1 = ccb_computeCross(dihedral_delta12, dihedral_delta32);\n";
-                out << tempType << "4 dihedral_cross2 = ccb_computeCross(dihedral_delta32, dihedral_delta34);\n";
-                out << tempType << " dihedral_theta = ccb_computeAngle(dihedral_cross1, dihedral_cross2);\n";
+                out << tempType << "4 dihedral_cross1 = computeCross(dihedral_delta12, dihedral_delta32);\n";
+                out << tempType << "4 dihedral_cross2 = computeCross(dihedral_delta32, dihedral_delta34);\n";
+                out << tempType << " dihedral_theta = computeAngle(dihedral_cross1, dihedral_cross2);\n";
                 out << "dihedral_theta *= (dihedral_delta12.x*dihedral_cross2.x + dihedral_delta12.y*dihedral_cross2.y + dihedral_delta12.z*dihedral_cross2.z < 0 ? -1 : 1);\n";
                 out << tempType << " dihedral_r = SQRT(dihedral_delta32.w);\n";
                 out << tempType << "4 dihedral_ff;\n";

--- a/platforms/common/src/kernels/customCentroidBond.cc
+++ b/platforms/common/src/kernels/customCentroidBond.cc
@@ -62,47 +62,6 @@ KERNEL void computeGroupCenters(int numParticleGroups, GLOBAL const real4* RESTR
 }
 
 /**
- * Compute the difference between two vectors, setting the fourth component to the squared magnitude.
- */
-DEVICE real4 delta(real4 vec1, real4 vec2, bool periodic, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ) {
-    real4 result = make_real4(vec1.x-vec2.x, vec1.y-vec2.y, vec1.z-vec2.z, 0);
-    if (periodic)
-        APPLY_PERIODIC_TO_DELTA(result);
-    result.w = result.x*result.x + result.y*result.y + result.z*result.z;
-    return result;
-}
-
-/**
- * Compute the angle between two vectors.  The w component of each vector should contain the squared magnitude.
- */
-DEVICE real computeAngle(real4 vec1, real4 vec2) {
-    real dotProduct = vec1.x*vec2.x + vec1.y*vec2.y + vec1.z*vec2.z;
-    real cosine = dotProduct*RSQRT(vec1.w*vec2.w);
-    real angle;
-    if (cosine > 0.99f || cosine < -0.99f) {
-        // We're close to the singularity in acos(), so take the cross product and use asin() instead.
-
-        real3 crossProduct = cross(trimTo3(vec1), trimTo3(vec2));
-        real scale = vec1.w*vec2.w;
-        angle = ASIN(SQRT(dot(crossProduct, crossProduct)/scale));
-        if (cosine < 0)
-            angle = M_PI-angle;
-    }
-    else
-       angle = ACOS(cosine);
-    return angle;
-}
-
-/**
- * Compute the cross product of two vectors, setting the fourth component to the squared magnitude.
- */
-DEVICE real4 computeCross(real4 vec1, real4 vec2) {
-    real3 cp = cross(trimTo3(vec1), trimTo3(vec2));
-    return make_real4(cp.x, cp.y, cp.z, cp.x*cp.x+cp.y*cp.y+cp.z*cp.z);
-}
-
-/**
  * Compute the forces on groups based on the bonds.
  */
 KERNEL void computeGroupForces(int numParticleGroups, GLOBAL mm_ulong* RESTRICT groupForce, GLOBAL mixed* RESTRICT energyBuffer, GLOBAL const real4* RESTRICT centerPositions,

--- a/platforms/common/src/kernels/customCompoundBond.cc
+++ b/platforms/common/src/kernels/customCompoundBond.cc
@@ -1,7 +1,7 @@
 /**
  * Compute the difference between two vectors, setting the fourth component to the squared magnitude.
  */
-DEVICE real4 ccb_delta(real4 vec1, real4 vec2, bool periodic, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
+DEVICE real4 delta(real4 vec1, real4 vec2, bool periodic, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
         real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ) {
     real4 result = make_real4(vec1.x-vec2.x, vec1.y-vec2.y, vec1.z-vec2.z, 0);
     if (periodic)
@@ -13,7 +13,7 @@ DEVICE real4 ccb_delta(real4 vec1, real4 vec2, bool periodic, real4 periodicBoxS
 /**
  * Compute the angle between two vectors.  The w component of each vector should contain the squared magnitude.
  */
-DEVICE real ccb_computeAngle(real4 vec1, real4 vec2) {
+DEVICE real computeAngle(real4 vec1, real4 vec2) {
     real dotProduct = vec1.x*vec2.x + vec1.y*vec2.y + vec1.z*vec2.z;
     real cosine = dotProduct*RSQRT(vec1.w*vec2.w);
     real angle;
@@ -34,7 +34,7 @@ DEVICE real ccb_computeAngle(real4 vec1, real4 vec2) {
 /**
  * Compute the cross product of two vectors, setting the fourth component to the squared magnitude.
  */
-DEVICE real4 ccb_computeCross(real4 vec1, real4 vec2) {
+DEVICE real4 computeCross(real4 vec1, real4 vec2) {
     real3 cp = cross(trimTo3(vec1), trimTo3(vec2));
     return make_real4(cp.x, cp.y, cp.z, cp.x*cp.x+cp.y*cp.y+cp.z*cp.z);
 }

--- a/platforms/common/src/kernels/customManyParticle.cc
+++ b/platforms/common/src/kernels/customManyParticle.cc
@@ -21,35 +21,6 @@ inline DEVICE real4 delta(real3 vec1, real3 vec2, real4 periodicBoxSize, real4 i
 }
 
 /**
- * Compute the angle between two vectors.  The w component of each vector should contain the squared magnitude.
- */
-DEVICE real computeAngle(real4 vec1, real4 vec2) {
-    real dotProduct = vec1.x*vec2.x + vec1.y*vec2.y + vec1.z*vec2.z;
-    real cosine = dotProduct*RSQRT(vec1.w*vec2.w);
-    real angle;
-    if (cosine > 0.99f || cosine < -0.99f) {
-        // We're close to the singularity in acos(), so take the cross product and use asin() instead.
-
-        real3 crossProduct = trimTo3(cross(vec1, vec2));
-        real scale = vec1.w*vec2.w;
-        angle = ASIN(SQRT(dot(crossProduct, crossProduct)/scale));
-        if (cosine < 0.0f)
-            angle = M_PI-angle;
-    }
-    else
-       angle = ACOS(cosine);
-    return angle;
-}
-
-/**
- * Compute the cross product of two vectors, setting the fourth component to the squared magnitude.
- */
-inline DEVICE real4 computeCross(real4 vec1, real4 vec2) {
-    real3 cp = trimTo3(cross(vec1, vec2));
-    return make_real4(cp.x, cp.y, cp.z, cp.x*cp.x+cp.y*cp.y+cp.z*cp.z);
-}
-
-/**
  * Determine whether a particular interaction is in the list of exclusions.
  */
 inline DEVICE bool isInteractionExcluded(int atom1, int atom2, GLOBAL const int* RESTRICT exclusions, GLOBAL const int* RESTRICT exclusionStartIndex) {

--- a/platforms/common/src/kernels/pointFunctions.cc
+++ b/platforms/common/src/kernels/pointFunctions.cc
@@ -1,16 +1,4 @@
 /**
- * Compute the difference between two vectors, setting the fourth component to the squared magnitude.
- */
-DEVICE real4 delta(real4 vec1, real4 vec2, bool periodic, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ) {
-    real4 result = make_real4(vec1.x-vec2.x, vec1.y-vec2.y, vec1.z-vec2.z, 0);
-    if (periodic)
-        APPLY_PERIODIC_TO_DELTA(result);
-    result.w = result.x*result.x + result.y*result.y + result.z*result.z;
-    return result;
-}
-
-/**
  * Compute the angle between two vectors.  The w component of each vector should contain the squared magnitude.
  */
 DEVICE real computeAngle(real4 vec1, real4 vec2) {

--- a/platforms/cpu/include/CpuCustomManyParticleForce.h
+++ b/platforms/cpu/include/CpuCustomManyParticleForce.h
@@ -1,4 +1,3 @@
-
 /* Portions copyright (c) 2009-2021 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
@@ -46,9 +45,6 @@ class CpuCustomManyParticleForce {
 private:
 
     class ParticleTermInfo;
-    class DistanceTermInfo;
-    class AngleTermInfo;
-    class DihedralTermInfo;
     class ThreadData;
     int numParticles, numParticlesPerSet, numPerParticleParameters, numTypes;
     bool useCutoff, usePeriodic, triclinic, centralParticleMode;
@@ -113,10 +109,6 @@ private:
      * periodic boundary conditions.
      */
     void computeDelta(const fvec4& posI, const fvec4& posJ, fvec4& deltaR, float& r2, const fvec4& boxSize, const fvec4& invBoxSize) const;
-    
-    static float computeAngle(const fvec4& vi, const fvec4& vj, float v2i, float v2j, float sign);
-    
-    static float getDihedralAngleBetweenThreeVectors(const fvec4& v1, const fvec4& v2, const fvec4& v3, fvec4& cross1, fvec4& cross2, const fvec4& signVector);
 
 public:
     /**
@@ -168,57 +160,16 @@ public:
     ParticleTermInfo(const std::string& name, int atom, int component, const Lepton::CompiledExpression& forceExpression, ThreadData& data);
 };
 
-class CpuCustomManyParticleForce::DistanceTermInfo {
-public:
-    std::string name;
-    int p1, p2, variableIndex;
-    Lepton::CompiledExpression forceExpression;
-    int delta;
-    float deltaSign;
-    DistanceTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression, ThreadData& data);
-};
-
-class CpuCustomManyParticleForce::AngleTermInfo {
-public:
-    std::string name;
-    int p1, p2, p3, variableIndex;
-    Lepton::CompiledExpression forceExpression;
-    int delta1, delta2;
-    float delta1Sign, delta2Sign;
-    AngleTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression, ThreadData& data);
-};
-
-class CpuCustomManyParticleForce::DihedralTermInfo {
-public:
-    std::string name;
-    int p1, p2, p3, p4, variableIndex;
-    Lepton::CompiledExpression forceExpression;
-    int delta1, delta2, delta3;
-    DihedralTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression, ThreadData& data);
-};
-
 class CpuCustomManyParticleForce::ThreadData {
 public:
     CompiledExpressionSet expressionSet;
     Lepton::CompiledExpression energyExpression;
     std::vector<std::vector<int> > particleParamIndices;
     std::vector<int> permutedParticles;
-    std::vector<std::pair<int, int> > deltaPairs;
     std::vector<ParticleTermInfo> particleTerms;
-    std::vector<DistanceTermInfo> distanceTerms;
-    std::vector<AngleTermInfo> angleTerms;
-    std::vector<DihedralTermInfo> dihedralTerms;
-    AlignedArray<fvec4> delta, cross1, cross2;
-    std::vector<float> normDelta;
-    std::vector<float> norm2Delta;
     AlignedArray<fvec4> f;
     double energy;
-    ThreadData(const CustomManyParticleForce& force, Lepton::ParsedExpression& energyExpr,
-            std::map<std::string, std::vector<int> >& distances, std::map<std::string, std::vector<int> >& angles, std::map<std::string, std::vector<int> >& dihedrals);
-    /**
-     * Request a pair of particles whose distance or displacement vector is needed in the computation.
-     */
-    void requestDeltaPair(int p1, int p2, int& pairIndex, float& pairSign, bool allowReversed);
+    ThreadData(const CustomManyParticleForce& force, Lepton::ParsedExpression& energyExpr);
 };
 
 } // namespace OpenMM

--- a/platforms/cpu/include/CpuCustomManyParticleForce.h
+++ b/platforms/cpu/include/CpuCustomManyParticleForce.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2009-2018 Stanford University and Simbios.
+/* Portions copyright (c) 2009-2021 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -55,6 +55,7 @@ private:
     double cutoffDistance;
     float recipBoxSize[3];
     Vec3 periodicBoxVectors[3];
+    Vec3* boxVectorsRef;
     AlignedArray<fvec4> periodicBoxVec4;
     CpuNeighborList* neighborList;
     ThreadPool& threads;

--- a/platforms/cpu/src/CpuCustomManyParticleForce.cpp
+++ b/platforms/cpu/src/CpuCustomManyParticleForce.cpp
@@ -1,4 +1,3 @@
-
 /* Portions copyright (c) 2009-2021 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
@@ -58,12 +57,9 @@ CpuCustomManyParticleForce::CpuCustomManyParticleForce(const CustomManyParticleF
 
     // Parse the expression and create the objects used to calculate the interaction.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpr = CustomManyParticleForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpr = CustomManyParticleForceImpl::prepareExpression(force, functions);
     for (int i = 0; i < threads.getNumThreads(); i++)
-        threadData.push_back(new ThreadData(force, energyExpr, distances, angles, dihedrals));
+        threadData.push_back(new ThreadData(force, energyExpr));
     if (force.getNonbondedMethod() != CustomManyParticleForce::NoCutoff)
         setUseCutoff(force.getCutoffDistance());
 
@@ -274,37 +270,14 @@ void CpuCustomManyParticleForce::calculateOneIxn(vector<int>& particleSet, vecto
     for (int i = 0; i < numParticlesPerSet; i++)
         for (int j = 0; j < numPerParticleParameters; j++)
             expressionSet.setVariable(data.particleParamIndices[i][j], particleParameters[permutedParticles[i]][j]);
-    
-    // Compute inter-particle deltas.
-    
-    int numDeltas = data.deltaPairs.size();
-    AlignedArray<fvec4>& delta = data.delta;
-    AlignedArray<fvec4>& cross1 = data.cross1;
-    AlignedArray<fvec4>& cross2 = data.cross2;
-    vector<float>& normDelta = data.normDelta;
-    vector<float>& norm2Delta = data.norm2Delta;
-    for (int i = 0; i < numDeltas; i++) {
-        int p1 = permutedParticles[data.deltaPairs[i].first];
-        int p2 = permutedParticles[data.deltaPairs[i].second];
-        computeDelta(fvec4(posq+4*p1), fvec4(posq+4*p2), delta[i], norm2Delta[i], boxSize, invBoxSize);
-        normDelta[i] = sqrtf(norm2Delta[i]);
-    }
-    
-    // Compute all of the variables the energy can depend on.
+
+    // Record particle coordinates.
 
     for (auto& term : data.particleTerms)
         expressionSet.setVariable(term.variableIndex, posq[4*permutedParticles[term.atom]+term.component]);
-    for (auto& term : data.distanceTerms)
-        expressionSet.setVariable(term.variableIndex, normDelta[term.delta]);
-    for (auto& term : data.angleTerms)
-        expressionSet.setVariable(term.variableIndex, computeAngle(delta[term.delta1], delta[term.delta2], norm2Delta[term.delta1], norm2Delta[term.delta2], term.delta1Sign*term.delta2Sign));
-    for (int i = 0; i < (int) data.dihedralTerms.size(); i++) {
-        const DihedralTermInfo& term = data.dihedralTerms[i];
-        expressionSet.setVariable(term.variableIndex, getDihedralAngleBetweenThreeVectors(delta[term.delta1], delta[term.delta2], delta[term.delta3], cross1[i], cross2[i], delta[term.delta1]));
-    }
-    
+
     if (includeForces) {
-        // Apply forces based on individual particle coordinates.
+        // Apply forces based on particle coordinates.
 
         AlignedArray<fvec4>& f = data.f;
         for (int i = 0; i < numParticlesPerSet; i++)
@@ -314,59 +287,6 @@ void CpuCustomManyParticleForce::calculateOneIxn(vector<int>& particleSet, vecto
             f[term.atom].store(temp);
             temp[term.component] -= term.forceExpression.evaluate();
             f[term.atom] = fvec4(temp);
-        }
-
-        // Apply forces based on distances.
-
-        for (auto& term : data.distanceTerms) {
-            float dEdR = (float) (term.forceExpression.evaluate()*term.deltaSign/(normDelta[term.delta]));
-            fvec4 force = -dEdR*delta[term.delta];
-            f[term.p1] -= force;
-            f[term.p2] += force;
-        }
-
-        // Apply forces based on angles.
-
-        for (auto& term : data.angleTerms) {
-            float dEdTheta = (float) term.forceExpression.evaluate();
-            fvec4 thetaCross = cross(delta[term.delta1], delta[term.delta2]);
-            float lengthThetaCross = sqrtf(dot3(thetaCross, thetaCross));
-            if (lengthThetaCross < 1.0e-6f)
-                lengthThetaCross = 1.0e-6f;
-            float termA = dEdTheta*term.delta2Sign/(norm2Delta[term.delta1]*lengthThetaCross);
-            float termC = -dEdTheta*term.delta1Sign/(norm2Delta[term.delta2]*lengthThetaCross);
-            fvec4 deltaCross1 = cross(delta[term.delta1], thetaCross);
-            fvec4 deltaCross2 = cross(delta[term.delta2], thetaCross);
-            fvec4 force1 = termA*deltaCross1;
-            fvec4 force3 = termC*deltaCross2;
-            fvec4 force2 = -(force1+force3);
-            f[term.p1] += force1;
-            f[term.p2] += force2;
-            f[term.p3] += force3;
-        }
-
-        // Apply forces based on dihedrals.
-
-        for (int i = 0; i < (int) data.dihedralTerms.size(); i++) {
-            const DihedralTermInfo& term = data.dihedralTerms[i];
-            float dEdTheta = (float) term.forceExpression.evaluate();
-            float normCross1 = dot3(cross1[i], cross1[i]);
-            float normBC = normDelta[term.delta2];
-            float forceFactors[4];
-            forceFactors[0] = (-dEdTheta*normBC)/normCross1;
-            float normCross2 = dot3(cross2[i], cross2[i]);
-            forceFactors[3] = (dEdTheta*normBC)/normCross2;
-            forceFactors[1] = dot3(delta[term.delta1], delta[term.delta2]);
-            forceFactors[1] /= norm2Delta[term.delta2];
-            forceFactors[2] = dot3(delta[term.delta3], delta[term.delta2]);
-            forceFactors[2] /= norm2Delta[term.delta2];
-            fvec4 force1 = forceFactors[0]*cross1[i];
-            fvec4 force4 = forceFactors[3]*cross2[i];
-            fvec4 s = forceFactors[1]*force1 - forceFactors[2]*force4;
-            f[term.p1] += force1;
-            f[term.p2] -= force1-s;
-            f[term.p3] -= force4+s;
-            f[term.p4] += force4;
         }
 
         // Store the forces.
@@ -399,61 +319,12 @@ void CpuCustomManyParticleForce::computeDelta(const fvec4& posI, const fvec4& po
     r2 = dot3(deltaR, deltaR);
 }
 
-float CpuCustomManyParticleForce::computeAngle(const fvec4& vi, const fvec4& vj, float v2i, float v2j, float sign) {
-    float dot = dot3(vi, vj)*sign;
-    float cosine = dot/sqrtf(v2i*v2j);
-    if (cosine > 0.99f || cosine < -0.99f) {
-        // We're close to the singularity in acos(), so take the cross product and use asin() instead.
-
-        fvec4 cross12 = cross(vi, vj);
-        float scale = v2i*v2j;
-        float angle = asinf(sqrtf(dot3(cross12, cross12)/scale));
-        if (cosine < 0.0f)
-            angle = (float) (M_PI-angle);
-        return angle;
-    }
-    return acosf(cosine);
-}
-
-float CpuCustomManyParticleForce::getDihedralAngleBetweenThreeVectors(const fvec4& v1, const fvec4& v2, const fvec4& v3, fvec4& cross1, fvec4& cross2, const fvec4& signVector) {
-    cross1 = cross(v1, v2);
-    cross2 = cross(v2, v3);
-    float angle = computeAngle(cross1, cross2, dot3(cross1, cross1), dot3(cross2, cross2), 1.0f);
-    float dotProduct = dot3(signVector, cross2);
-    if (dotProduct < 0) 
-        angle = -angle;
-    return angle;
-}
-
 CpuCustomManyParticleForce::ParticleTermInfo::ParticleTermInfo(const string& name, int atom, int component, const Lepton::CompiledExpression& forceExpression, ThreadData& data) :
         name(name), atom(atom), component(component), forceExpression(forceExpression) {
     variableIndex = data.expressionSet.getVariableIndex(name);
 }
 
-CpuCustomManyParticleForce::DistanceTermInfo::DistanceTermInfo(const string& name, const vector<int>& atoms, const Lepton::CompiledExpression& forceExpression, ThreadData& data) :
-        name(name), p1(atoms[0]), p2(atoms[1]), forceExpression(forceExpression) {
-    variableIndex = data.expressionSet.getVariableIndex(name);
-    data.requestDeltaPair(p1, p2, delta, deltaSign, true);
-}
-
-CpuCustomManyParticleForce::AngleTermInfo::AngleTermInfo(const string& name, const vector<int>& atoms, const Lepton::CompiledExpression& forceExpression, ThreadData& data) :
-        name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), forceExpression(forceExpression) {
-    variableIndex = data.expressionSet.getVariableIndex(name);
-    data.requestDeltaPair(p1, p2,delta1, delta1Sign, true);
-    data.requestDeltaPair(p3, p2, delta2, delta2Sign, true);
-}
-
-CpuCustomManyParticleForce::DihedralTermInfo::DihedralTermInfo(const string& name, const vector<int>& atoms, const Lepton::CompiledExpression& forceExpression, ThreadData& data) :
-        name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), p4(atoms[3]), forceExpression(forceExpression) {
-    variableIndex = data.expressionSet.getVariableIndex(name);
-    float sign;
-    data.requestDeltaPair(p2, p1, delta1, sign, false);
-    data.requestDeltaPair(p2, p3, delta2, sign, false);
-    data.requestDeltaPair(p4, p3, delta3, sign, false);
-}
-
-CpuCustomManyParticleForce::ThreadData::ThreadData(const CustomManyParticleForce& force, Lepton::ParsedExpression& energyExpr,
-            map<string, vector<int> >& distances, map<string, vector<int> >& angles, map<string, vector<int> >& dihedrals) {
+CpuCustomManyParticleForce::ThreadData::ThreadData(const CustomManyParticleForce& force, Lepton::ParsedExpression& energyExpr) {
     int numParticlesPerSet = force.getNumParticlesPerSet();
     int numPerParticleParameters = force.getNumPerParticleParameters();
     particleParamIndices.resize(numParticlesPerSet);
@@ -478,43 +349,6 @@ CpuCustomManyParticleForce::ThreadData::ThreadData(const CustomManyParticleForce
             particleParamIndices[i].push_back(expressionSet.getVariableIndex(paramname.str()));
         }
     }
-    for (auto& term : dihedrals)
-        dihedralTerms.push_back(CpuCustomManyParticleForce::DihedralTermInfo(term.first, term.second, energyExpr.differentiate(term.first).optimize().createCompiledExpression(), *this));
-    for (auto& term : distances)
-        distanceTerms.push_back(CpuCustomManyParticleForce::DistanceTermInfo(term.first, term.second, energyExpr.differentiate(term.first).optimize().createCompiledExpression(), *this));
-    for (auto& term : angles)
-        angleTerms.push_back(CpuCustomManyParticleForce::AngleTermInfo(term.first, term.second, energyExpr.differentiate(term.first).optimize().createCompiledExpression(), *this));
     for (auto& term : particleTerms)
         expressionSet.registerExpression(term.forceExpression);
-    for (auto& term : distanceTerms)
-        expressionSet.registerExpression(term.forceExpression);
-    for (auto& term : angleTerms)
-        expressionSet.registerExpression(term.forceExpression);
-    for (auto& term : dihedralTerms)
-        expressionSet.registerExpression(term.forceExpression);
-    int numDeltas = deltaPairs.size();
-    delta.resize(numDeltas);
-    normDelta.resize(numDeltas);
-    norm2Delta.resize(numDeltas);
-    cross1.resize(numDeltas);
-    cross2.resize(numDeltas);
-    
-}
-
-void CpuCustomManyParticleForce::ThreadData::requestDeltaPair(int p1, int p2, int& pairIndex, float& pairSign, bool allowReversed) {
-    for (int i = 0; i < (int) deltaPairs.size(); i++) {
-        if (deltaPairs[i].first == p1 && deltaPairs[i].second == p2) {
-            pairIndex = i;
-            pairSign = 1;
-            return;
-        }
-        if (deltaPairs[i].first == p2 && deltaPairs[i].second == p1 && allowReversed) {
-            pairIndex = i;
-            pairSign = -1;
-            return;
-        }
-    }
-    pairIndex = deltaPairs.size();
-    pairSign = 1;
-    deltaPairs.push_back(make_pair(p1, p2));
 }

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -419,7 +419,7 @@ CudaContext::~CudaContext() {
     string errorMessage = "Error deleting Context";
     if (contextIsValid && !isLinkedContext) {
         cuProfilerStop();
-        CHECK_RESULT(cuCtxDestroy(context));
+        cuCtxDestroy(context);
     }
     contextIsValid = false;
 }

--- a/platforms/reference/include/ReferenceBondIxn.h
+++ b/platforms/reference/include/ReferenceBondIxn.h
@@ -82,7 +82,7 @@ class OPENMM_EXPORT ReferenceBondIxn {
       
          --------------------------------------------------------------------------------------- */
       
-      static double getNormedDotProduct(double* vector1, double* vector2, int hasREntry);
+      static double getNormedDotProduct(double* vector1, double* vector2, int hasREntry=0);
       
       /**---------------------------------------------------------------------------------------
       
@@ -99,7 +99,7 @@ class OPENMM_EXPORT ReferenceBondIxn {
          --------------------------------------------------------------------------------------- */
       
       static double getAngleBetweenTwoVectors(double* vector1, double* vector2, 
-                                              double* outputDotProduct, int hasREntry);
+                                              double* outputDotProduct=NULL, int hasREntry=0);
       
       /**---------------------------------------------------------------------------------------
       
@@ -120,9 +120,9 @@ class OPENMM_EXPORT ReferenceBondIxn {
          --------------------------------------------------------------------------------------- */
       
       static double getDihedralAngleBetweenThreeVectors(double* vector1, double* vector2, 
-                                                        double* vector3, double** outputCrossProduct, 
-                                                        double* cosineOfAngle, double* signVector, 
-                                                        double* signOfAngle, int hasREntry);
+                                                        double* vector3, double** outputCrossProduct=NULL, 
+                                                        double* cosineOfAngle=NULL, double* signVector=NULL, 
+                                                        double* signOfAngle=NULL, int hasREntry=0);
       
 };
 

--- a/platforms/reference/include/ReferenceCustomCentroidBondIxn.h
+++ b/platforms/reference/include/ReferenceCustomCentroidBondIxn.h
@@ -38,9 +38,6 @@ class ReferenceCustomCentroidBondIxn : public ReferenceBondIxn {
    private:
 
       class PositionTermInfo;
-      class DistanceTermInfo;
-      class AngleTermInfo;
-      class DihedralTermInfo;
       std::vector<std::vector<int> > groupAtoms;
       std::vector<std::vector<double> > normalizedWeights;
       std::vector<std::vector<int> > bondGroups;
@@ -49,9 +46,6 @@ class ReferenceCustomCentroidBondIxn : public ReferenceBondIxn {
       std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
       std::vector<int> bondParamIndex;
       std::vector<PositionTermInfo> positionTerms;
-      std::vector<DistanceTermInfo> distanceTerms;
-      std::vector<AngleTermInfo> angleTerms;
-      std::vector<DihedralTermInfo> dihedralTerms;
       int numParameters;
       bool usePeriodic;
       Vec3 boxVectors[3];
@@ -86,9 +80,7 @@ class ReferenceCustomCentroidBondIxn : public ReferenceBondIxn {
 
        ReferenceCustomCentroidBondIxn(int numGroupsPerBond, const std::vector<std::vector<int> >& groupAtoms,
                                const std::vector<std::vector<double> >& normalizedWeights, const std::vector<std::vector<int> >& bondGroups, const Lepton::ParsedExpression& energyExpression,
-                               const std::vector<std::string>& bondParameterNames, const std::map<std::string, std::vector<int> >& distances,
-                               const std::map<std::string, std::vector<int> >& angles, const std::map<std::string, std::vector<int> >& dihedrals,
-                               const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
+                               const std::vector<std::string>& bondParameterNames, const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 
@@ -145,44 +137,6 @@ public:
     Lepton::CompiledExpression forceExpression;
     PositionTermInfo(const std::string& name, int group, int component, const Lepton::CompiledExpression& forceExpression) :
             name(name), group(group), component(component), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomCentroidBondIxn::DistanceTermInfo {
-public:
-    std::string name;
-    int g1, g2, index;
-    Lepton::CompiledExpression forceExpression;
-    mutable double delta[ReferenceForce::LastDeltaRIndex];
-    DistanceTermInfo(const std::string& name, const std::vector<int>& groups, const Lepton::CompiledExpression& forceExpression) :
-            name(name), g1(groups[0]), g2(groups[1]), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomCentroidBondIxn::AngleTermInfo {
-public:
-    std::string name;
-    int g1, g2, g3, index;
-    Lepton::CompiledExpression forceExpression;
-    mutable double delta1[ReferenceForce::LastDeltaRIndex];
-    mutable double delta2[ReferenceForce::LastDeltaRIndex];
-    AngleTermInfo(const std::string& name, const std::vector<int>& groups, const Lepton::CompiledExpression& forceExpression) :
-            name(name), g1(groups[0]), g2(groups[1]), g3(groups[2]), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomCentroidBondIxn::DihedralTermInfo {
-public:
-    std::string name;
-    int g1, g2, g3, g4, index;
-    Lepton::CompiledExpression forceExpression;
-    mutable double delta1[ReferenceForce::LastDeltaRIndex];
-    mutable double delta2[ReferenceForce::LastDeltaRIndex];
-    mutable double delta3[ReferenceForce::LastDeltaRIndex];
-    mutable double cross1[3];
-    mutable double cross2[3];
-    DihedralTermInfo(const std::string& name, const std::vector<int>& groups, const Lepton::CompiledExpression& forceExpression) :
-            name(name), g1(groups[0]), g2(groups[1]), g3(groups[2]), g4(groups[3]), forceExpression(forceExpression) {
     }
 };
 

--- a/platforms/reference/include/ReferenceCustomCompoundBondIxn.h
+++ b/platforms/reference/include/ReferenceCustomCompoundBondIxn.h
@@ -38,18 +38,12 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
    private:
 
       class ParticleTermInfo;
-      class DistanceTermInfo;
-      class AngleTermInfo;
-      class DihedralTermInfo;
       std::vector<std::vector<int> > bondAtoms;
       CompiledExpressionSet expressionSet;
       Lepton::CompiledExpression energyExpression;
       std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
       std::vector<int> bondParamIndex;
       std::vector<ParticleTermInfo> particleTerms;
-      std::vector<DistanceTermInfo> distanceTerms;
-      std::vector<AngleTermInfo> angleTerms;
-      std::vector<DihedralTermInfo> dihedralTerms;
       int numParameters;
       bool usePeriodic;
       Vec3 boxVectors[3];
@@ -83,9 +77,7 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
          --------------------------------------------------------------------------------------- */
 
        ReferenceCustomCompoundBondIxn(int numParticlesPerBond, const std::vector<std::vector<int> >& bondAtoms, const Lepton::ParsedExpression& energyExpression,
-                               const std::vector<std::string>& bondParameterNames, const std::map<std::string, std::vector<int> >& distances,
-                               const std::map<std::string, std::vector<int> >& angles, const std::map<std::string, std::vector<int> >& dihedrals,
-                               const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
+                               const std::vector<std::string>& bondParameterNames, const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 
@@ -142,44 +134,6 @@ public:
     Lepton::CompiledExpression forceExpression;
     ParticleTermInfo(const std::string& name, int atom, int component, const Lepton::CompiledExpression& forceExpression) :
             name(name), atom(atom), component(component), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomCompoundBondIxn::DistanceTermInfo {
-public:
-    std::string name;
-    int p1, p2, index;
-    Lepton::CompiledExpression forceExpression;
-    mutable double delta[ReferenceForce::LastDeltaRIndex];
-    DistanceTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression) :
-            name(name), p1(atoms[0]), p2(atoms[1]), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomCompoundBondIxn::AngleTermInfo {
-public:
-    std::string name;
-    int p1, p2, p3, index;
-    Lepton::CompiledExpression forceExpression;
-    mutable double delta1[ReferenceForce::LastDeltaRIndex];
-    mutable double delta2[ReferenceForce::LastDeltaRIndex];
-    AngleTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression) :
-            name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomCompoundBondIxn::DihedralTermInfo {
-public:
-    std::string name;
-    int p1, p2, p3, p4, index;
-    Lepton::CompiledExpression forceExpression;
-    mutable double delta1[ReferenceForce::LastDeltaRIndex];
-    mutable double delta2[ReferenceForce::LastDeltaRIndex];
-    mutable double delta3[ReferenceForce::LastDeltaRIndex];
-    mutable double cross1[3];
-    mutable double cross2[3];
-    DihedralTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression) :
-            name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), p4(atoms[3]), forceExpression(forceExpression) {
     }
 };
 

--- a/platforms/reference/include/ReferenceCustomManyParticleIxn.h
+++ b/platforms/reference/include/ReferenceCustomManyParticleIxn.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2009-2018 Stanford University and Simbios.
+/* Portions copyright (c) 2009-2021 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -46,7 +46,7 @@ class ReferenceCustomManyParticleIxn {
       int numParticlesPerSet, numPerParticleParameters, numTypes;
       bool useCutoff, usePeriodic, centralParticleMode;
       double cutoffDistance;
-      OpenMM::Vec3 periodicBoxVectors[3];
+      OpenMM::Vec3* periodicBoxVectors;
       Lepton::ExpressionProgram energyExpression;
       std::vector<std::vector<std::string> > particleParamNames;
       std::vector<std::set<int> > exclusions;

--- a/platforms/reference/include/ReferenceCustomManyParticleIxn.h
+++ b/platforms/reference/include/ReferenceCustomManyParticleIxn.h
@@ -1,4 +1,3 @@
-
 /* Portions copyright (c) 2009-2021 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
@@ -40,9 +39,6 @@ class ReferenceCustomManyParticleIxn {
    private:
 
       class ParticleTermInfo;
-      class DistanceTermInfo;
-      class AngleTermInfo;
-      class DihedralTermInfo;
       int numParticlesPerSet, numPerParticleParameters, numTypes;
       bool useCutoff, usePeriodic, centralParticleMode;
       double cutoffDistance;
@@ -54,9 +50,6 @@ class ReferenceCustomManyParticleIxn {
       std::vector<int> orderIndex;
       std::vector<std::vector<int> > particleOrder;
       std::vector<ParticleTermInfo> particleTerms;
-      std::vector<DistanceTermInfo> distanceTerms;
-      std::vector<AngleTermInfo> angleTerms;
-      std::vector<DihedralTermInfo> dihedralTerms;
 
       void loopOverInteractions(std::vector<int>& particles, int loopIndex, std::vector<OpenMM::Vec3>& atomCoordinates,
                                 std::vector<std::vector<double> >& particleParameters, std::map<std::string, double>& variables,
@@ -148,44 +141,6 @@ public:
     Lepton::ExpressionProgram forceExpression;
     ParticleTermInfo(const std::string& name, int atom, int component, const Lepton::ExpressionProgram& forceExpression) :
             name(name), atom(atom), component(component), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomManyParticleIxn::DistanceTermInfo {
-public:
-    std::string name;
-    int p1, p2;
-    Lepton::ExpressionProgram forceExpression;
-    mutable double delta[ReferenceForce::LastDeltaRIndex];
-    DistanceTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::ExpressionProgram& forceExpression) :
-            name(name), p1(atoms[0]), p2(atoms[1]), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomManyParticleIxn::AngleTermInfo {
-public:
-    std::string name;
-    int p1, p2, p3;
-    Lepton::ExpressionProgram forceExpression;
-    mutable double delta1[ReferenceForce::LastDeltaRIndex];
-    mutable double delta2[ReferenceForce::LastDeltaRIndex];
-    AngleTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::ExpressionProgram& forceExpression) :
-            name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), forceExpression(forceExpression) {
-    }
-};
-
-class ReferenceCustomManyParticleIxn::DihedralTermInfo {
-public:
-    std::string name;
-    int p1, p2, p3, p4;
-    Lepton::ExpressionProgram forceExpression;
-    mutable double delta1[ReferenceForce::LastDeltaRIndex];
-    mutable double delta2[ReferenceForce::LastDeltaRIndex];
-    mutable double delta3[ReferenceForce::LastDeltaRIndex];
-    mutable double cross1[3];
-    mutable double cross2[3];
-    DihedralTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::ExpressionProgram& forceExpression) :
-            name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), p4(atoms[3]), forceExpression(forceExpression) {
     }
 };
 

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -806,7 +806,6 @@ public:
      */
     void copyParametersToContext(ContextImpl& context, const CustomExternalForce& force);
 private:
-    class PeriodicDistanceFunction;
     int numParticles;
     ReferenceCustomExternalIxn* ixn;
     std::vector<int> particles;
@@ -814,16 +813,6 @@ private:
     Lepton::CompiledExpression energyExpression, forceExpressionX, forceExpressionY, forceExpressionZ;
     std::vector<std::string> parameterNames, globalParameterNames;
     Vec3* boxVectors;
-};
-
-class ReferenceCalcCustomExternalForceKernel::PeriodicDistanceFunction : public Lepton::CustomFunction {
-public:
-    Vec3** boxVectorHandle;
-    PeriodicDistanceFunction(Vec3** boxVectorHandle);
-    int getNumArguments() const;
-    double evaluate(const double* arguments) const;
-    double evaluateDerivative(const double* arguments, const int* derivOrder) const;
-    Lepton::CustomFunction* clone() const;
 };
 
 /**
@@ -943,6 +932,7 @@ private:
     ReferenceCustomCompoundBondIxn* ixn;
     std::vector<std::string> globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
+    Vec3* boxVectors;
 };
 
 /**

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -893,6 +893,7 @@ private:
     ReferenceCustomCentroidBondIxn* ixn;
     std::vector<std::string> globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
+    Vec3* boxVectors;
 };
 
 /**

--- a/platforms/reference/include/ReferencePointFunctions.h
+++ b/platforms/reference/include/ReferencePointFunctions.h
@@ -1,0 +1,79 @@
+#ifndef OPENMM_REFERENCEPOINTFUNCTIONS_H_
+#define OPENMM_REFERENCEPOINTFUNCTIONS_H_
+
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2021 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#include "openmm/Vec3.h"
+#include "openmm/internal/windowsExport.h"
+#include "lepton/CustomFunction.h"
+
+namespace OpenMM {
+
+class OPENMM_EXPORT ReferencePointDistanceFunction : public Lepton::CustomFunction {
+public:
+    ReferencePointDistanceFunction(bool periodic, Vec3** boxVectorHandle);
+    int getNumArguments() const;
+    double evaluate(const double* arguments) const;
+    double evaluateDerivative(const double* arguments, const int* derivOrder) const;
+    Lepton::CustomFunction* clone() const;
+private:
+    bool periodic;
+    Vec3** boxVectorHandle;
+};
+
+class OPENMM_EXPORT ReferencePointAngleFunction : public Lepton::CustomFunction {
+public:
+    ReferencePointAngleFunction(bool periodic, Vec3** boxVectorHandle);
+    int getNumArguments() const;
+    double evaluate(const double* arguments) const;
+    double evaluateDerivative(const double* arguments, const int* derivOrder) const;
+    Lepton::CustomFunction* clone() const;
+private:
+    bool periodic;
+    Vec3** boxVectorHandle;
+};
+
+class OPENMM_EXPORT ReferencePointDihedralFunction : public Lepton::CustomFunction {
+public:
+    ReferencePointDihedralFunction(bool periodic, Vec3** boxVectorHandle);
+    int getNumArguments() const;
+    double evaluate(const double* arguments) const;
+    double evaluateDerivative(const double* arguments, const int* derivOrder) const;
+    Lepton::CustomFunction* clone() const;
+private:
+    bool periodic;
+    Vec3** boxVectorHandle;
+};
+
+} // namespace OpenMM
+
+#endif /*OPENMM_REFERENCEPOINTFUNCTIONS_H_*/

--- a/platforms/reference/include/ReferencePointFunctions.h
+++ b/platforms/reference/include/ReferencePointFunctions.h
@@ -38,6 +38,9 @@
 
 namespace OpenMM {
 
+/**
+ * This implements the pointdistance() function used in custom forces.
+ */
 class OPENMM_EXPORT ReferencePointDistanceFunction : public Lepton::CustomFunction {
 public:
     ReferencePointDistanceFunction(bool periodic, Vec3** boxVectorHandle);
@@ -50,6 +53,9 @@ private:
     Vec3** boxVectorHandle;
 };
 
+/**
+ * This implements the pointangle() function used in custom forces.
+ */
 class OPENMM_EXPORT ReferencePointAngleFunction : public Lepton::CustomFunction {
 public:
     ReferencePointAngleFunction(bool periodic, Vec3** boxVectorHandle);
@@ -62,6 +68,9 @@ private:
     Vec3** boxVectorHandle;
 };
 
+/**
+ * This implements the pointdihedral() function used in custom forces.
+ */
 class OPENMM_EXPORT ReferencePointDihedralFunction : public Lepton::CustomFunction {
 public:
     ReferencePointDihedralFunction(bool periodic, Vec3** boxVectorHandle);

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -58,6 +58,7 @@
 #include "ReferenceMonteCarloBarostat.h"
 #include "ReferenceNoseHooverChain.h"
 #include "ReferenceNoseHooverDynamics.h"
+#include "ReferencePointFunctions.h"
 #include "ReferenceProperDihedralBond.h"
 #include "ReferenceRbDihedralBond.h"
 #include "ReferenceRMSDForce.h"
@@ -903,7 +904,6 @@ void ReferenceCalcNonbondedForceKernel::initialize(const System& system, const N
     baseExceptionParams.resize(num14);
     for (int i = 0; i < numParticles; ++i)
        force.getParticleParameters(i, baseParticleParams[i][0], baseParticleParams[i][1], baseParticleParams[i][2]);
-    this->exclusions = exclusions;
     for (int i = 0; i < num14; ++i) {
         int particle1, particle2;
         force.getExceptionParameters(nb14s[i], particle1, particle2, baseExceptionParams[i][0], baseExceptionParams[i][1], baseExceptionParams[i][2]);
@@ -1525,48 +1525,6 @@ void ReferenceCalcCustomGBForceKernel::copyParametersToContext(ContextImpl& cont
     }
 }
 
-ReferenceCalcCustomExternalForceKernel::PeriodicDistanceFunction::PeriodicDistanceFunction(Vec3** boxVectorHandle) : boxVectorHandle(boxVectorHandle) {
-}
-
-int ReferenceCalcCustomExternalForceKernel::PeriodicDistanceFunction::getNumArguments() const {
-    return 6;
-}
-
-double ReferenceCalcCustomExternalForceKernel::PeriodicDistanceFunction::evaluate(const double* arguments) const {
-    Vec3* boxVectors = *boxVectorHandle;
-    Vec3 delta = Vec3(arguments[0], arguments[1], arguments[2])-Vec3(arguments[3], arguments[4], arguments[5]);
-    delta -= boxVectors[2]*floor(delta[2]/boxVectors[2][2]+0.5);
-    delta -= boxVectors[1]*floor(delta[1]/boxVectors[1][1]+0.5);
-    delta -= boxVectors[0]*floor(delta[0]/boxVectors[0][0]+0.5);
-    return sqrt(delta.dot(delta));
-}
-
-double ReferenceCalcCustomExternalForceKernel::PeriodicDistanceFunction::evaluateDerivative(const double* arguments, const int* derivOrder) const {
-    int argIndex = -1;
-    for (int i = 0; i < 6; i++) {
-        if (derivOrder[i] > 0) {
-            if (derivOrder[i] > 1 || argIndex != -1)
-                throw OpenMMException("Unsupported derivative of periodicdistance"); // Should be impossible for this to happen.
-            argIndex = i;
-        }
-    }
-    Vec3* boxVectors = *boxVectorHandle;
-    Vec3 delta = Vec3(arguments[0], arguments[1], arguments[2])-Vec3(arguments[3], arguments[4], arguments[5]);
-    delta -= boxVectors[2]*floor(delta[2]/boxVectors[2][2]+0.5);
-    delta -= boxVectors[1]*floor(delta[1]/boxVectors[1][1]+0.5);
-    delta -= boxVectors[0]*floor(delta[0]/boxVectors[0][0]+0.5);
-    double r = sqrt(delta.dot(delta));
-    if (r == 0)
-        return 0.0;    
-    if (argIndex < 3)
-        return delta[argIndex]/r;
-    return -delta[argIndex-3]/r;
-}
-
-Lepton::CustomFunction* ReferenceCalcCustomExternalForceKernel::PeriodicDistanceFunction::clone() const {
-    return new PeriodicDistanceFunction(boxVectorHandle);
-}
-
 ReferenceCalcCustomExternalForceKernel::~ReferenceCalcCustomExternalForceKernel() {
     if (ixn != NULL)
         delete ixn;
@@ -1586,7 +1544,7 @@ void ReferenceCalcCustomExternalForceKernel::initialize(const System& system, co
     // Parse the expression used to calculate the force.
 
     map<string, Lepton::CustomFunction*> functions;
-    PeriodicDistanceFunction periodicDistance(&boxVectors);
+    ReferencePointDistanceFunction periodicDistance(true, &boxVectors);
     functions["periodicdistance"] = &periodicDistance;
     Lepton::ParsedExpression expression = Lepton::Parser::parse(force.getEnergyFunction(), functions).optimize();
     energyExpression = expression.createCompiledExpression();
@@ -1875,6 +1833,12 @@ void ReferenceCalcCustomCompoundBondForceKernel::initialize(const System& system
     for (int i = 0; i < force.getNumFunctions(); i++)
         functions[force.getTabulatedFunctionName(i)] = createReferenceTabulatedFunction(force.getTabulatedFunction(i));
 
+    // Create implementations of point functions.
+
+    functions["pointdistance"] = new ReferencePointDistanceFunction(usePeriodic, &boxVectors);
+    functions["pointangle"] = new ReferencePointAngleFunction(usePeriodic, &boxVectors);
+    functions["pointdihedral"] = new ReferencePointDihedralFunction(usePeriodic, &boxVectors);
+
     // Parse the expression and create the object used to calculate the interaction.
 
     map<string, vector<int> > distances;
@@ -1907,8 +1871,10 @@ double ReferenceCalcCustomCompoundBondForceKernel::execute(ContextImpl& context,
     map<string, double> globalParameters;
     for (auto& name : globalParameterNames)
         globalParameters[name] = context.getParameter(name);
-    if (usePeriodic)
-        ixn->setPeriodic(extractBoxVectors(context));
+    if (usePeriodic) {
+        boxVectors = extractBoxVectors(context);
+        ixn->setPeriodic(boxVectors);
+    }
     vector<double> energyParamDerivValues(energyParamDerivNames.size()+1, 0.0);
     ixn->calculatePairIxn(posData, bondParamArray, globalParameters, forceData, includeEnergy ? &energy : NULL, &energyParamDerivValues[0]);
     map<string, double>& energyParamDerivs = extractEnergyParameterDerivatives(context);

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -1756,10 +1756,7 @@ void ReferenceCalcCustomCentroidBondForceKernel::initialize(const System& system
 
     // Parse the expression and create the object used to calculate the interaction.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpression = CustomCentroidBondForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpression = CustomCentroidBondForceImpl::prepareExpression(force, functions);
     vector<string> bondParameterNames;
     for (int i = 0; i < numBondParameters; i++)
         bondParameterNames.push_back(force.getPerBondParameterName(i));
@@ -1771,7 +1768,7 @@ void ReferenceCalcCustomCentroidBondForceKernel::initialize(const System& system
         energyParamDerivNames.push_back(param);
         energyParamDerivExpressions.push_back(energyExpression.differentiate(param).createCompiledExpression());
     }
-    ixn = new ReferenceCustomCentroidBondIxn(force.getNumGroupsPerBond(), groupAtoms, normalizedWeights, bondGroups, energyExpression, bondParameterNames, distances, angles, dihedrals, energyParamDerivExpressions);
+    ixn = new ReferenceCustomCentroidBondIxn(force.getNumGroupsPerBond(), groupAtoms, normalizedWeights, bondGroups, energyExpression, bondParameterNames, energyParamDerivExpressions);
 
     // Delete the custom functions.
 
@@ -1849,10 +1846,7 @@ void ReferenceCalcCustomCompoundBondForceKernel::initialize(const System& system
 
     // Parse the expression and create the object used to calculate the interaction.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpression = CustomCompoundBondForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpression = CustomCompoundBondForceImpl::prepareExpression(force, functions);
     vector<string> bondParameterNames;
     for (int i = 0; i < numBondParameters; i++)
         bondParameterNames.push_back(force.getPerBondParameterName(i));
@@ -1864,7 +1858,7 @@ void ReferenceCalcCustomCompoundBondForceKernel::initialize(const System& system
         energyParamDerivNames.push_back(param);
         energyParamDerivExpressions.push_back(energyExpression.differentiate(param).createCompiledExpression());
     }
-    ixn = new ReferenceCustomCompoundBondIxn(force.getNumParticlesPerBond(), bondParticles, energyExpression, bondParameterNames, distances, angles, dihedrals, energyParamDerivExpressions);
+    ixn = new ReferenceCustomCompoundBondIxn(force.getNumParticlesPerBond(), bondParticles, energyExpression, bondParameterNames, energyParamDerivExpressions);
 
     // Delete the custom functions.
 

--- a/platforms/reference/src/ReferencePointFunctions.cpp
+++ b/platforms/reference/src/ReferencePointFunctions.cpp
@@ -1,0 +1,218 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2021 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#include "ReferencePointFunctions.h"
+#include "ReferenceBondIxn.h"
+#include "openmm/OpenMMException.h"
+#include <cmath>
+
+using namespace OpenMM;
+
+ReferencePointDistanceFunction::ReferencePointDistanceFunction(bool periodic, Vec3** boxVectorHandle) : periodic(periodic), boxVectorHandle(boxVectorHandle) {
+}
+
+int ReferencePointDistanceFunction::getNumArguments() const {
+    return 6;
+}
+
+double ReferencePointDistanceFunction::evaluate(const double* arguments) const {
+    Vec3 delta = Vec3(arguments[0], arguments[1], arguments[2])-Vec3(arguments[3], arguments[4], arguments[5]);
+    if (periodic) {
+        Vec3* boxVectors = *boxVectorHandle;
+        delta -= boxVectors[2]*floor(delta[2]/boxVectors[2][2]+0.5);
+        delta -= boxVectors[1]*floor(delta[1]/boxVectors[1][1]+0.5);
+        delta -= boxVectors[0]*floor(delta[0]/boxVectors[0][0]+0.5);
+    }
+    return sqrt(delta.dot(delta));
+}
+
+double ReferencePointDistanceFunction::evaluateDerivative(const double* arguments, const int* derivOrder) const {
+    int argIndex = -1;
+    for (int i = 0; i < 6; i++) {
+        if (derivOrder[i] > 0) {
+            if (derivOrder[i] > 1 || argIndex != -1)
+                throw OpenMMException("Unsupported derivative of pointdistance"); // Should be impossible for this to happen.
+            argIndex = i;
+        }
+    }
+    Vec3 delta = Vec3(arguments[0], arguments[1], arguments[2])-Vec3(arguments[3], arguments[4], arguments[5]);
+    if (periodic) {
+        Vec3* boxVectors = *boxVectorHandle;
+        delta -= boxVectors[2]*floor(delta[2]/boxVectors[2][2]+0.5);
+        delta -= boxVectors[1]*floor(delta[1]/boxVectors[1][1]+0.5);
+        delta -= boxVectors[0]*floor(delta[0]/boxVectors[0][0]+0.5);
+    }
+    double r = sqrt(delta.dot(delta));
+    if (r == 0)
+        return 0.0;    
+    if (argIndex < 3)
+        return delta[argIndex]/r;
+    return -delta[argIndex-3]/r;
+}
+
+Lepton::CustomFunction* ReferencePointDistanceFunction::clone() const {
+    return new ReferencePointDistanceFunction(periodic, boxVectorHandle);
+}
+
+ReferencePointAngleFunction::ReferencePointAngleFunction(bool periodic, Vec3** boxVectorHandle) : periodic(periodic), boxVectorHandle(boxVectorHandle) {
+}
+
+int ReferencePointAngleFunction::getNumArguments() const {
+    return 9;
+}
+
+double ReferencePointAngleFunction::evaluate(const double* arguments) const {
+    Vec3 delta12 = Vec3(arguments[3], arguments[4], arguments[5])-Vec3(arguments[0], arguments[1], arguments[2]);
+    Vec3 delta32 = Vec3(arguments[3], arguments[4], arguments[5])-Vec3(arguments[6], arguments[7], arguments[8]);
+    if (periodic) {
+        Vec3* boxVectors = *boxVectorHandle;
+        delta12 -= boxVectors[2]*floor(delta12[2]/boxVectors[2][2]+0.5);
+        delta12 -= boxVectors[1]*floor(delta12[1]/boxVectors[1][1]+0.5);
+        delta12 -= boxVectors[0]*floor(delta12[0]/boxVectors[0][0]+0.5);
+        delta32 -= boxVectors[2]*floor(delta32[2]/boxVectors[2][2]+0.5);
+        delta32 -= boxVectors[1]*floor(delta32[1]/boxVectors[1][1]+0.5);
+        delta32 -= boxVectors[0]*floor(delta32[0]/boxVectors[0][0]+0.5);
+    }
+    return ReferenceBondIxn::getAngleBetweenTwoVectors(&delta12[0], &delta32[0]);
+}
+
+double ReferencePointAngleFunction::evaluateDerivative(const double* arguments, const int* derivOrder) const {
+    int argIndex = -1;
+    for (int i = 0; i < 9; i++) {
+        if (derivOrder[i] > 0) {
+            if (derivOrder[i] > 1 || argIndex != -1)
+                throw OpenMMException("Unsupported derivative of pointangle"); // Should be impossible for this to happen.
+            argIndex = i;
+        }
+    }
+    Vec3 delta12 = Vec3(arguments[3], arguments[4], arguments[5])-Vec3(arguments[0], arguments[1], arguments[2]);
+    Vec3 delta32 = Vec3(arguments[3], arguments[4], arguments[5])-Vec3(arguments[6], arguments[7], arguments[8]);
+    if (periodic) {
+        Vec3* boxVectors = *boxVectorHandle;
+        delta12 -= boxVectors[2]*floor(delta12[2]/boxVectors[2][2]+0.5);
+        delta12 -= boxVectors[1]*floor(delta12[1]/boxVectors[1][1]+0.5);
+        delta12 -= boxVectors[0]*floor(delta12[0]/boxVectors[0][0]+0.5);
+        delta32 -= boxVectors[2]*floor(delta32[2]/boxVectors[2][2]+0.5);
+        delta32 -= boxVectors[1]*floor(delta32[1]/boxVectors[1][1]+0.5);
+        delta32 -= boxVectors[0]*floor(delta32[0]/boxVectors[0][0]+0.5);
+    }
+    Vec3 thetaCross = delta12.cross(delta32);
+    double lengthThetaCross = sqrt(thetaCross.dot(thetaCross));
+    if (lengthThetaCross < 1.0e-6)
+        lengthThetaCross = 1.0e-6;
+    Vec3 deltaCrossP[3];
+    deltaCrossP[0] = delta12.cross(thetaCross)/(delta12.dot(delta12)*lengthThetaCross);
+    deltaCrossP[2] = -delta32.cross(thetaCross)/(delta32.dot(delta32)*lengthThetaCross);
+    deltaCrossP[1] = -(deltaCrossP[0]+deltaCrossP[2]);
+    return -deltaCrossP[argIndex/3][argIndex%3];
+}
+
+Lepton::CustomFunction* ReferencePointAngleFunction::clone() const {
+    return new ReferencePointAngleFunction(periodic, boxVectorHandle);
+}
+
+ReferencePointDihedralFunction::ReferencePointDihedralFunction(bool periodic, Vec3** boxVectorHandle) : periodic(periodic), boxVectorHandle(boxVectorHandle) {
+}
+
+int ReferencePointDihedralFunction::getNumArguments() const {
+    return 12;
+}
+
+double ReferencePointDihedralFunction::evaluate(const double* arguments) const {
+    Vec3 delta12 = Vec3(arguments[0], arguments[1], arguments[2])-Vec3(arguments[3], arguments[4], arguments[5]);
+    Vec3 delta32 = Vec3(arguments[6], arguments[7], arguments[8])-Vec3(arguments[3], arguments[4], arguments[5]);
+    Vec3 delta34 = Vec3(arguments[6], arguments[7], arguments[8])-Vec3(arguments[9], arguments[10], arguments[11]);
+    if (periodic) {
+        Vec3* boxVectors = *boxVectorHandle;
+        delta12 -= boxVectors[2]*floor(delta12[2]/boxVectors[2][2]+0.5);
+        delta12 -= boxVectors[1]*floor(delta12[1]/boxVectors[1][1]+0.5);
+        delta12 -= boxVectors[0]*floor(delta12[0]/boxVectors[0][0]+0.5);
+        delta32 -= boxVectors[2]*floor(delta32[2]/boxVectors[2][2]+0.5);
+        delta32 -= boxVectors[1]*floor(delta32[1]/boxVectors[1][1]+0.5);
+        delta32 -= boxVectors[0]*floor(delta32[0]/boxVectors[0][0]+0.5);
+        delta34 -= boxVectors[2]*floor(delta34[2]/boxVectors[2][2]+0.5);
+        delta34 -= boxVectors[1]*floor(delta34[1]/boxVectors[1][1]+0.5);
+        delta34 -= boxVectors[0]*floor(delta34[0]/boxVectors[0][0]+0.5);
+    }
+    return ReferenceBondIxn::getDihedralAngleBetweenThreeVectors(&delta12[0], &delta32[0], &delta34[0], NULL, NULL, &delta12[0]);
+}
+
+double ReferencePointDihedralFunction::evaluateDerivative(const double* arguments, const int* derivOrder) const {
+    int argIndex = -1;
+    for (int i = 0; i < 12; i++) {
+        if (derivOrder[i] > 0) {
+            if (derivOrder[i] > 1 || argIndex != -1)
+                throw OpenMMException("Unsupported derivative of pointdihedral"); // Should be impossible for this to happen.
+            argIndex = i;
+        }
+    }
+    Vec3 delta12 = Vec3(arguments[0], arguments[1], arguments[2])-Vec3(arguments[3], arguments[4], arguments[5]);
+    Vec3 delta32 = Vec3(arguments[6], arguments[7], arguments[8])-Vec3(arguments[3], arguments[4], arguments[5]);
+    Vec3 delta34 = Vec3(arguments[6], arguments[7], arguments[8])-Vec3(arguments[9], arguments[10], arguments[11]);
+    if (periodic) {
+        Vec3* boxVectors = *boxVectorHandle;
+        delta12 -= boxVectors[2]*floor(delta12[2]/boxVectors[2][2]+0.5);
+        delta12 -= boxVectors[1]*floor(delta12[1]/boxVectors[1][1]+0.5);
+        delta12 -= boxVectors[0]*floor(delta12[0]/boxVectors[0][0]+0.5);
+        delta32 -= boxVectors[2]*floor(delta32[2]/boxVectors[2][2]+0.5);
+        delta32 -= boxVectors[1]*floor(delta32[1]/boxVectors[1][1]+0.5);
+        delta32 -= boxVectors[0]*floor(delta32[0]/boxVectors[0][0]+0.5);
+        delta34 -= boxVectors[2]*floor(delta34[2]/boxVectors[2][2]+0.5);
+        delta34 -= boxVectors[1]*floor(delta34[1]/boxVectors[1][1]+0.5);
+        delta34 -= boxVectors[0]*floor(delta34[0]/boxVectors[0][0]+0.5);
+    }
+    Vec3 cross1 = delta12.cross(delta32);
+    Vec3 cross2 = delta32.cross(delta34);
+    double norm2Cross1 = cross1.dot(cross1);
+    double norm2Cross2 = cross2.dot(cross2);
+    double norm2Delta32 = delta32.dot(delta32);
+    double normDelta32 = sqrt(norm2Delta32);
+    double forceFactors[4];
+    forceFactors[0] = -normDelta32/norm2Cross1;
+    forceFactors[3] = normDelta32/norm2Cross2;
+    forceFactors[1] = delta12.dot(delta32);
+    forceFactors[1] /= norm2Delta32;
+    forceFactors[2] = delta34.dot(delta32);
+    forceFactors[2] /= norm2Delta32;
+    Vec3 internalF[4];
+    internalF[0] = forceFactors[0]*cross1;
+    internalF[3] = forceFactors[3]*cross2;
+    Vec3 s = forceFactors[1]*internalF[0] - forceFactors[2]*internalF[3];
+    internalF[1] = internalF[0] - s;
+    internalF[2] = internalF[3] + s;
+    internalF[0] *= -1;
+    internalF[3] *= -1;
+    return internalF[argIndex/3][argIndex%3];
+}
+
+Lepton::CustomFunction* ReferencePointDihedralFunction::clone() const {
+    return new ReferencePointDihedralFunction(periodic, boxVectorHandle);
+}

--- a/platforms/reference/src/SimTKReference/ReferenceBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceBondIxn.cpp
@@ -83,7 +83,7 @@ ReferenceBondIxn::~ReferenceBondIxn() {
    --------------------------------------------------------------------------------------- */
 
 double ReferenceBondIxn::getNormedDotProduct(double* vector1, double* vector2,
-                                             int hasREntry = 0) {
+                                             int hasREntry) {
 
    double dotProduct = DOT3(vector1, vector2);
    if (dotProduct != 0.0) {
@@ -122,9 +122,7 @@ double ReferenceBondIxn::getNormedDotProduct(double* vector1, double* vector2,
 
    --------------------------------------------------------------------------------------- */
 
-double ReferenceBondIxn::getAngleBetweenTwoVectors(double* vector1, double* vector2, 
-                                                   double* outputDotProduct = NULL,
-                                                   int hasREntry = 0) {
+double ReferenceBondIxn::getAngleBetweenTwoVectors(double* vector1, double* vector2, double* outputDotProduct, int hasREntry) {
 
     // get dot product betweenn vectors and then angle
 
@@ -173,11 +171,11 @@ double ReferenceBondIxn::getAngleBetweenTwoVectors(double* vector1, double* vect
 double ReferenceBondIxn::getDihedralAngleBetweenThreeVectors(double*  vector1,
                                                              double*  vector2, 
                                                              double*  vector3, 
-                                                             double** outputCrossProduct  = NULL, 
-                                                             double*  cosineOfAngle       = NULL, 
-                                                             double*  signVector          = NULL, 
-                                                             double*  signOfAngle         = NULL, 
-                                                             int          hasREntry = 0) {
+                                                             double** outputCrossProduct, 
+                                                             double*  cosineOfAngle, 
+                                                             double*  signVector, 
+                                                             double*  signOfAngle, 
+                                                             int      hasREntry) {
 
    double   tempVectors[6]         = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 

--- a/platforms/reference/src/SimTKReference/ReferenceCustomCentroidBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomCentroidBondIxn.cpp
@@ -40,7 +40,6 @@ using namespace OpenMM;
 ReferenceCustomCentroidBondIxn::ReferenceCustomCentroidBondIxn(int numGroupsPerBond, const vector<vector<int> >& groupAtoms,
             const vector<vector<double> >& normalizedWeights, const vector<vector<int> >& bondGroups,
             const Lepton::ParsedExpression& energyExpression, const vector<string>& bondParameterNames,
-            const map<string, vector<int> >& distances, const map<string, vector<int> >& angles, const map<string, vector<int> >& dihedrals,
             const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions) :
             groupAtoms(groupAtoms), normalizedWeights(normalizedWeights), bondGroups(bondGroups), energyExpression(energyExpression.createCompiledExpression()),
             usePeriodic(false), energyParamDerivExpressions(energyParamDerivExpressions) {
@@ -56,27 +55,9 @@ ReferenceCustomCentroidBondIxn::ReferenceCustomCentroidBondIxn(int numGroupsPerB
         positionTerms.push_back(ReferenceCustomCentroidBondIxn::PositionTermInfo(yname.str(), i, 1, energyExpression.differentiate(yname.str()).createCompiledExpression()));
         positionTerms.push_back(ReferenceCustomCentroidBondIxn::PositionTermInfo(zname.str(), i, 2, energyExpression.differentiate(zname.str()).createCompiledExpression()));
     }
-    for (auto& term : distances)
-        distanceTerms.push_back(ReferenceCustomCentroidBondIxn::DistanceTermInfo(term.first, term.second, energyExpression.differentiate(term.first).createCompiledExpression()));
-    for (auto& term : angles)
-        angleTerms.push_back(ReferenceCustomCentroidBondIxn::AngleTermInfo(term.first, term.second, energyExpression.differentiate(term.first).createCompiledExpression()));
-    for (auto& term : dihedrals)
-        dihedralTerms.push_back(ReferenceCustomCentroidBondIxn::DihedralTermInfo(term.first, term.second, energyExpression.differentiate(term.first).createCompiledExpression()));
     for (int i = 0; i < positionTerms.size(); i++) {
         expressionSet.registerExpression(positionTerms[i].forceExpression);
         positionTerms[i].index = expressionSet.getVariableIndex(positionTerms[i].name);
-    }
-    for (int i = 0; i < distanceTerms.size(); i++) {
-        expressionSet.registerExpression(distanceTerms[i].forceExpression);
-        distanceTerms[i].index = expressionSet.getVariableIndex(distanceTerms[i].name);
-    }
-    for (int i = 0; i < angleTerms.size(); i++) {
-        expressionSet.registerExpression(angleTerms[i].forceExpression);
-        angleTerms[i].index = expressionSet.getVariableIndex(angleTerms[i].name);
-    }
-    for (int i = 0; i < dihedralTerms.size(); i++) {
-        expressionSet.registerExpression(dihedralTerms[i].forceExpression);
-        dihedralTerms[i].index = expressionSet.getVariableIndex(dihedralTerms[i].name);
     }
     numParameters = bondParameterNames.size();
     for (int i = 0; i < numParameters; i++)
@@ -133,95 +114,11 @@ void ReferenceCustomCentroidBondIxn::calculateOneIxn(int bond, vector<Vec3>& gro
     const vector<int>& groups = bondGroups[bond];
     for (auto& term : positionTerms)
         expressionSet.setVariable(term.index, groupCenters[groups[term.group]][term.component]);
-    for (auto& term : distanceTerms) {
-        computeDelta(groups[term.g1], groups[term.g2], term.delta, groupCenters);
-        expressionSet.setVariable(term.index, term.delta[ReferenceForce::RIndex]);
-    }
-    for (auto& term : angleTerms) {
-        computeDelta(groups[term.g1], groups[term.g2], term.delta1, groupCenters);
-        computeDelta(groups[term.g3], groups[term.g2], term.delta2, groupCenters);
-        expressionSet.setVariable(term.index, computeAngle(term.delta1, term.delta2));
-    }
-    for (auto& term : dihedralTerms) {
-        computeDelta(groups[term.g2], groups[term.g1], term.delta1, groupCenters);
-        computeDelta(groups[term.g2], groups[term.g3], term.delta2, groupCenters);
-        computeDelta(groups[term.g4], groups[term.g3], term.delta3, groupCenters);
-        double dotDihedral, signOfDihedral;
-        double* crossProduct[] = {term.cross1, term.cross2};
-        expressionSet.setVariable(term.index, getDihedralAngleBetweenThreeVectors(term.delta1, term.delta2, term.delta3, crossProduct, &dotDihedral, term.delta1, &signOfDihedral, 1));
-    }
 
-    // Apply forces based on individual particle coordinates.
+    // Apply forces based on particle coordinates.
 
     for (auto& term : positionTerms)
         forces[groups[term.group]][term.component] -= term.forceExpression.evaluate();
-
-    // Apply forces based on distances.
-
-    for (auto& term : distanceTerms) {
-        double dEdR = term.forceExpression.evaluate()/(term.delta[ReferenceForce::RIndex]);
-        for (int i = 0; i < 3; i++) {
-           double force  = -dEdR*term.delta[i];
-           forces[groups[term.g1]][i] -= force;
-           forces[groups[term.g2]][i] += force;
-        }
-    }
-
-    // Apply forces based on angles.
-
-    for (auto& term : angleTerms) {
-        double dEdTheta = term.forceExpression.evaluate();
-        double thetaCross[ReferenceForce::LastDeltaRIndex];
-        SimTKOpenMMUtilities::crossProductVector3(term.delta1, term.delta2, thetaCross);
-        double lengthThetaCross = sqrt(DOT3(thetaCross, thetaCross));
-        if (lengthThetaCross < 1.0e-06)
-            lengthThetaCross = 1.0e-06;
-        double termA = dEdTheta/(term.delta1[ReferenceForce::R2Index]*lengthThetaCross);
-        double termC = -dEdTheta/(term.delta2[ReferenceForce::R2Index]*lengthThetaCross);
-        double deltaCrossP[3][3];
-        SimTKOpenMMUtilities::crossProductVector3(term.delta1, thetaCross, deltaCrossP[0]);
-        SimTKOpenMMUtilities::crossProductVector3(term.delta2, thetaCross, deltaCrossP[2]);
-        for (int i = 0; i < 3; i++) {
-            deltaCrossP[0][i] *= termA;
-            deltaCrossP[2][i] *= termC;
-            deltaCrossP[1][i] = -(deltaCrossP[0][i]+deltaCrossP[2][i]);
-        }
-        for (int i = 0; i < 3; i++) {
-            forces[groups[term.g1]][i] += deltaCrossP[0][i];
-            forces[groups[term.g2]][i] += deltaCrossP[1][i];
-            forces[groups[term.g3]][i] += deltaCrossP[2][i];
-        }
-    }
-
-    // Apply forces based on dihedrals.
-
-    for (auto& term : dihedralTerms) {
-        double dEdTheta = term.forceExpression.evaluate();
-        double internalF[4][3];
-        double forceFactors[4];
-        double normCross1 = DOT3(term.cross1, term.cross1);
-        double normBC = term.delta2[ReferenceForce::RIndex];
-        forceFactors[0] = (-dEdTheta*normBC)/normCross1;
-        double normCross2 = DOT3(term.cross2, term.cross2);
-        forceFactors[3] = (dEdTheta*normBC)/normCross2;
-        forceFactors[1] = DOT3(term.delta1, term.delta2);
-        forceFactors[1] /= term.delta2[ReferenceForce::R2Index];
-        forceFactors[2] = DOT3(term.delta3, term.delta2);
-        forceFactors[2] /= term.delta2[ReferenceForce::R2Index];
-        for (int i = 0; i < 3; i++) {
-            internalF[0][i] = forceFactors[0]*term.cross1[i];
-            internalF[3][i] = forceFactors[3]*term.cross2[i];
-            double s = forceFactors[1]*internalF[0][i] - forceFactors[2]*internalF[3][i];
-            internalF[1][i] = internalF[0][i] - s;
-            internalF[2][i] = internalF[3][i] + s;
-        }
-        for (int i = 0; i < 3; i++) {
-            forces[groups[term.g1]][i] += internalF[0][i];
-            forces[groups[term.g2]][i] -= internalF[1][i];
-            forces[groups[term.g3]][i] -= internalF[2][i];
-            forces[groups[term.g4]][i] += internalF[3][i];
-        }
-    }
 
     // Add the energy
 

--- a/platforms/reference/src/SimTKReference/ReferenceCustomManyParticleIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomManyParticleIxn.cpp
@@ -1,4 +1,3 @@
-
 /* Portions copyright (c) 2009-2021 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
@@ -56,10 +55,7 @@ ReferenceCustomManyParticleIxn::ReferenceCustomManyParticleIxn(const CustomManyP
 
     // Parse the expression and create the object used to calculate the interaction.
 
-    map<string, vector<int> > distances;
-    map<string, vector<int> > angles;
-    map<string, vector<int> > dihedrals;
-    Lepton::ParsedExpression energyExpr = CustomManyParticleForceImpl::prepareExpression(force, functions, distances, angles, dihedrals);
+    Lepton::ParsedExpression energyExpr = CustomManyParticleForceImpl::prepareExpression(force, functions);
     energyExpression = energyExpr.createProgram();
     if (force.getNonbondedMethod() != CustomManyParticleForce::NoCutoff)
         setUseCutoff(force.getCutoffDistance());
@@ -86,12 +82,6 @@ ReferenceCustomManyParticleIxn::ReferenceCustomManyParticleIxn(const CustomManyP
             particleParamNames[i].push_back(paramname.str());
         }
     }
-    for (auto& term : distances)
-        distanceTerms.push_back(ReferenceCustomManyParticleIxn::DistanceTermInfo(term.first, term.second, energyExpr.differentiate(term.first).optimize().createProgram()));
-    for (auto& term : angles)
-        angleTerms.push_back(ReferenceCustomManyParticleIxn::AngleTermInfo(term.first, term.second, energyExpr.differentiate(term.first).optimize().createProgram()));
-    for (auto& term : dihedrals)
-        dihedralTerms.push_back(ReferenceCustomManyParticleIxn::DihedralTermInfo(term.first, term.second, energyExpr.differentiate(term.first).optimize().createProgram()));
     
     // Record exclusions.
     
@@ -194,99 +184,15 @@ void ReferenceCustomManyParticleIxn::calculateOneIxn(const vector<int>& particle
         for (int j = 0; j < numPerParticleParameters; j++)
             variables[particleParamNames[i][j]] = particleParameters[permutedParticles[i]][j];
     
-    // Compute all of the variables the energy can depend on.
+    // Record particle coordinates.
 
     for (auto& term : particleTerms)
         variables[term.name] = atomCoordinates[permutedParticles[term.atom]][term.component];
-    for (auto& term : distanceTerms) {
-        computeDelta(permutedParticles[term.p1], permutedParticles[term.p2], term.delta, atomCoordinates);
-        variables[term.name] = term.delta[ReferenceForce::RIndex];
-    }
-    for (auto& term : angleTerms) {
-        computeDelta(permutedParticles[term.p1], permutedParticles[term.p2], term.delta1, atomCoordinates);
-        computeDelta(permutedParticles[term.p3], permutedParticles[term.p2], term.delta2, atomCoordinates);
-        variables[term.name] = computeAngle(term.delta1, term.delta2);
-    }
-    for (auto& term : dihedralTerms) {
-        computeDelta(permutedParticles[term.p2], permutedParticles[term.p1], term.delta1, atomCoordinates);
-        computeDelta(permutedParticles[term.p2], permutedParticles[term.p3], term.delta2, atomCoordinates);
-        computeDelta(permutedParticles[term.p4], permutedParticles[term.p3], term.delta3, atomCoordinates);
-        double dotDihedral, signOfDihedral;
-        double* crossProduct[] = {term.cross1, term.cross2};
-        variables[term.name] = ReferenceBondIxn::getDihedralAngleBetweenThreeVectors(term.delta1, term.delta2, term.delta3, crossProduct, &dotDihedral, term.delta1, &signOfDihedral, 1);
-    }
-    
-    // Apply forces based on individual particle coordinates.
-    
+
+    // Apply forces based on particle coordinates.
+
     for (auto& term : particleTerms)
         forces[permutedParticles[term.atom]][term.component] -= term.forceExpression.evaluate(variables);
-
-    // Apply forces based on distances.
-
-    for (auto& term : distanceTerms) {
-        double dEdR = term.forceExpression.evaluate(variables)/(term.delta[ReferenceForce::RIndex]);
-        for (int i = 0; i < 3; i++) {
-           double force  = -dEdR*term.delta[i];
-           forces[permutedParticles[term.p1]][i] -= force;
-           forces[permutedParticles[term.p2]][i] += force;
-        }
-    }
-
-    // Apply forces based on angles.
-
-    for (auto& term : angleTerms) {
-        double dEdTheta = term.forceExpression.evaluate(variables);
-        double thetaCross[ReferenceForce::LastDeltaRIndex];
-        SimTKOpenMMUtilities::crossProductVector3(term.delta1, term.delta2, thetaCross);
-        double lengthThetaCross = sqrt(DOT3(thetaCross, thetaCross));
-        if (lengthThetaCross < 1.0e-06)
-            lengthThetaCross = 1.0e-06;
-        double termA = dEdTheta/(term.delta1[ReferenceForce::R2Index]*lengthThetaCross);
-        double termC = -dEdTheta/(term.delta2[ReferenceForce::R2Index]*lengthThetaCross);
-        double deltaCrossP[3][3];
-        SimTKOpenMMUtilities::crossProductVector3(term.delta1, thetaCross, deltaCrossP[0]);
-        SimTKOpenMMUtilities::crossProductVector3(term.delta2, thetaCross, deltaCrossP[2]);
-        for (int i = 0; i < 3; i++) {
-            deltaCrossP[0][i] *= termA;
-            deltaCrossP[2][i] *= termC;
-            deltaCrossP[1][i] = -(deltaCrossP[0][i]+deltaCrossP[2][i]);
-        }
-        for (int i = 0; i < 3; i++) {
-            forces[permutedParticles[term.p1]][i] += deltaCrossP[0][i];
-            forces[permutedParticles[term.p2]][i] += deltaCrossP[1][i];
-            forces[permutedParticles[term.p3]][i] += deltaCrossP[2][i];
-        }
-    }
-
-    // Apply forces based on dihedrals.
-
-    for (auto& term : dihedralTerms) {
-        double dEdTheta = term.forceExpression.evaluate(variables);
-        double internalF[4][3];
-        double forceFactors[4];
-        double normCross1 = DOT3(term.cross1, term.cross1);
-        double normBC = term.delta2[ReferenceForce::RIndex];
-        forceFactors[0] = (-dEdTheta*normBC)/normCross1;
-        double normCross2 = DOT3(term.cross2, term.cross2);
-        forceFactors[3] = (dEdTheta*normBC)/normCross2;
-        forceFactors[1] = DOT3(term.delta1, term.delta2);
-        forceFactors[1] /= term.delta2[ReferenceForce::R2Index];
-        forceFactors[2] = DOT3(term.delta3, term.delta2);
-        forceFactors[2] /= term.delta2[ReferenceForce::R2Index];
-        for (int i = 0; i < 3; i++) {
-            internalF[0][i] = forceFactors[0]*term.cross1[i];
-            internalF[3][i] = forceFactors[3]*term.cross2[i];
-            double s = forceFactors[1]*internalF[0][i] - forceFactors[2]*internalF[3][i];
-            internalF[1][i] = internalF[0][i] - s;
-            internalF[2][i] = internalF[3][i] + s;
-        }
-        for (int i = 0; i < 3; i++) {
-            forces[permutedParticles[term.p1]][i] += internalF[0][i];
-            forces[permutedParticles[term.p2]][i] -= internalF[1][i];
-            forces[permutedParticles[term.p3]][i] -= internalF[2][i];
-            forces[permutedParticles[term.p4]][i] += internalF[3][i];
-        }
-    }
 
     // Add the energy
 

--- a/tests/TestCustomCompoundBondForce.h
+++ b/tests/TestCustomCompoundBondForce.h
@@ -50,7 +50,7 @@ using namespace std;
 
 const double TOL = 1e-5;
 
-void testBond() {
+void testBond(bool byParticles) {
     // Create a system using a CustomCompoundBondForce.
 
     System customSystem;
@@ -58,7 +58,12 @@ void testBond() {
     customSystem.addParticle(1.0);
     customSystem.addParticle(1.0);
     customSystem.addParticle(1.0);
-    CustomCompoundBondForce* custom = new CustomCompoundBondForce(4, "0.5*kb*((distance(p1,p2)-b0)^2+(distance(p2,p3)-b0)^2)+0.5*ka*(angle(p2,p3,p4)-a0)^2+kt*(1+cos(dihedral(p1,p2,p3,p4)-t0))");
+    string expression;
+    if (byParticles)
+        expression = "0.5*kb*((distance(p1,p2)-b0)^2+(distance(p2,p3)-b0)^2)+0.5*ka*(angle(p2,p3,p4)-a0)^2+kt*(1+cos(dihedral(p1,p2,p3,p4)-t0))";
+    else
+        expression = "0.5*kb*((pointdistance(x1,y1,z1,x2,y2,z2)-b0)^2+(pointdistance(x2,y2,z2,x3,y3,z3)-b0)^2)+0.5*ka*(pointangle(x2,y2,z2,x3,y3,z3,x4,y4,z4)-a0)^2+kt*(1+cos(pointdihedral(x1,y1,z1,x2,y2,z2,x3,y3,z3,x4,y4,z4)-t0))";
+    CustomCompoundBondForce* custom = new CustomCompoundBondForce(4, expression);
     custom->addPerBondParameter("kb");
     custom->addPerBondParameter("ka");
     custom->addPerBondParameter("kt");
@@ -330,7 +335,7 @@ void testIllegalVariable() {
     ASSERT(threwException);
 }
 
-void testPeriodic() {
+void testPeriodic(bool byParticles) {
     // Create a force that uses periodic boundary conditions.
 
     System customSystem;
@@ -339,7 +344,12 @@ void testPeriodic() {
     customSystem.addParticle(1.0);
     customSystem.addParticle(1.0);
     customSystem.setDefaultPeriodicBoxVectors(Vec3(3, 0, 0), Vec3(0, 3, 0), Vec3(0, 0, 3));
-    CustomCompoundBondForce* custom = new CustomCompoundBondForce(4, "0.5*kb*((distance(p1,p2)-b0)^2+(distance(p2,p3)-b0)^2)+0.5*ka*(angle(p2,p3,p4)-a0)^2+kt*(1+cos(dihedral(p1,p2,p3,p4)-t0))");
+    string expression;
+    if (byParticles)
+        expression = "0.5*kb*((distance(p1,p2)-b0)^2+(distance(p2,p3)-b0)^2)+0.5*ka*(angle(p2,p3,p4)-a0)^2+kt*(1+cos(dihedral(p1,p2,p3,p4)-t0))";
+    else
+        expression = "0.5*kb*((pointdistance(x1,y1,z1,x2,y2,z2)-b0)^2+(pointdistance(x2,y2,z2,x3,y3,z3)-b0)^2)+0.5*ka*(pointangle(x2,y2,z2,x3,y3,z3,x4,y4,z4)-a0)^2+kt*(1+cos(pointdihedral(x1,y1,z1,x2,y2,z2,x3,y3,z3,x4,y4,z4)-t0))";
+    CustomCompoundBondForce* custom = new CustomCompoundBondForce(4, expression);
     custom->addPerBondParameter("kb");
     custom->addPerBondParameter("ka");
     custom->addPerBondParameter("kt");
@@ -453,13 +463,15 @@ void runPlatformTests();
 int main(int argc, char* argv[]) {
     try {
         initializeTests(argc, argv);
-        testBond();
+        testBond(true);
+        testBond(false);
         testPositionDependence();
         testContinuous2DFunction();
         testContinuous3DFunction();
         testMultipleBonds();
         testIllegalVariable();
-        testPeriodic();
+        testPeriodic(true);
+        testPeriodic(false);
         testEnergyParameterDerivatives();
         runPlatformTests();
     }

--- a/tests/TestCustomCompoundBondForce.h
+++ b/tests/TestCustomCompoundBondForce.h
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2012-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2012-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *


### PR DESCRIPTION
This adds three new functions that can be used in CustomCompoundBondForce, CustomCentroidBondForce, and CustomManyParticleForce: `pointdistance()`, `pointangle()`, and `pointdihedral()`.  These are similar to the `distance()`, `angle()`, and `dihedral()` functions, but instead of taking particle identifiers they take the coordinates of the points to base the calculation on.  This allows lots of computations that weren't possible before.  As an example, you can calculate the distance from p1 to the midpoint between p2 and p3 with `pointdistance(x1, y1, z1, (x2+x3)/2, (y2+y3)/2, (z2+z3)/2)`.

As a bonus, I was able to use this feature to simplify the implementation of custom forces, so it actually leads to a large reduction in total lines of code!

My immediate reason for implementing this is that it will let me use custom forces for more of the AMOEBA terms.  It should be useful for a lot of other things too.