### PR TITLE
Fixed rare error related to single pairs

### DIFF
--- a/platforms/cuda/src/kernels/findInteractingBlocks.cu
+++ b/platforms/cuda/src/kernels/findInteractingBlocks.cu
@@ -98,7 +98,7 @@ __device__ int saveSinglePairs(int x, int* atoms, int* flags, int length, unsign
     int pairIndex = pairStartIndex + (indexInWarp > 0 ? prevSum : 0);
     for (int i = indexInWarp; i < length; i += 32) {
         int count = __popc(flags[i]);
-        if (count <= MAX_BITS_FOR_PAIRS && pairIndex+count < maxSinglePairs) {
+        if (count <= MAX_BITS_FOR_PAIRS && pairIndex+count <= maxSinglePairs) {
             int f = flags[i];
             while (f != 0) {
                 singlePairs[pairIndex] = make_int2(atoms[i], x*TILE_SIZE+__ffs(f)-1);


### PR DESCRIPTION
Fixes #3029.

This fixes a very rare error related to the single pairs optimization, which was reenabled in #2863.  It doesn't know in advance how many single pairs there will be.  So it allocates an amount of memory that it hopes will be enough.  If it ever turns out not to be, it cancels that force evaluation and allocates a new, larger array for it.

Due to an off by one error, if the number of single pairs was *exactly* equal to the number it allocated space for, the last few entries in the list wouldn't get recorded properly.