### PR TITLE
Made ComputeContext worker threads rethrow encountered exceptions into the main thread.

### DIFF
--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -515,7 +515,8 @@ public:
     void flush();
 private:
     std::queue<ComputeContext::WorkTask*> tasks;
-    bool waiting, finished;
+    bool waiting, finished, crashed;
+    OpenMM::OpenMMException crash;
     pthread_mutex_t queueLock;
     pthread_cond_t waitForTaskCondition, queueEmptyCondition;
     pthread_t thread;

--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -515,8 +515,8 @@ public:
     void flush();
 private:
     std::queue<ComputeContext::WorkTask*> tasks;
-    bool waiting, finished, crashed;
-    OpenMM::OpenMMException crash;
+    bool waiting, finished, threwException;
+    OpenMMException stashedException;
     pthread_mutex_t queueLock;
     pthread_cond_t waitForTaskCondition, queueEmptyCondition;
     pthread_t thread;

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -621,14 +621,16 @@ void ComputeContext::addPostComputation(ForcePostComputation* computation) {
 }
 
 struct ComputeContext::WorkThread::ThreadData {
-    ThreadData(std::queue<ComputeContext::WorkTask*>& tasks, bool& waiting,  bool& finished,
+    ThreadData(std::queue<ComputeContext::WorkTask*>& tasks, bool& waiting,  bool& finished, bool& crashed, OpenMMException& crash,
             pthread_mutex_t& queueLock, pthread_cond_t& waitForTaskCondition, pthread_cond_t& queueEmptyCondition) :
-        tasks(tasks), waiting(waiting), finished(finished), queueLock(queueLock),
-        waitForTaskCondition(waitForTaskCondition), queueEmptyCondition(queueEmptyCondition) {
+        tasks(tasks), waiting(waiting), finished(finished), crashed(crashed), crash(crash),
+        queueLock(queueLock), waitForTaskCondition(waitForTaskCondition), queueEmptyCondition(queueEmptyCondition) {
     }
     std::queue<ComputeContext::WorkTask*>& tasks;
     bool& waiting;
     bool& finished;
+    bool& crashed;
+    OpenMMException& crash;
     pthread_mutex_t& queueLock;
     pthread_cond_t& waitForTaskCondition;
     pthread_cond_t& queueEmptyCondition;
@@ -643,6 +645,11 @@ static void* threadBody(void* args) {
             pthread_cond_signal(&data.queueEmptyCondition);
             pthread_cond_wait(&data.waitForTaskCondition, &data.queueLock);
         }
+        // If we keep going after having crashed once, next tasks will likely throw too and we don't want the initial exception overshadowed.
+        while(data.crashed && !data.tasks.empty()) {
+            delete data.tasks.front();
+            data.tasks.pop();
+        }
         ComputeContext::WorkTask* task = NULL;
         if (!data.tasks.empty()) {
             data.waiting = false;
@@ -651,7 +658,13 @@ static void* threadBody(void* args) {
         }
         pthread_mutex_unlock(&data.queueLock);
         if (task != NULL) {
-            task->execute();
+            try {
+                task->execute();
+            }
+            catch(const OpenMMException& e) {
+                data.crashed = true;
+                data.crash = e;
+            }
             delete task;
         }
     }
@@ -661,11 +674,11 @@ static void* threadBody(void* args) {
     return 0;
 }
 
-ComputeContext::WorkThread::WorkThread() : waiting(true), finished(false) {
+ComputeContext::WorkThread::WorkThread() : waiting(true), finished(false), crashed(false), crash("Default threadPool exception. This should never be thrown.") {
     pthread_mutex_init(&queueLock, NULL);
     pthread_cond_init(&waitForTaskCondition, NULL);
     pthread_cond_init(&queueEmptyCondition, NULL);
-    ThreadData* data = new ThreadData(tasks, waiting, finished, queueLock, waitForTaskCondition, queueEmptyCondition);
+    ThreadData* data = new ThreadData(tasks, waiting, finished, crashed, crash, queueLock, waitForTaskCondition, queueEmptyCondition);
     pthread_create(&thread, NULL, threadBody, data);
 }
 
@@ -701,4 +714,8 @@ void ComputeContext::WorkThread::flush() {
     while (!waiting)
        pthread_cond_wait(&queueEmptyCondition, &queueLock);
     pthread_mutex_unlock(&queueLock);
+    if(crashed) {
+        crashed = false;
+        throw crash;
+    }
 }

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -674,7 +674,7 @@ static void* threadBody(void* args) {
     return 0;
 }
 
-ComputeContext::WorkThread::WorkThread() : waiting(true), finished(false), threwException(false), stashedException("Default threadPool exception. This should never be thrown.") {
+ComputeContext::WorkThread::WorkThread() : waiting(true), finished(false), threwException(false), stashedException("Default WorkThread exception. This should never be thrown.") {
     pthread_mutex_init(&queueLock, NULL);
     pthread_cond_init(&waitForTaskCondition, NULL);
     pthread_cond_init(&queueEmptyCondition, NULL);


### PR DESCRIPTION
While trying to debug the #3039 i ran into a problem: when i tried to catch crashes from main, the exception just "ignored" the catch statement. It puzzled me for a while and after some thinking i realized what the problem was: when an exception arises inside of a worker thread, it crashes the entire thing. So i made it stash the exception until the `flush()` is called and then rethrow it into the main thread.