### PR TITLE
Accept relative links between documentation sites

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -613,7 +613,7 @@ jobs:
           set +e
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
+            npx linkinator ./${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs
             ((exitcode+=$?))
             echo "::endgroup::"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -613,7 +613,7 @@ jobs:
           set +e
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./build/api-docs/${d}/* --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
+            npx linkinator ./build/api-docs/${d}/index.html --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
             ((exitcode+=$?))
             echo "::endgroup::"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -606,19 +606,29 @@ jobs:
       - name: Check 404s
         shell: bash -l {0}
         env:
-          # From --help: "List of (comma-separated) urls in regexy form to not include in the check"
-          # Multi-skip syntax example: https://github.com/volkamerlab/volkamerlab_org/blob/fd4be6a/.github/workflows/ci.yaml#L33-L41
-          SKIP_URL: support.amd.com
+          # Pipe-seperated list of domains to skip
+          SKIP_DOMAIN: support.amd.com|ks.uiuc.edu
         run: |
           set +e
+          # Linkinator accepts regex for its --skip argument, so we
+          # should pre-process the domains into the relevant pattern
+          SKIP_REGEX=$(python -c "print(
+            '^(https?://)?([a-zA-Z0-9\-_.]+\.)?', # Optionally match protocol and subdomains
+            '(',                                  # Open sub-pattern for domain names
+              '$SKIP_URL'.replace('.', '\.'),     # Escape out periods
+            ')',                                  # Close sub-pattern of domains
+            '(/.*)?$'                             # only match if this is the end of the domain name
+            sep='',                               # Concatenate the above strings exactly
+            end=''                                # No newline at end of print()
+          )")
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs --verbosity error
+            npx linkinator ./${d}/ --recurse --timeout=5000 --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
             ((exitcode+=$?))
             echo "::endgroup::"
           done
           echo "::group:: Check README"
-          npx linkinator ./README.md --markdown --skip "$SKIP_URL"
+          npx linkinator ./README.md --markdown --skip "$SKIP_REGEX"
           ((exitcode+=$?))
           echo "::endgroup::"
           exit $exitcode

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -607,7 +607,7 @@ jobs:
         shell: bash -l {0}
         env:
           # Pipe-seperated list of domains to skip
-          SKIP_DOMAIN: support.amd.com|ks.uiuc.edu
+          SKIP_DOMAIN: support.amd.com
         run: |
           set +e
           # Linkinator accepts regex for its --skip argument, so we
@@ -623,7 +623,7 @@ jobs:
           )")
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./${d}/ --recurse --timeout=5000 --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
+            npx linkinator ./${d}/ --recurse --timeout=20000 --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
             ((exitcode+=$?))
             echo "::endgroup::"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -613,7 +613,7 @@ jobs:
           set +e
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs
+            npx linkinator ./${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs --verbosity error
             ((exitcode+=$?))
             echo "::endgroup::"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -617,7 +617,7 @@ jobs:
             '(',                                  # Open sub-pattern for domain names
               '$SKIP_URL'.replace('.', '\.'),     # Escape out periods
             ')',                                  # Close sub-pattern of domains
-            '(/.*)?$'                             # only match if this is the end of the domain name
+            '(/.*)?$',                            # only match if this is the end of the domain name
             sep='',                               # Concatenate the above strings exactly
             end=''                                # No newline at end of print()
           )")

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -615,7 +615,7 @@ jobs:
           SKIP_REGEX=$(python -c "print(
             '^(https?://)?([a-zA-Z0-9\-_.]+\.)?', # Optionally match protocol and subdomains
             '(',                                  # Open sub-pattern for domain names
-              '$SKIP_URL'.replace('.', '\.'),     # Escape out periods
+              '$SKIP_DOMAIN'.replace('.', '\.'),     # Escape out periods
             ')',                                  # Close sub-pattern of domains
             '(/.*)?$',                            # only match if this is the end of the domain name
             sep='',                               # Concatenate the above strings exactly

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -613,7 +613,7 @@ jobs:
           set +e
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./build/api-docs/${d}/index.html --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
+            npx linkinator ${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
             ((exitcode+=$?))
             echo "::endgroup::"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -613,7 +613,7 @@ jobs:
           set +e
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./build/api-docs/${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
+            npx linkinator ./build/api-docs/${d}/* --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
             ((exitcode+=$?))
             echo "::endgroup::"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -613,7 +613,7 @@ jobs:
           set +e
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./build/api-docs/${d}/ --recurse --timeout=5000 --skip "$SKIP_URL"
+            npx linkinator ./build/api-docs/${d}/ --recurse --timeout=5000 --skip "$SKIP_URL" --server-root ./build/api-docs/
             ((exitcode+=$?))
             echo "::endgroup::"
           done


### PR DESCRIPTION
Previously, the 404 checker run on the docs in CI would fail when a document has a relative link to a page in one of the other documentation sites. This is because linkinator assumed the web server was running from each site's root directory, so relative paths further up the file hierarchy were errors. This PR fixes this behaviour and should hopefully fix the documentation check failures.

The failure is confirmed spurious by the fact that the sidebar links work correctly on the [development documentation](http://docs.openmm.org/development/userguide/)