### PR TITLE
Allow disabling the direct space calculation in NonbondedForce

### DIFF
--- a/openmmapi/include/openmm/NonbondedForce.h
+++ b/openmmapi/include/openmm/NonbondedForce.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -544,6 +544,18 @@ public:
      */
     void setReciprocalSpaceForceGroup(int group);
     /**
+     * Get whether to include direct space interactions when calculating forces and energies.  This is useful if you want
+     * to completely replace the direct space calculation, typically with a CustomNonbondedForce that computes it in a
+     * nonstandard way, while still using this object for the reciprocal space calculation.
+     */
+    bool getIncludeDirectSpace() const;
+    /**
+     * Set whether to include direct space interactions when calculating forces and energies.  This is useful if you want
+     * to completely replace the direct space calculation, typically with a CustomNonbondedForce that computes it in a
+     * nonstandard way, while still using this object for the reciprocal space calculation.
+     */
+    void setIncludeDirectSpace(bool include);
+    /**
      * Update the particle and exception parameters in a Context to match those stored in this Force object.  This method
      * provides an efficient method to update certain parameters in an existing Context without needing to reinitialize it.
      * Simply call setParticleParameters() and setExceptionParameters() to modify this object's parameters, then call
@@ -604,7 +616,7 @@ private:
     class ExceptionOffsetInfo;
     NonbondedMethod nonbondedMethod;
     double cutoffDistance, switchingDistance, rfDielectric, ewaldErrorTol, alpha, dalpha;
-    bool useSwitchingFunction, useDispersionCorrection, exceptionsUsePeriodic;
+    bool useSwitchingFunction, useDispersionCorrection, exceptionsUsePeriodic, includeDirectSpace;
     int recipForceGroup, nx, ny, nz, dnx, dny, dnz;
     void addExclusionsToSet(const std::vector<std::set<int> >& bonded12, std::set<int>& exclusions, int baseParticle, int fromParticle, int currentLevel) const;
     int getGlobalParameterIndex(const std::string& parameter) const;

--- a/openmmapi/src/NonbondedForce.cpp
+++ b/openmmapi/src/NonbondedForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -49,7 +49,7 @@ using std::vector;
 
 NonbondedForce::NonbondedForce() : nonbondedMethod(NoCutoff), cutoffDistance(1.0), switchingDistance(-1.0), rfDielectric(78.3),
         ewaldErrorTol(5e-4), alpha(0.0), dalpha(0.0), useSwitchingFunction(false), useDispersionCorrection(true), exceptionsUsePeriodic(false), recipForceGroup(-1),
-        nx(0), ny(0), nz(0), dnx(0), dny(0), dnz(0) {
+        includeDirectSpace(true), nx(0), ny(0), nz(0), dnx(0), dny(0), dnz(0) {
 }
 
 NonbondedForce::NonbondedMethod NonbondedForce::getNonbondedMethod() const {
@@ -342,6 +342,14 @@ void NonbondedForce::setReciprocalSpaceForceGroup(int group) {
     if (group < -1 || group > 31)
         throw OpenMMException("Force group must be between -1 and 31");
     recipForceGroup = group;
+}
+
+bool NonbondedForce::getIncludeDirectSpace() const {
+    return includeDirectSpace;
+}
+
+void NonbondedForce::setIncludeDirectSpace(bool include) {
+    includeDirectSpace = include;
 }
 
 void NonbondedForce::updateParametersInContext(Context& context) {

--- a/openmmapi/src/NonbondedForceImpl.cpp
+++ b/openmmapi/src/NonbondedForceImpl.cpp
@@ -103,10 +103,11 @@ void NonbondedForceImpl::initialize(ContextImpl& context) {
 }
 
 double NonbondedForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    bool includeDirect = ((groups&(1<<owner.getForceGroup())) != 0);
-    bool includeReciprocal = includeDirect;
-    if (owner.getReciprocalSpaceForceGroup() >= 0)
-        includeReciprocal = ((groups&(1<<owner.getReciprocalSpaceForceGroup())) != 0);
+    bool includeDirect = (owner.getIncludeDirectSpace() && (groups&(1<<owner.getForceGroup())) != 0);
+    int reciprocalGroup = owner.getReciprocalSpaceForceGroup();
+    if (reciprocalGroup < 0)
+        reciprocalGroup = owner.getForceGroup();
+    bool includeReciprocal = ((groups&(1<<reciprocalGroup)) != 0);
     return kernel.getAs<CalcNonbondedForceKernel>().execute(context, includeForces, includeEnergy, includeDirect, includeReciprocal);
 }
 

--- a/serialization/src/NonbondedForceProxy.cpp
+++ b/serialization/src/NonbondedForceProxy.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -54,6 +54,7 @@ void NonbondedForceProxy::serialize(const void* object, SerializationNode& node)
     node.setDoubleProperty("rfDielectric", force.getReactionFieldDielectric());
     node.setIntProperty("dispersionCorrection", force.getUseDispersionCorrection());
     node.setIntProperty("exceptionsUsePeriodic", force.getExceptionsUsePeriodicBoundaryConditions());
+    node.setBoolProperty("includeDirectSpace", force.getIncludeDirectSpace());
     double alpha;
     int nx, ny, nz;
     force.getPMEParameters(alpha, nx, ny, nz);
@@ -116,6 +117,8 @@ void* NonbondedForceProxy::deserialize(const SerializationNode& node) const {
         force->setEwaldErrorTolerance(node.getDoubleProperty("ewaldTolerance"));
         force->setReactionFieldDielectric(node.getDoubleProperty("rfDielectric"));
         force->setUseDispersionCorrection(node.getIntProperty("dispersionCorrection"));
+        if (node.hasProperty("includeDirectSpace"))
+            force->setIncludeDirectSpace(node.getBoolProperty("includeDirectSpace"));
         double alpha = node.getDoubleProperty("alpha", 0.0);
         int nx = node.getIntProperty("nx", 0);
         int ny = node.getIntProperty("ny", 0);

--- a/serialization/tests/TestSerializeNonbondedForce.cpp
+++ b/serialization/tests/TestSerializeNonbondedForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -52,6 +52,7 @@ void testSerialization() {
     force.setReactionFieldDielectric(50.0);
     force.setUseDispersionCorrection(false);
     force.setExceptionsUsePeriodicBoundaryConditions(true);
+    force.setIncludeDirectSpace(false);
     double alpha = 0.5;
     int nx = 3, ny = 5, nz = 7;
     force.setPMEParameters(alpha, nx, ny, nz);
@@ -92,6 +93,7 @@ void testSerialization() {
     ASSERT_EQUAL(force.getNumGlobalParameters(), force2.getNumGlobalParameters());
     ASSERT_EQUAL(force.getNumParticleParameterOffsets(), force2.getNumParticleParameterOffsets());
     ASSERT_EQUAL(force.getNumExceptionParameterOffsets(), force2.getNumExceptionParameterOffsets());
+    ASSERT_EQUAL(force.getIncludeDirectSpace(), force2.getIncludeDirectSpace());
     double alpha2;
     int nx2, ny2, nz2;
     force2.getPMEParameters(alpha2, nx2, ny2, nz2);


### PR DESCRIPTION
This lets you use a NonbondedForce only for the reciprocal space calculation, while using a CustomNonbondedForce to compute the direct space part in a nonstandard way.  This will be useful for #3166.

cc @dominicrufa @zhang-ivy