### PR TITLE
Fixed error adding exclusions from Gromacs top file

### DIFF
--- a/wrappers/python/openmm/app/gromacstopfile.py
+++ b/wrappers/python/openmm/app/gromacstopfile.py
@@ -997,8 +997,7 @@ class GromacsTopFile(object):
                 for fields in moleculeType.exclusions:
                     atoms = [int(x)-1 for x in fields]
                     for atom in atoms[1:]:
-                        if atom > atoms[0]:
-                            exclusions.append((baseAtomIndex+atoms[0], baseAtomIndex+atom))
+                        exclusions.append((baseAtomIndex+atoms[0], baseAtomIndex+atom))
 
                 # Record virtual sites
 


### PR DESCRIPTION
Fixes #3096.  When adding exclusions, it was specifically checking whether they were in ascending order.  I have no idea why I originally wrote it that way in #482!  I can't find anything in the documentation that suggests it should work that way.  It would make sense if top files included duplicate exception records with both orders, but the files I looked at don't.

cc @Ziz1