### PR TITLE
Remove Gromacs version pin

### DIFF
--- a/devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
@@ -17,4 +17,4 @@ dependencies:
 - pytest
 - pytest-xdist
 - pytest-timeout
-- gromacs 2018.*
+- gromacs

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
@@ -19,4 +19,4 @@ dependencies:
 - pytest
 - pytest-xdist
 - pytest-timeout
-- gromacs 2018.*
+- gromacs


### PR DESCRIPTION
#3006 reports that CI fails with recent versions of Gromacs.  I'm removing the pin to see how it fails.