### PR TITLE
Deleted the default copy-constuctor for ContextImpl.

### DIFF
--- a/openmmapi/include/openmm/internal/ContextImpl.h
+++ b/openmmapi/include/openmm/internal/ContextImpl.h
@@ -57,6 +57,7 @@ public:
      */
     ContextImpl(Context& owner, const System& system, Integrator& integrator, Platform* platform, const std::map<std::string, std::string>& properties,
             ContextImpl* originalContext=NULL);
+    ContextImpl(const ContextImpl&) = delete;
     ~ContextImpl();
     /**
      * Get the Context for which this is the implementation.

--- a/openmmapi/include/openmm/internal/ContextImpl.h
+++ b/openmmapi/include/openmm/internal/ContextImpl.h
@@ -58,6 +58,7 @@ public:
     ContextImpl(Context& owner, const System& system, Integrator& integrator, Platform* platform, const std::map<std::string, std::string>& properties,
             ContextImpl* originalContext=NULL);
     ContextImpl(const ContextImpl&) = delete;
+    ContextImpl& operator=(const ContextImpl&) = delete;
     ~ContextImpl();
     /**
      * Get the Context for which this is the implementation.


### PR DESCRIPTION
Whenever a `ContextImpl` object is destroyed, it calls `contextDestroyed` which deletes the `platformData`, thus corrupting all copies of the object that might have been created, because all the `platformData` pointers in copies are now dangling. The same happens to pointers in `forceImpls`. Therefore, it should be impossible to copy `ContextImpl`.

I got bitten by this after accidentally passing a `ContextImpl` object by value into a function, which deleted the `platformData` after it returned. It wasn't trivial to track down, hence the motivation to propose this change.