### PR TITLE
Release GIL when calling getState()

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
@@ -10,6 +10,20 @@
     }
 }
 
+%exception *::getState {
+    PyThreadState* _savePythonThreadState = PyEval_SaveThread();
+    try {
+        $action
+    } catch (std::exception &e) {
+        PyEval_RestoreThread(_savePythonThreadState);
+        PyObject* mm = PyImport_AddModule("openmm");
+        PyObject* openmm_exception = PyObject_GetAttrString(mm, "OpenMMException");
+        PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
+        return NULL;
+    }
+    PyEval_RestoreThread(_savePythonThreadState);
+}
+
 %exception *::step {
     PyThreadState* _savePythonThreadState = PyEval_SaveThread();
     try {


### PR DESCRIPTION
The Python wrapper already released the GIL when calling `step()` or `minimize()`, but not `getState()`.  This matters for two reasons.  First, it allows another Python thread to run while OpenMM is working.  Second, it's necessary for the PyTorch plugin.  Apparently the latest version of libtorch throws an exception if you try to do certain operations while holding the GIL.