### PR TITLE
Remove hard-coded default path to nvcc

### DIFF
--- a/docs-source/usersguide/library.rst
+++ b/docs-source/usersguide/library.rst
@@ -1908,7 +1908,7 @@ The CUDA Platform recognizes the following Platform-specific properties:
 
   * Mac/Linux: It first looks for an environment variable called
     OPENMM_CUDA_COMPILER.  If that is set, its value is used.  Otherwise, the
-    default location is set to /usr/local/cuda/bin/nvcc.
+    default location is set to nvcc.
   * Windows: It looks for an environment variable called CUDA_BIN_PATH, then
     appends \nvcc.exe to it.  That environment variable is set by the CUDA
     installer, so it usually is present.

--- a/platforms/cuda/src/CudaPlatform.cpp
+++ b/platforms/cuda/src/CudaPlatform.cpp
@@ -136,7 +136,7 @@ CudaPlatform::CudaPlatform() {
     setPropertyDefaultValue(CudaTempDirectory(), string(getenv("TEMP")));
 #else
     char* compiler = getenv("OPENMM_CUDA_COMPILER");
-    string nvcc = (compiler == NULL ? "/usr/local/cuda/bin/nvcc" : string(compiler));
+    string nvcc = (compiler == NULL ? "nvcc" : string(compiler));
     setPropertyDefaultValue(CudaCompiler(), nvcc);
     char* tmpdir = getenv("TMPDIR");
     string tmp = (tmpdir == NULL ? string(P_tmpdir) : string(tmpdir));


### PR DESCRIPTION
The current version of the code hardcodes the default value of `CudaCompiler` to `/usr/local/cuda/bin/nvcc`, but it is commonly not installed at that location on HPC systems. This means that nvcc compilation cannot be forced by simply setting `CudaCompiler` to the value from `getPropertyDefaultValue("CudaCompiler")`. Instead, the user must explicitly set `OPENMM_CUDA_COMPILER` which adds undesirable complexity.

This changes the default value of `CudaCompiler` to simply be `nvcc` rather than a hardcoded path. This should use whatever version of nvcc is in the user's path. This will make it easier to force the compilation of a kernel with nvcc rather than nvrtc without requiring the user to set `OPENMM_CUDA_COMPILER`.
