### PR TITLE
Updated build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+__pycache__

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We welcome anyone who wants to contribute to the project, whether by adding a feature,
 fixing a bug, or improving documentation.  The process is quite simple.
 
-First, it is always best to begin by opening an issue on Github that describes the change you
+First, it is always best to begin by opening an issue on GitHub that describes the change you
 want to make.  This gives everyone a chance to discuss it before you put in a lot of work.
 For bug fixes, we will confirm that the behavior is actually a bug and that the proposed fix
 is correct.  For new features, we will decide whether the proposed feature is something we
@@ -11,7 +11,7 @@ want and discuss possible designs for it.
 
 Once everyone is in agreement, the next step is to
 [create a pull request](https://help.github.com/en/articles/about-pull-requests) with the code changes.
-For larger features, feel free to create the pull request even before the implementaton is
+For larger features, feel free to create the pull request even before the implementation is
 finished so as to get early feedback on the code.  When doing this, put the letters "WIP" at
 the start of the title of the pull request to indicate it is still a work in progress.
 
@@ -24,4 +24,72 @@ The core developers will review the pull request and may suggest changes.  Simpl
 changes to the branch that is being pulled from, and they will automatically be added to the
 pull request.  In addition, the full test suite is automatically run on every pull request,
 and rerun every time a change is added.  Once the tests are passing and everyone is satisfied
-with the code, the pull request will be merged.  Congratulations on a succesful contribution!
+with the code, the pull request will be merged.  Congratulations on a successful contribution!
+
+## Building OpenMM
+
+OpenMM uses [cmake](https://cmake.org/) as our build system and requires quite a number of dependencies.
+
+### Installing dependencies
+
+OpenMM's dependencies are described in detail in [the User Guide](http://docs.openmm.org/latest/userguide/library.html#compiling-openmm-from-source-code). The easiest and fastest way to install all required dependencies is to use the [Conda package manager](https://conda.io).
+
+#### on Linux
+
+```shell
+# Install build requirements
+conda env create -n openmm-dev -f devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
+# Add documentation requirements to environment - optional
+conda env update -n openmm-dev -f devtools/ci/gh-actions/conda-envs/docs.yml
+```
+
+#### on OSX
+
+```shell
+# Install build requirements
+conda env create -n openmm-dev -f devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
+# Add documentation requirements to environment - optional
+conda env update -n openmm-dev -f devtools/ci/gh-actions/conda-envs/docs.yml
+```
+
+#### on Windows
+
+```shell
+# Install build requirements
+conda env create -n openmm-dev -f devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
+# Add documentation requirements to environment - optional
+conda env update -n openmm-dev -f devtools/ci/gh-actions/conda-envs/docs.yml
+```
+
+### Configuring make files
+
+```shell
+mkdir build
+cd build
+# For other options, check the User Guide or try `ccmake ..`
+cmake .. -DOPENMM_GENERATE_API_DOCS=ON
+```
+
+### Compiling OpenMM
+
+From the `build` directory created in the previous step:
+
+```shell
+# Build libraries and tests
+make
+# Build Python API
+make PythonInstall
+```
+
+### Compiling the documentation
+
+The docs require the Python API to be compiled, as described in the previous step
+
+```shell
+# Compile the User's and Developer's guides as HTML
+make sphinxhtml
+# Compile the C++ API docs
+make C++ApiDocs
+# Compile the Python API docs
+make PythonApiDocs
+```

--- a/docs-source/developerguide/developer.rst
+++ b/docs-source/developerguide/developer.rst
@@ -42,6 +42,8 @@ Users Manual and work through some of the example programs.  Pay especially
 close attention to the “Introduction to the OpenMM Library” chapter, since it
 introduces concepts that are important in understanding this guide.
 
+For detailed build instructions, see the `User Guide <http://docs.openmm.org/latest/userguide/library.html#compiling-openmm-from-source-code>`_.
+
 
 .. _the-core-library:
 

--- a/docs-source/usersguide/library.rst
+++ b/docs-source/usersguide/library.rst
@@ -416,15 +416,13 @@ Get the OpenMM source code
 You will also need the OpenMM source code before building OpenMM from source.
 To download and unpack OpenMM source code:
 
-#. Browse to https://simtk.org/home/openmm.
-#. Click the "Downloads" link in the navigation bar on the left side.
-#. Download OpenMM<Version>-Source.zip, choosing the latest version.
-#. Unpack the zip file.  Note the location where you unpacked the OpenMM source
-   code.
+#. Browse to https://github.com/openmm/openmm/releases.
+#. Download the source code for the latest version under the Assets heading. Choose the zip file on Windows or if you're unsure.
+#. Unpack the downloaded file.  Note the location where you unpacked the OpenMM source code.
 
 Alternatively, if you want the most recent development version of the code rather
 than the version corresponding to a particular release, you can get it from
-https://github.com/pandegroup/openmm.  Be aware that the development code is constantly
+https://github.com/openmm/openmm/.  Be aware that the development code is constantly
 changing, may contain bugs, and should never be used for production work.  If
 you want a stable, well tested version of OpenMM, you should download the source
 code for the latest release as described above.
@@ -465,7 +463,7 @@ CMake.
 
    * Doxygen (http://www.doxygen.org)
 
-
+Instructions for installing all of these dependencies with the Conda package manager are included in the CONTRIBUTING.md file in the source distribution.
 
 Step 1: Configure with CMake
 ****************************
@@ -499,7 +497,7 @@ On Mac and Linux machines, type the following two lines:
 ::
 
     cd build_openmm
-    ccmake -i <path to OpenMM src directory>
+    ccmake <path to OpenMM src directory>
 
 That is not a typo.  :code:`ccmake` has two c’s.  CCMake is the visual CMake
 configuration tool.         Press “\ :code:`c`\ ” within the CCMake interface to
@@ -543,7 +541,7 @@ There are several variables that can be adjusted in the CMake interface:
 Configure (press “c”) again.  Adjust any variables that cause an
 error.
 
-Continue to configure (press “c”) until no starred/red CMake
+Continue to adjust and configure (press “c”) until no starred/red CMake
 variables are displayed.  Congratulations, you have completed the configuration
 step.
 
@@ -692,21 +690,21 @@ Building the Documentation (Optional)
 *************************************
 
 The documentation that you're currently reading, as well as the developer guide and API
-documentation can be built through CMake by setting the OpenMM option :code:`OPENMM_GENERATE_API_DOCS=ON`.
+documentation can be built through CMake by setting the OpenMM option :code:`OPENMM_GENERATE_API_DOCS=ON`. Building the documentation requires that at least the Python API is built (see above).
 
 User Guide and Developer Guide
 ==============================
 
 Generating the user guide and developer guide requires the following dependencies
 
-* Sphinx (http://sphinx-doc.org/)
+* Sphinx --- version 2.3.1 (http://sphinx-doc.org/)
 
-* sphinxcontrib-bibtex (https://pypi.python.org/pypi/sphinxcontrib-bibtex)
+* sphinxcontrib-bibtex --- any version before 2.0.0 (https://pypi.python.org/pypi/sphinxcontrib-bibtex)
 
 These dependencies may not be available in your system package manager, but should
 be installable through Python's ``pip`` package manager. ::
 
-   pip install sphinx sphinxcontrib-bibtex
+   pip install sphinx==2.3.1 sphinxcontrib-bibtex<2.0.0
 
 The developer and user guides can be built either as HTML or a PDFs. Building the
 PDF version will also require a functional LaTeX installation.
@@ -725,7 +723,7 @@ Python and C++ API Documentation
 
 The following dependencies are required to build the Python and C++ API documentation.
 
-* Sphinx (http://sphinx-doc.org/)
+* Sphinx version 2.3.1 (http://sphinx-doc.org/)
 
 * sphinxcontrib-lunrsearch (https://pypi.python.org/pypi/sphinxcontrib-lunrsearch)
 
@@ -735,7 +733,7 @@ The following dependencies are required to build the Python and C++ API document
 These dependencies may not be available in your system package manager, but should
 be installable through Python's ``pip`` package manager. ::
 
-   pip install sphinx sphinxcontrib-lunrsearch sphinxcontrib-autodoc_doxygen
+   pip install sphinx==2.3.1 sphinxcontrib-lunrsearch sphinxcontrib-autodoc_doxygen
 
 To build the C++ API documentation, type: ::
 


### PR DESCRIPTION
Previously, the build instructions especially for documentation was out of date and was difficult to locate. With this PR, simple instructions for experienced developers are found in CONTRIBUTING.md, the reader is referred to the appropriate section of the User Guide from both CONTRIBUTING.md and the introduction of the Developer's Guide, and the User Guide has been updated to be more complete and accurate.

Closes #3125 and #3126.