### PR TITLE
add setAtomIndex() method to ComputeContext

### DIFF
--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -357,6 +357,16 @@ public:
         return atomIndex;
     }
     /**
+     * Set the reordered index of an atom.
+     *
+     * It is used only in special circumstances to sync the ordering
+     * of particles of the same system across two contexts.
+     *
+     * @param index  The index of the atom in the system
+     * @param order  The index of the same atom in the context
+     */
+    void setAtomIndex(const int index, const int order);
+    /**
      * Get the array which contains the index of each atom.
      */
     virtual ArrayInterface& getAtomIndexArray() = 0;

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -427,6 +427,17 @@ bool ComputeContext::invalidateMolecules(ComputeForceInfo* force) {
     return true;
 }
 
+
+void ComputeContext::setAtomIndex(const int index, const int order){
+  if(index < 0 || index >= numAtoms){
+    throw OpenMMException("Particle index is out of range");
+  }
+  if(order < 0 || order >= numAtoms){
+    throw OpenMMException("Particle reordered index is out of range");
+  }
+  atomIndex[index] = order;
+}
+
 void ComputeContext::reorderAtoms() {
     atomsWereReordered = false;
     if (numAtoms == 0 || !getNonbondedUtilities().getUseCutoff() || stepsSinceReorder < 250) {

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -429,10 +429,10 @@ bool ComputeContext::invalidateMolecules(ComputeForceInfo* force) {
 
 
 void ComputeContext::setAtomIndex(const int index, const int order){
-  if(index < 0 || index >= numAtoms){
+  if(index < 0 || index >= paddedNumAtoms){
     throw OpenMMException("Particle index is out of range");
   }
-  if(order < 0 || order >= numAtoms){
+  if(order < 0 || order >= paddedNumAtoms){
     throw OpenMMException("Particle reordered index is out of range");
   }
   atomIndex[index] = order;


### PR DESCRIPTION
We discovered that the current implementation of atom reordering in the [ATMMetaForce](https://github.com/Gallicchio-Lab/openmm-atmmetaforce-plugin) plugin based on calling reorderAtoms() on each inner context did not lead to good performance of the non-bonded energy calculation. While we did not fully investigate the exact origin of the problem, one suspicion is that, because the inner contexts lack a full complement of Forces, reordering does not lead to an efficient neighbor list.

In any case, we obtained significantly better performance (30% or so) by synchronizing in the ReorderListener the atom index of the inner contexts with those of the main context. To do so we added a setAtomIndex() method to ComputeContext. Hence the present pull request.