### PR TITLE
Fix compilation error in test

### DIFF
--- a/tests/TestVectorizeGeneric.h
+++ b/tests/TestVectorizeGeneric.h
@@ -36,6 +36,7 @@
  */
 
 #include <array>
+#include <cstring>
 #include <functional>
 #include <iostream>
 #include <iterator>


### PR DESCRIPTION
Fixes #3033.  For some reason, the compiler being used there seems to require an extra `#include` that isn't required on other compilers.