### PR TITLE
Update instructions on compiling from source

### DIFF
--- a/docs-source/usersguide/library/02_compiling.rst
+++ b/docs-source/usersguide/library/02_compiling.rst
@@ -3,281 +3,134 @@
 Compiling OpenMM from Source Code
 #################################
 
-This chapter describes the procedure for building and installing OpenMM
-libraries from source code.  It is recommended that you use binary OpenMM
-libraries, if possible.  If there are not suitable binary libraries for your
-system, consider building OpenMM from source code by following these
-instructions.
+This chapter describes the procedure for building and installing OpenMM from
+source code.  In most cases, it is best to use the pre-built versions installed
+with conda.  Sometimes you might need to build from source, though, such as if
+you want to modify OpenMM, or if conda does not provide packages compatible with
+your environment.
+
+We first describe how to build on Linux or Mac.  We then describe how to build
+on Windows, where the process is slightly different.
+
+Compiling on Linux and Mac
+**************************
 
 Prerequisites
-*************
-
-Before building OpenMM from source, you will need the following:
-
-* A C++ compiler
-
-* CMake
-
-* OpenMM source code
-
-
-See the sections below for specific instructions for the different platforms.
-
-Get a C++ compiler
-==================
-
-You must have a C++ compiler installed before attempting to build OpenMM from
-source.
-
-Mac and Linux: clang or gcc
----------------------------
-
-Use clang or gcc on Mac/Linux.  OpenMM should compile correctly with all recent
-versions of these compilers.  We recommend clang since it produces faster code,
-especially when using the CPU platform.  If you do not already have a compiler
-installed, you will need to download and install it.  On Mac OS X, this means
-downloading the Xcode Tools from the App Store.
-
-Windows: Visual Studio
-----------------------
-
-On Windows systems, use the C++ compiler in Visual Studio 2015 or later.  You
-can download a free version of the Visual Studio C++ build tools from
-https://visualstudio.microsoft.com.  If you plan to use OpenMM from
-Python, it is critical that both OpenMM and Python be compiled with the same
-version of Visual Studio.
-
-Install CMake
 =============
 
-CMake is the build system used for OpenMM.  You must install CMake version 3.1
-or higher before attempting to build OpenMM from source.  You can get CMake from
-http://www.cmake.org/.  If you choose to build CMake from source on Linux, make
-sure you have the curses library installed beforehand, so that you will be able
-to build the CCMake visual CMake tool.
+Before building OpenMM from source, you will need certain tools.
 
-Get the OpenMM source code
-==========================
+C++ compiler
+------------
 
-You will also need the OpenMM source code before building OpenMM from source.
-To download and unpack OpenMM source code:
+You must have a C++ compiler installed before attempting to build OpenMM from
+source.  All recent versions of clang or gcc should work correctly.  On Linux,
+you can install the compiler with your system's standard package manager (such
+as apt or yum).  On MacOS, you can get a C++ compiler by installing the Xcode
+developer tools from the App Store.  Alternatively you can use a package manager
+such as Homebrew to install clang or gcc.
 
-#. Browse to https://simtk.org/home/openmm.
-#. Click the "Downloads" link in the navigation bar on the left side.
-#. Download OpenMM<Version>-Source.zip, choosing the latest version.
-#. Unpack the zip file.  Note the location where you unpacked the OpenMM source
-   code.
+Python
+------
+
+You will need a 64-bit Python 3.x environment.  We recommend using Miniconda
+(https://docs.conda.io/en/latest/miniconda.html), which includes the conda
+package manager.
+
+OpenMM Source Code
+------------------
+
+You will also need the OpenMM source code.  To download it:
+
+#. Browse to https://github.com/openmm/openmm/releases.
+#. Find the latest release and click the link to download the source as either
+   a .zip or .tar.gz file.
+#. Unpack the file.  Note the location where you unpacked the OpenMM source code.
 
 Alternatively, if you want the most recent development version of the code rather
 than the version corresponding to a particular release, you can get it from
-https://github.com/pandegroup/openmm.  Be aware that the development code is constantly
+https://github.com/openmm/openmm.  Be aware that the development code is constantly
 changing, may contain bugs, and should never be used for production work.  If
 you want a stable, well tested version of OpenMM, you should download the source
 code for the latest release as described above.
 
+CUDA or OpenCL Support
+----------------------
+
+If you want to compile OpenMM with support for running on GPUs, you will need
+CUDA and/or OpenCL.  MacOS comes with OpenCL built in, so nothing else needs to
+be installed.  For Linux, you need an appropriate SDK.
+
+The easiest way is to install the most recent CUDA Toolkit from https://developer.nvidia.com/cuda-downloads.
+It includes the headers and libraries needed to compile both CUDA and OpenCL
+applications.  In addition, it has runtime libraries that are needed for running
+CUDA applications.  The runtime components for OpenCL applications are included
+with the GPU drivers from NVIDIA, AMD, and Intel, so make sure you have an
+up-to-date driver.
+
 Other Required Software
-=======================
+-----------------------
 
-There are several other pieces of software you must install to compile certain
-parts of OpenMM.  Which of these you need depends on the options you select in
-CMake.
-
-* For compiling the CUDA Platform, you need:
-
-   * CUDA (See Chapter :numref:`installing-openmm` for installation instructions.)
-
-* For compiling the OpenCL Platform, you need:
-
-   * OpenCL (See Chapter :numref:`installing-openmm` for installation instructions.)
-
-* For compiling C and Fortran API wrappers, you need:
-
-   * Python 2.7 or later (http://www.python.org)
-   * Doxygen (http://www.doxygen.org)
-   * A Fortran compiler
-
-* For compiling the Python API wrappers, you need:
-
-   * Python 2.7 or later (http://www.python.org)
-   * SWIG (http://www.swig.org)
-   * Doxygen (http://www.doxygen.org)
-   * Cython (https://cython.org)
-
-* For compiling the CPU platform, you need:
-
-   * FFTW, single precision multithreaded version (http://www.fftw.org)
-
-* To generate API documentation, you need:
-
-   * Doxygen (http://www.doxygen.org)
-
-
-
-Step 1: Configure with CMake
-****************************
-
-
-Build and source directories
-============================
-
-First, create a directory in which to build OpenMM.  A good name for this
-directory is build_openmm.  We will refer to this as the “build_openmm
-directory” in the instructions below.  This directory will contain the temporary
-files used by the OpenMM CMake build system.  Do not create this build directory
-within the OpenMM source code directory.  This is what is called an “out of
-source” build, because the build files will not be mixed with the source files.
-
-Also note the location of the OpenMM source directory (i.e., where you unpacked
-the source code zip file).  It should contain a file called CMakeLists.txt.
-This directory is what we will call the “OpenMM source directory” in the
-following instructions.
-
-Starting CMake
-==============
-
-Configuration is the first step of the CMake build process.  In the
-configuration step, the values of important build variables will be established.
-
-Mac and Linux
--------------
-
-On Mac and Linux machines, type the following two lines:
+Several other tools are required to build OpenMM.  The easiest way to install
+them is with conda.  The following command will install everything needed to
+build OpenMM.
 ::
 
-    cd build_openmm
-    ccmake -i <path to OpenMM src directory>
+    conda install -c conda-forge cmake make cython swig fftw doxygen numpy
+
+Step 1: Configure with CMake
+============================
+
+First, create a directory in which to build OpenMM.  Starting from the root
+level of the OpenMM source tree (the directory containing the top CMakeLists.txt
+file), execute the following commands:
+
+.. code-block:: none
+
+    mkdir build
+    cd build
+    ccmake ..
 
 That is not a typo.  :code:`ccmake` has two c’s.  CCMake is the visual CMake
-configuration tool.         Press “\ :code:`c`\ ” within the CCMake interface to
-configure CMake.  Follow the instructions in the “All Platforms” section below.
-
-Windows
--------
-
-On Windows, perform the following steps:
-
-#. Click Start->All Programs->CMake 3.1->CMake
-#. In the box labeled "Where is the source code:" browse to OpenMM src directory
-   (containing top CMakeLists.txt)
-#. In the box labeled "Where to build the binaries" browse to your build_openmm
-   directory.
-#. Click the "Configure" button at the bottom of the CMake screen.
-#. Select "Visual Studio 10 2010" from the  list of Generators (or whichever
-   version you have installed)
-#. Follow the instructions in the “All Platforms” section below.
-
-
-All platforms
--------------
+configuration tool.  Press :code:`c` within the CCMake interface to load the
+OpenMM build scripts and begin configuring CMake.
 
 There are several variables that can be adjusted in the CMake interface:
 
-* If you intend to use CUDA (NVIDIA) or OpenCL acceleration, set the variable
-  OPENMM_BUILD_CUDA_LIB or OPENMM_BUILD_OPENCL_LIB, respectively, to ON.  Before
-  doing so, be certain that you have installed and tested the drivers for the
-  platform you have selected (see Chapter :numref:`installing-openmm` for information on
-  installing GPU software).
-* There are lots of other options starting with OPENMM_BUILD that control
-  whether to build particular features of OpenMM, such as plugins, API wrappers,
-  and documentation.
 * Set the variable CMAKE_INSTALL_PREFIX to the location where you want to
   install OpenMM.
 * Set the variable PYTHON_EXECUTABLE to the Python interpreter you plan to use
-  OpenMM with.
+  OpenMM with.  Usually this will be detected automatically.
+* There are lots of options starting with OPENMM_BUILD that control
+  whether to build particular features of OpenMM, such as plugins, API wrappers,
+  and documentation.
+* Usually the OpenCL library and headers will be detected automatically.  If for
+  any reason CMake is unable to find them, set OPENCL_INCLUDE_DIR to point to
+  the directory containing the headers (usually /usr/local/cuda/include on Linux)
+  and OPENCL_LIBRARY to point to the library (usually /usr/local/cuda/lib64/libOpenCL.so
+  on Linux).  
 
+Configure (press “c”) again.  Adjust any variables that cause an error.
 
-Configure (press “c”) again.  Adjust any variables that cause an
-error.
+Continue to configure (press “c”) until no starred CMake variables are
+displayed, then press “g” to generate the makefiles for building the project.
 
-Continue to configure (press “c”) until no starred/red CMake
-variables are displayed.  Congratulations, you have completed the configuration
-step.
+Step 2: Build and Install
+=========================
 
-Step 2: Generate Build Files with CMake
-***************************************
-
-Once the configuration is done, the next step is generation.  The generate
-“g” or “OK” or “Generate” option will not be available until
-configuration has completely converged.
-
-Windows
-=======
-
-* Press the "OK" or “Generate” button to generate Visual Studio project files.
-
-* If CMake does not exit automatically, press the close button in the upper-
-  right corner of the CMake title bar to exit.
-
-
-Mac and Linux
-=============
-
-* Press “g” to generate the Makefile.
-* If CMake does not exit automatically, press “q” to exit.
-
-
-That’s it!  Generation is the easy part.  Now it’s time to build.
-
-Step 3: Build OpenMM
-********************
-
-
-Windows
-=======
-
-#. Open the file OpenMM.sln in your openmm_build directory in Visual Studio.
-#. Set the configuration type to "Release" (not "Debug") in the toolbar.
-#. From the Build menu, click Build->Build Solution
-#. The OpenMM libraries and test programs will be created.  This takes some
-   time.
-#. The test program TestCudaRandom might not build on Windows.  This is OK.
-
-
-Mac and Linux
-=============
-
-* Type :code:`make` in the openmm_build directory.
-
-The OpenMM libraries and test programs will be created.  This takes some time.
-
-
-Step 4: Install OpenMM
-**********************
-
-
-Windows
-=======
-
-In the Solution Explorer Panel, far-click/right-click INSTALL->build.
-
-Mac and Linux
-=============
-
-Type:
-::
+Build and install OpenMM with the command::
 
     make install
 
 If you are installing to a system area, such as /usr/local/openmm/, you will
-need to type:
-::
+need to type::
 
     sudo make install
 
-Step 5: Install the Python API
-******************************
+Step 3: Install the Python API
+==============================
 
-
-Windows
-=======
-
-In the Solution Explorer Panel, right-click PythonInstall->build.
-
-Mac and Linux
-=============
-
-Type:
-::
+Build and install the Python API with the command::
 
     make PythonInstall
 
@@ -289,29 +142,17 @@ need to type:
 
 .. _test-your-build:
 
-Step 6: Test your build
-***********************
+Step 4: Test your build
+=======================
 
 After OpenMM has been built, you should run the unit tests to make sure it
-works.
-
-Windows
-=======
-
-In Visual Studio, far-click/right-click RUN_TESTS in the Solution Explorer
-Panel.  Select RUN_TESTS->build to begin testing.  Ignore any failures for
-TestCudaRandom.
-
-Mac and Linux
-=============
-
-Type:
-::
+works.  Enter the command::
 
     make test
 
 You should see a series of test results like this:
-::
+
+.. code-block:: none
 
             Start   1: TestReferenceAndersenThermostat
       1/317 Test   #1: TestReferenceAndersenThermostat .............. Passed  0.26 sec
@@ -325,69 +166,209 @@ You should see a series of test results like this:
 can run them individually to get more detailed error information.  Note that
 some tests are stochastic, and therefore are expected to fail a small fraction
 of the time.  These tests will say so in the error message:
-::
+
+.. code-block:: none
 
     ./TestReferenceLangevinIntegrator
 
     exception: Assertion failure at TestReferenceLangevinIntegrator.cpp:129.  Expected 9.97741,
         found 10.7884 (This test is stochastic and may occasionally fail)
 
-Congratulations! You successfully have built and installed OpenMM from source.
+Congratulations! You have successfully built and installed OpenMM from source.
+
+
+Compiling on Windows
+********************
+
+Prerequisites
+=============
+
+Before building OpenMM from source, you will need certain tools.
+
+C++ compiler
+------------
+
+On Windows systems, use the C++ compiler in Visual Studio 2015 or later.  You
+can download a free version of Visual Studio from https://visualstudio.microsoft.com.
+
+Python
+------
+
+You will need a 64-bit Python 3.x environment.  We recommend using Miniconda
+(https://docs.conda.io/en/latest/miniconda.html), which includes the conda
+package manager.
+
+CMake
+-----
+
+CMake is the build system used for OpenMM.  You must install CMake version 3.17
+or higher before attempting to build OpenMM from source.  You can get CMake from
+http://www.cmake.org/.
+
+OpenMM Source Code
+------------------
+
+You will also need the OpenMM source code.  To download it:
+
+#. Browse to https://github.com/openmm/openmm/releases.
+#. Find the latest release and click the link to download the source as either
+   a .zip or .tar.gz file.
+#. Unpack the file.  Note the location where you unpacked the OpenMM source code.
+
+Alternatively, if you want the most recent development version of the code rather
+than the version corresponding to a particular release, you can get it from
+https://github.com/openmm/openmm.  Be aware that the development code is constantly
+changing, may contain bugs, and should never be used for production work.  If
+you want a stable, well tested version of OpenMM, you should download the source
+code for the latest release as described above.
+
+CUDA or OpenCL Support
+----------------------
+
+If you want to compile OpenMM with support for running on GPUs, you will need
+CUDA and/or OpenCL.  Install the most recent CUDA Toolkit from https://developer.nvidia.com/cuda-downloads.
+It includes the headers and libraries needed to compile both CUDA and OpenCL
+applications.  In addition, it has runtime libraries that are needed for running
+CUDA applications.  The runtime components for OpenCL applications are included
+with the GPU drivers from NVIDIA, AMD, and Intel, so make sure you have an
+up-to-date driver.
+
+Other Required Software
+-----------------------
+
+Several other tools are required to build OpenMM.  The easiest way to install
+them is with conda.  From the Windows Start menu, select "Anaconda Prompt (Miniconda3)".
+It will open a command window that is preconfigured for conda.  Enter the
+following command to install everything needed to build OpenMM.
+::
+
+    conda install -c conda-forge cython swig fftw doxygen numpy
+
+Step 1: Configure with CMake
+============================
+
+First, create a directory in which to build OpenMM.  In the "Anaconda Prompt"
+window opened above, cd to the root level of the OpenMM source tree (the
+directory containing the top CMakeLists.txt file).  Execute the following commands:
+
+.. code-block:: none
+
+    mkdir build
+    cd build
+    "C:\Program Files\CMake\bin\cmake-gui.exe"
+
+This will launch the CMake GUI configuration tool.  It is critical that you
+launch it from the "Anaconda Prompt" window as shown above.  Do *not* launch
+it from the Start menu.  If you do, it will not be able to find the tools you
+installed with conda.
+
+#. In the box labeled "Where is the source code" browse to the OpenMM source directory
+   (containing the top CMakeLists.txt file).
+#. In the box labeled "Where to build the binaries" browse to the build
+   directory you just created.
+#. Click the "Configure" button at the bottom of the CMake window.
+#. Select "Visual Studio 16 2019" from the  list of Generators (or whichever
+   version you have installed) and click "Finish".
+
+There are several variables that can be adjusted in the CMake interface:
+
+* Set the variable CMAKE_INSTALL_PREFIX to the location where you want to
+  install OpenMM.
+* Set the variable PYTHON_EXECUTABLE to the Python interpreter you plan to use
+  OpenMM with.  Usually this will be detected automatically.
+* There are lots of options starting with OPENMM_BUILD that control
+  whether to build particular features of OpenMM, such as plugins, API wrappers,
+  and documentation.
+* Usually the OpenCL library and headers will be detected automatically.  If for
+  any reason CMake is unable to find them, set OPENCL_INCLUDE_DIR to point to
+  the directory containing the headers (usually
+  "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.4/include", except
+  with the correct version number for the toolkit you installed) and
+  OPENCL_LIBRARY to point to the library (usually "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.4/lib/x64/OpenCL.lib").  
+
+Press "Configure" again.  Adjust any variables that cause an error.
+
+Continue to press "Configure" until no red CMake variables are displayed, then
+press "Generate" to create the Visual Studio project files for building OpenMM.
+
+Step 2: Build and Install
+=========================
+
+#. Open the file OpenMM.sln in your build directory in Visual Studio.
+#. Set the configuration type to "Release" (not "Debug") in the toolbar.
+#. From the Build menu, select "Build Solution".  This takes some time.
+#. In the Solution Explorer, right-click on "INSTALL" and select "Build".
+
+Step 3: Install the Python API
+==============================
+
+In the Solution Explorer, right-click on "PythonInstall" and select "Build".
+
+Step 4: Test your build
+=======================
+
+After OpenMM has been built, you should run the unit tests to make sure it
+works.  In the Solution Explorer, right-click on "RUN_TESTS" and select "Build".
+You should see a series of test results like this:
+
+.. code-block:: none
+
+            Start   1: TestReferenceAndersenThermostat
+      1/317 Test   #1: TestReferenceAndersenThermostat .............. Passed  0.26 sec
+            Start   2: TestReferenceBrownianIntegrator
+      2/317 Test   #2: TestReferenceBrownianIntegrator .............. Passed  0.13 sec
+            Start   3: TestReferenceCheckpoints
+      3/317 Test   #3: TestReferenceCheckpoints ..................... Passed  0.02 sec
+      ... <many other tests> ...
+
+:code:`Passed` is good.  :code:`FAILED` is bad.  If any tests fail, you
+can run them individually to get more detailed error information.  Note that
+some tests are stochastic, and therefore are expected to fail a small fraction
+of the time.  These tests will say so in the error message:
+
+.. code-block:: none
+
+    exception: Assertion failure at TestReferenceLangevinIntegrator.cpp:129.  Expected 9.97741,
+        found 10.7884 (This test is stochastic and may occasionally fail)
+
+Congratulations! You have successfully built and installed OpenMM from source.
+
 
 Building the Documentation (Optional)
 *************************************
 
-The documentation that you're currently reading, as well as the developer guide and API
-documentation can be built through CMake by setting the OpenMM option :code:`OPENMM_GENERATE_API_DOCS=ON`.
+The documentation that you're currently reading, as well as the Developer Guide and API
+documentation, can be built through CMake.  To do that, you need to install a few
+additional tools.  The easiest way is to use :code:`pip` to install them into
+your Python environment.  The following command installs everything needed to
+build documentation in HTML format.
+::
 
-User Guide and Developer Guide
-==============================
+    pip install sphinx sphinxcontrib-bibtex sphinxcontrib-lunrsearch sphinxcontrib-autodoc_doxygen jinja2
 
-Generating the user guide and developer guide requires the following dependencies
+To build documentation in PDF format, you also must have a functional LaTeX
+installation.  It can be obtained from https://www.latex-project.org/get.
 
-* Sphinx (http://sphinx-doc.org/)
+If you want to build documentation, make sure that OPENMM_GENERATE_API_DOCS is
+set to ON when configuring the build in CMake.
 
-* sphinxcontrib-bibtex (https://pypi.python.org/pypi/sphinxcontrib-bibtex)
+To build the documentation, use the following build targets.
 
-These dependencies may not be available in your system package manager, but should
-be installable through Python's ``pip`` package manager. ::
+* :code:`sphinxhtml`: Build the User Guide and Developer Guide in HTML format.
 
-   pip install sphinx sphinxcontrib-bibtex
+* :code:`sphinxpdf`: Build the User Guide and Developer Guide in PDF format.
 
-The developer and user guides can be built either as HTML or a PDFs. Building the
-PDF version will also require a functional LaTeX installation.
+* :code:`C++ApiDocs`: Build the C++ API documentation.
 
-To build the HTML version of the documentation, type: ::
+* :code:`PythonApiDocs`: Build the Python API documentation.
 
-  make sphinxhtml
+On Linux or Mac, build a target using the :code:`make` command.  For example,
+::
 
-To build the PDF version of the documentation, type: ::
+    make sphinxhtml
 
-  make sphinxpdf
+On Windows, right-click on the target in the Solution Explorer and select "Build".
 
-
-Python and C++ API Documentation
-================================
-
-The following dependencies are required to build the Python and C++ API documentation.
-
-* Sphinx (http://sphinx-doc.org/)
-
-* sphinxcontrib-lunrsearch (https://pypi.python.org/pypi/sphinxcontrib-lunrsearch)
-
-* sphinxcontrib-autodoc_doxygen (https://pypi.python.org/pypi/sphinxcontrib-autodoc_doxygen)
-
-
-These dependencies may not be available in your system package manager, but should
-be installable through Python's ``pip`` package manager. ::
-
-   pip install sphinx sphinxcontrib-lunrsearch sphinxcontrib-autodoc_doxygen
-
-To build the C++ API documentation, type: ::
-
-  make C++ApiDocs
-
-To build the Python API documentation, type: ::
-
-  make PythonApiDocs
-
+After building the documentation, build the :code:`install` target to install
+the documentation into the installation directory (the one you specified with
+CMAKE_INSTALL_PREFIX).

--- a/docs-source/usersguide/library/02_compiling.rst
+++ b/docs-source/usersguide/library/02_compiling.rst
@@ -163,13 +163,15 @@ You should see a series of test results like this:
       ... <many other tests> ...
 
 :code:`Passed` is good.  :code:`FAILED` is bad.  If any tests fail, you
-can run them individually to get more detailed error information.  Note that
-some tests are stochastic, and therefore are expected to fail a small fraction
-of the time.  These tests will say so in the error message:
-
-.. code-block:: none
+can run them individually to get more detailed error information.  For example,
+::
 
     ./TestReferenceLangevinIntegrator
+
+Note that some tests are stochastic, and therefore are expected to fail a small
+fraction of the time.  These tests will say so in the error message:
+
+.. code-block:: none
 
     exception: Assertion failure at TestReferenceLangevinIntegrator.cpp:129.  Expected 9.97741,
         found 10.7884 (This test is stochastic and may occasionally fail)
@@ -294,7 +296,9 @@ press "Generate" to create the Visual Studio project files for building OpenMM.
 Step 2: Build and Install
 =========================
 
-#. Open the file OpenMM.sln in your build directory in Visual Studio.
+#. Open the file :file:`OpenMM.sln` in your build directory in Visual Studio.
+   Note that this file will appear as just :file:`OpenMM` if you have configured
+   Explorer to hide file name extensions.
 #. Set the configuration type to "Release" (not "Debug") in the toolbar.
 #. From the Build menu, select "Build Solution".  This takes some time.
 #. In the Solution Explorer, right-click on "INSTALL" and select "Build".
@@ -322,9 +326,11 @@ You should see a series of test results like this:
       ... <many other tests> ...
 
 :code:`Passed` is good.  :code:`FAILED` is bad.  If any tests fail, you
-can run them individually to get more detailed error information.  Note that
-some tests are stochastic, and therefore are expected to fail a small fraction
-of the time.  These tests will say so in the error message:
+can run them individually to get more detailed error information.  Right-click
+on a test in the Solution Explorer and select "Debug > Start New Instance".
+
+Note that some tests are stochastic, and therefore are expected to fail a small
+fraction of the time.  These tests will say so in the error message:
 
 .. code-block:: none
 
@@ -360,7 +366,9 @@ To build the documentation, use the following build targets.
 
 * :code:`C++ApiDocs`: Build the C++ API documentation.
 
-* :code:`PythonApiDocs`: Build the Python API documentation.
+* :code:`PythonApiDocs`: Build the Python API documentation.  This target
+  requires that you have already built the :code:`install` target, such as with
+  :code:`make install`.
 
 On Linux or Mac, build a target using the :code:`make` command.  For example,
 ::


### PR DESCRIPTION
This is a major reorganization and rewrite of the chapter on compiling from source.  It hopefully should now be simpler and easier to follow, as well as being accurate and up to date.