### PR TITLE
Read E14FAC Coulomb 1-4 scaling factor in CHARMM files

### DIFF
--- a/wrappers/python/openmm/app/charmmparameterset.py
+++ b/wrappers/python/openmm/app/charmmparameterset.py
@@ -116,6 +116,7 @@ class CharmmParameterSet(object):
         self.nbthole_types = dict()
         self.parametersets = []
         self.nbxmod = 5
+        self.e14fac = 1.0
 
         # Load all of the files
         tops, pars, strs = [], [], []
@@ -273,6 +274,8 @@ class CharmmParameterSet(object):
                     if nbxmod not in list(range(-5, 6)):
                         raise CharmmFileError('Unsupported value for NBXMOD: %d' % nbxmod)
                     self.nbxmod = nbxmod
+                if 'E14FAC' in fields:
+                    self.e14fac = float(fields[fields.index('E14FAC')+1])
                 continue
             if line.startswith('NBFIX'):
                 section = 'NBFIX'

--- a/wrappers/python/openmm/app/charmmpsffile.py
+++ b/wrappers/python/openmm/app/charmmpsffile.py
@@ -1384,7 +1384,7 @@ class CharmmPsfFile(object):
             for ia1, ia4 in self.pair_14_list:
                 atom1 = self.atom_list[ia1]
                 atom4 = self.atom_list[ia4]
-                charge_prod = (atom1.charge * atom4.charge)
+                charge_prod = (atom1.charge * atom4.charge) * params.e14fac
                 epsilon = sqrt(abs(atom1.type.epsilon_14 * atom4.type.epsilon_14)) * ene_conv
                 sigma = (atom1.type.rmin_14 + atom4.type.rmin_14) * (length_conv * sigma_scale)
                 force.addException(ia1, ia4, charge_prod, sigma, epsilon)


### PR DESCRIPTION
Read the E14FAC Coulomb 1-4 scaling factor from CHARMM parameter files (NONBONDED line).
This would enable support of different force field specifications in the CHARMM input format.