### PR TITLE
Support initialization scripts in force fields

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -330,7 +330,7 @@ class ForceField(object):
                             self.registerTemplatePatch(resName, patchName, 0)
                     self.registerResidueTemplate(template)
 
-        # Load the patch defintions.
+        # Load the patch definitions.
 
         for tree in trees:
             if tree.getroot().find('Patches') is not None:
@@ -410,6 +410,12 @@ class ForceField(object):
         for tree in trees:
             for node in tree.getroot().findall('Script'):
                 self.registerScript(node.text)
+
+        # Execute initialization scripts.
+
+        for tree in trees:
+            for node in tree.getroot().findall('InitializationScript'):
+                exec(node.text, locals())
 
     def getGenerators(self):
         """Get the list of all registered generators."""

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -1149,6 +1149,19 @@ END"""))
         self.assertAlmostEqual(26.10373, propers, delta=propers*1e-3) # DIHEdrals
         self.assertAlmostEqual(0.14113, impropers, delta=impropers*1e-3) # IMPRopers
 
+    def test_InitializationScript(self):
+        """Test that <InitializationScript> tags get executed."""
+        xml = """
+<ForceField>
+  <InitializationScript>
+self.scriptExecuted = True
+  </InitializationScript>
+</ForceField>
+"""
+        ff = ForceField(StringIO(xml))
+        self.assertTrue(ff.scriptExecuted)
+        
+
 class AmoebaTestForceField(unittest.TestCase):
     """Test the ForceField.createSystem() method with the AMOEBA forcefield."""
 


### PR DESCRIPTION
This allows force fields to include an `<InitializationScript>` tag that gets executed when the file is loaded.  This is needed to let GLYCAM be fully self contained.  See https://github.com/openmm/openmmforcefields/pull/156#issuecomment-870799618 for details.

For the moment, I'm leaving this as an undocumented feature and treating it as part of the internal implementation of GLYCAM.  That way we can change it in the future without breaking users' code.  If we decide later we want to make it a fully supported feature, we can document it then.

For GLYCAM, add the following tag to the XML file:

```xml
  <InitializationScript>
class GlycamTemplateMatcher(object):
  def __init__(self, glycam_residues):
    self.glycam_residues = glycam_residues
  def __call__(self, ff, residue):
    if residue.name in self.glycam_residues:
      return ff._templates[residue.name]
    return None

glycam_residues = set()
for residue in tree.getroot().find('Residues').findall('Residue'):
  glycam_residues.add(residue.get('name'))
self.registerTemplateMatcher(GlycamTemplateMatcher(glycam_residues))
  </InitializationScript>
```

cc @zhang-ivy