### PR TITLE
Optimized computing long range correction for CustomNonbondedForce

### DIFF
--- a/openmmapi/include/openmm/internal/CustomNonbondedForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomNonbondedForceImpl.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -35,6 +35,7 @@
 #include "ForceImpl.h"
 #include "openmm/CustomNonbondedForce.h"
 #include "openmm/Kernel.h"
+#include "openmm/internal/ThreadPool.h"
 #include "lepton/CompiledExpression.h"
 #include <utility>
 #include <map>
@@ -48,6 +49,7 @@ namespace OpenMM {
 
 class OPENMM_EXPORT CustomNonbondedForceImpl : public ForceImpl {
 public:
+    class LongRangeCorrectionData;
     CustomNonbondedForceImpl(const CustomNonbondedForce& owner);
     ~CustomNonbondedForceImpl();
     void initialize(ContextImpl& context);
@@ -62,16 +64,33 @@ public:
     std::vector<std::string> getKernelNames();
     void updateParametersInContext(ContextImpl& context);
     /**
+     * Prepare for computing the long range correction.  This function pre-computes anything
+     * that depends only on the Force (such as particle parameters) but not on information in
+     * the Context (such as global parameters).  This allows the coefficient to be updated
+     * more quickly when global parameters change.
+     */
+    static LongRangeCorrectionData prepareLongRangeCorrection(const CustomNonbondedForce& force);
+    /**
      * Compute the coefficient which, when divided by the periodic box volume, gives the
      * long range correction to the energy.  If the Force computes parameter derivatives,
      * also compute the corresponding derivatives of the correction.
      */
-    static void calcLongRangeCorrection(const CustomNonbondedForce& force, const Context& context, double& coefficient, std::vector<double>& derivatives);
+    static void calcLongRangeCorrection(const CustomNonbondedForce& force, LongRangeCorrectionData& data, const Context& context, double& coefficient, std::vector<double>& derivatives, ThreadPool& threads);
 private:
     static double integrateInteraction(Lepton::CompiledExpression& expression, const std::vector<double>& params1, const std::vector<double>& params2,
             const CustomNonbondedForce& force, const Context& context, const std::vector<std::string>& paramNames);
     const CustomNonbondedForce& owner;
     Kernel kernel;
+};
+
+class CustomNonbondedForceImpl::LongRangeCorrectionData {
+public:
+    CustomNonbondedForce::NonbondedMethod method;
+    std::vector<std::vector<double> > classes;
+    std::vector<std::string> paramNames;
+    std::map<std::pair<int, int>, long long int> interactionCount;
+    Lepton::CompiledExpression energyExpression;
+    std::vector<Lepton::CompiledExpression> derivExpressions;
 };
 
 } // namespace OpenMM

--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,6 +34,7 @@
 #include "openmm/kernels.h"
 #include "openmm/internal/CompiledExpressionSet.h"
 #include "openmm/internal/CustomIntegratorUtilities.h"
+#include "openmm/internal/CustomNonbondedForceImpl.h"
 #include "lepton/CompiledExpression.h"
 #include "lepton/ExpressionProgram.h"
 
@@ -616,6 +617,8 @@ public:
     void copyParametersToContext(ContextImpl& context, const CustomNonbondedForce& force);
 private:
     class ForceInfo;
+    class LongRangePostComputation;
+    class LongRangeTask;
     void initInteractionGroups(const CustomNonbondedForce& force, const std::string& interactionSource, const std::vector<std::string>& tableTypes);
     ComputeContext& cc;
     ForceInfo* info;
@@ -631,6 +634,7 @@ private:
     bool hasInitializedLongRangeCorrection, hasInitializedKernel, hasParamDerivs, useNeighborList;
     int numGroupThreadBlocks;
     CustomNonbondedForce* forceCopy;
+    CustomNonbondedForceImpl::LongRangeCorrectionData longRangeCorrectionData;
     const System& system;
 };
 

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -34,7 +34,6 @@
 #include "openmm/internal/CustomCompoundBondForceImpl.h"
 #include "openmm/internal/CustomHbondForceImpl.h"
 #include "openmm/internal/CustomManyParticleForceImpl.h"
-#include "openmm/internal/CustomNonbondedForceImpl.h"
 #include "CommonKernelSources.h"
 #include "lepton/CustomFunction.h"
 #include "lepton/ExpressionTreeNode.h"
@@ -1771,6 +1770,47 @@ private:
     vector<set<int> > groupsForParticle;
 };
 
+class CommonCalcCustomNonbondedForceKernel::LongRangePostComputation : public ComputeContext::ForcePostComputation {
+public:
+    LongRangePostComputation(ComputeContext& cc, double& longRangeCoefficient, vector<double>& longRangeCoefficientDerivs, CustomNonbondedForce* force) :
+            cc(cc), longRangeCoefficient(longRangeCoefficient), longRangeCoefficientDerivs(longRangeCoefficientDerivs), force(force) {
+    }
+    double computeForceAndEnergy(bool includeForces, bool includeEnergy, int groups) {
+        cc.getWorkThread().flush();
+        Vec3 a, b, c;
+        cc.getPeriodicBoxVectors(a, b, c);
+        double volume = a[0]*b[1]*c[2];
+        map<string, double>& derivs = cc.getEnergyParamDerivWorkspace();
+        for (int i = 0; i < longRangeCoefficientDerivs.size(); i++)
+            derivs[force->getEnergyParameterDerivativeName(i)] += longRangeCoefficientDerivs[i]/volume;
+        return longRangeCoefficient/volume;
+    }
+private:
+    ComputeContext& cc;
+    double& longRangeCoefficient;
+    vector<double>& longRangeCoefficientDerivs;
+    CustomNonbondedForce* force;
+};
+
+class CommonCalcCustomNonbondedForceKernel::LongRangeTask : public ComputeContext::WorkTask {
+public:
+    LongRangeTask(ComputeContext& cc, Context& context, CustomNonbondedForceImpl::LongRangeCorrectionData& data,
+                  double& longRangeCoefficient, vector<double>& longRangeCoefficientDerivs, CustomNonbondedForce* force) :
+                        cc(cc), context(context), data(data), longRangeCoefficient(longRangeCoefficient),
+                        longRangeCoefficientDerivs(longRangeCoefficientDerivs), force(force) {
+    }
+    void execute() {
+        CustomNonbondedForceImpl::calcLongRangeCorrection(*force, data, context, longRangeCoefficient, longRangeCoefficientDerivs, cc.getThreadPool());
+    }
+private:
+    ComputeContext& cc;
+    Context& context;
+    CustomNonbondedForceImpl::LongRangeCorrectionData& data;
+    double& longRangeCoefficient;
+    vector<double>& longRangeCoefficientDerivs;
+    CustomNonbondedForce* force;
+};
+
 CommonCalcCustomNonbondedForceKernel::~CommonCalcCustomNonbondedForceKernel() {
     cc.setAsCurrent();
     if (params != NULL)
@@ -1912,6 +1952,8 @@ void CommonCalcCustomNonbondedForceKernel::initialize(const System& system, cons
     
     if (force.getNonbondedMethod() == CustomNonbondedForce::CutoffPeriodic && force.getUseLongRangeCorrection() && cc.getContextIndex() == 0) {
         forceCopy = new CustomNonbondedForce(force);
+        longRangeCorrectionData = CustomNonbondedForceImpl::prepareLongRangeCorrection(force);
+        cc.addPostComputation(new LongRangePostComputation(cc, longRangeCoefficient, longRangeCoefficientDerivs, forceCopy));
         hasInitializedLongRangeCorrection = false;
     }
     else {
@@ -2199,6 +2241,7 @@ double CommonCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
         // When using a neighbor list, run the whole calculation on a single device.
         return 0.0;
     }
+    bool recomputeLongRangeCorrection = !hasInitializedLongRangeCorrection;
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -2209,14 +2252,12 @@ double CommonCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
         }
         if (changed) {
             globals.upload(globalParamValues);
-            if (forceCopy != NULL) {
-                CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
-                hasInitializedLongRangeCorrection = true;
-            }
+            if (forceCopy != NULL)
+                recomputeLongRangeCorrection = true;
         }
     }
-    if (!hasInitializedLongRangeCorrection) {
-        CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
+    if (recomputeLongRangeCorrection) {
+        cc.getWorkThread().addTask(new LongRangeTask(cc, context.getOwner(), longRangeCorrectionData, longRangeCoefficient, longRangeCoefficientDerivs, forceCopy));
         hasInitializedLongRangeCorrection = true;
     }
     if (interactionGroupData.isInitialized()) {
@@ -2264,13 +2305,7 @@ double CommonCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
         setPeriodicBoxArgs(cc, interactionGroupKernel, 6);
         interactionGroupKernel->execute(numGroupThreadBlocks*forceThreadBlockSize, forceThreadBlockSize);
     }
-    Vec3 a, b, c;
-    cc.getPeriodicBoxVectors(a, b, c);
-    double volume = a[0]*b[1]*c[2];
-    map<string, double>& derivs = cc.getEnergyParamDerivWorkspace();
-    for (int i = 0; i < longRangeCoefficientDerivs.size(); i++)
-        derivs[forceCopy->getEnergyParameterDerivativeName(i)] += longRangeCoefficientDerivs[i]/volume;
-    return longRangeCoefficient/volume;
+    return 0;
 }
 
 void CommonCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const CustomNonbondedForce& force) {
@@ -2296,8 +2331,9 @@ void CommonCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& 
     // If necessary, recompute the long range correction.
     
     if (forceCopy != NULL) {
-        CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
-        hasInitializedLongRangeCorrection = true;
+        longRangeCorrectionData = CustomNonbondedForceImpl::prepareLongRangeCorrection(force);
+        CustomNonbondedForceImpl::calcLongRangeCorrection(force, longRangeCorrectionData, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs, cc.getThreadPool());
+        hasInitializedLongRangeCorrection = false;
         *forceCopy = force;
     }
     

--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -45,6 +45,7 @@
 #include "CpuPlatform.h"
 #include "openmm/kernels.h"
 #include "openmm/System.h"
+#include "openmm/internal/CustomNonbondedForceImpl.h"
 #include <array>
 #include <tuple>
 
@@ -326,6 +327,7 @@ private:
     double nonbondedCutoff, switchingDistance, periodicBoxSize[3], longRangeCoefficient;
     bool useSwitchingFunction, hasInitializedLongRangeCorrection;
     CustomNonbondedForce* forceCopy;
+    CustomNonbondedForceImpl::LongRangeCorrectionData longRangeCorrectionData;
     std::map<std::string, double> globalParamValues;
     std::vector<std::set<int> > exclusions;
     std::vector<std::string> parameterNames, globalParameterNames, energyParamDerivNames;

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -34,6 +34,7 @@
 
 #include "ReferencePlatform.h"
 #include "openmm/kernels.h"
+#include "openmm/internal/CustomNonbondedForceImpl.h"
 #include "SimTKOpenMMRealType.h"
 #include "ReferenceNeighborList.h"
 #include "lepton/CompiledExpression.h"
@@ -674,6 +675,7 @@ private:
     double nonbondedCutoff, switchingDistance, periodicBoxSize[3], longRangeCoefficient;
     bool useSwitchingFunction, hasInitializedLongRangeCorrection;
     CustomNonbondedForce* forceCopy;
+    CustomNonbondedForceImpl::LongRangeCorrectionData longRangeCorrectionData;
     std::map<std::string, double> globalParamValues;
     std::vector<std::set<int> > exclusions;
     Lepton::CompiledExpression energyExpression, forceExpression;


### PR DESCRIPTION
Fixes #3229.  This PR includes three different optimizations.

1. Any part of the computation that doesn't depend on context parameters is precomputed and saved.  It only needs to be repeated if you call `updateParametersInContext()`, not if you change a global parameter.
2. The computation of integrals is parallelized across all the cores in your CPU.
3. On the CUDA and OpenCL platforms, the computation is driven by a separate worker thread so it can be done at the same time the GPU is computing the forces.

I can't give a single number for how much faster it is.  That depends both on the details of your system and on the relative speed of your CPU and GPU.  In the best case where computing the coefficient on the CPU takes less time than computing the forces on the GPU, changing a global parameter will now have negligible cost.  In other cases it may still be quite expensive, but a lot less expensive than it was before.