### PR TITLE
Use cuCtxPushCurrent() and cuCtxPopCurrent() for selecting CUDA context

### DIFF
--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -93,8 +93,29 @@ public:
      * doing any computation when you do not know what other code has just been executing on
      * the thread.  Platforms that rely on binding contexts to threads (such as CUDA) need to
      * implement this.
+     * 
+     * @deprecated It is recommended to use pushAsCurrent() and popAsCurrent() instead, or even better to create a ContextSelector.
+     * This provides better interoperability with other libraries that use CUDA and create
+     * their own contexts.
      */
     virtual void setAsCurrent() {
+    }
+    /**
+     * Set this as the current context for the calling thread, maintaining any previous context
+     * on a stack.  This should be called before doing any computation when you do not know what
+     * other code has just been executing on the thread.  It must be paired with popAsCurrent()
+     * when you are done to restore the previous context.  Alternatively, you can create a
+     * ContextSelector object to automate this for a block of code.
+     * 
+     * Platforms that rely on binding contexts to threads (such as CUDA) need to implement this.
+     */
+    virtual void pushAsCurrent() {
+    }
+    /**
+     * Restore a previous context that was replaced by pushAsCurrent().  Platforms that rely on binding
+     * contexts to threads (such as CUDA) need to implement this.
+     */
+    virtual void popAsCurrent() {
     }
     /**
      * Get the number of contexts being used for the current simulation.

--- a/platforms/common/include/openmm/common/ContextSelector.h
+++ b/platforms/common/include/openmm/common/ContextSelector.h
@@ -1,0 +1,56 @@
+#ifndef OPENMM_CONTEXTSELECTOR_H_
+#define OPENMM_CONTEXTSELECTOR_H_
+
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2021 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
+ * -------------------------------------------------------------------------- */
+
+#include "ComputeContext.h"
+
+namespace OpenMM {
+
+/**
+ * This class provides a safe and easy way to select a ComputeContext as current
+ * for a block of code.  The constructor calls pushAsCurrent() on the context.
+ * When it goes out of scope, the destructor calls popAsCurrent() on it.  Simply
+ * create a local variable of this class, and the context will be current for
+ * the remainder of the code block in which it is declared.  
+ */
+
+class OPENMM_EXPORT_COMMON ContextSelector {
+public:
+    ContextSelector(ComputeContext& context) : context(context) {
+        context.pushAsCurrent();
+    }
+    ~ContextSelector() {
+        context.popAsCurrent();
+    }
+private:
+    ComputeContext& context;
+};
+
+} // namespace OpenMM
+
+#endif /*OPENMM_CONTEXTSELECTOR_H_*/

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -25,6 +25,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "openmm/common/CommonKernels.h"
+#include "openmm/common/ContextSelector.h"
 #include "openmm/common/ExpressionUtilities.h"
 #include "openmm/Context.h"
 #include "openmm/internal/AndersenThermostatImpl.h"
@@ -111,7 +112,7 @@ void CommonApplyConstraintsKernel::initialize(const System& system) {
 }
 
 void CommonApplyConstraintsKernel::apply(ContextImpl& context, double tol) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (!hasInitializedKernel) {
         hasInitializedKernel = true;
         map<string, string> defines;
@@ -168,7 +169,7 @@ private:
 };
 
 void CommonCalcHarmonicBondForceKernel::initialize(const System& system, const HarmonicBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumBonds()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumBonds()/numContexts;
@@ -198,7 +199,7 @@ double CommonCalcHarmonicBondForceKernel::execute(ContextImpl& context, bool inc
 }
 
 void CommonCalcHarmonicBondForceKernel::copyParametersToContext(ContextImpl& context, const HarmonicBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumBonds()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumBonds()/numContexts;
@@ -252,13 +253,13 @@ private:
 };
 
 CommonCalcCustomBondForceKernel::~CommonCalcCustomBondForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
 }
 
 void CommonCalcCustomBondForceKernel::initialize(const System& system, const CustomBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumBonds()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumBonds()/numContexts;
@@ -333,6 +334,7 @@ void CommonCalcCustomBondForceKernel::initialize(const System& system, const Cus
 }
 
 double CommonCalcCustomBondForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -348,7 +350,7 @@ double CommonCalcCustomBondForceKernel::execute(ContextImpl& context, bool inclu
 }
 
 void CommonCalcCustomBondForceKernel::copyParametersToContext(ContextImpl& context, const CustomBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumBonds()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumBonds()/numContexts;
@@ -403,7 +405,7 @@ private:
 };
 
 void CommonCalcHarmonicAngleForceKernel::initialize(const System& system, const HarmonicAngleForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumAngles()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumAngles()/numContexts;
@@ -434,7 +436,7 @@ double CommonCalcHarmonicAngleForceKernel::execute(ContextImpl& context, bool in
 }
 
 void CommonCalcHarmonicAngleForceKernel::copyParametersToContext(ContextImpl& context, const HarmonicAngleForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumAngles()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumAngles()/numContexts;
@@ -490,13 +492,13 @@ private:
 };
 
 CommonCalcCustomAngleForceKernel::~CommonCalcCustomAngleForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
 }
 
 void CommonCalcCustomAngleForceKernel::initialize(const System& system, const CustomAngleForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumAngles()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumAngles()/numContexts;
@@ -571,6 +573,7 @@ void CommonCalcCustomAngleForceKernel::initialize(const System& system, const Cu
 }
 
 double CommonCalcCustomAngleForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -586,7 +589,7 @@ double CommonCalcCustomAngleForceKernel::execute(ContextImpl& context, bool incl
 }
 
 void CommonCalcCustomAngleForceKernel::copyParametersToContext(ContextImpl& context, const CustomAngleForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumAngles()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumAngles()/numContexts;
@@ -642,7 +645,7 @@ private:
 };
 
 void CommonCalcPeriodicTorsionForceKernel::initialize(const System& system, const PeriodicTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -673,7 +676,7 @@ double CommonCalcPeriodicTorsionForceKernel::execute(ContextImpl& context, bool 
 }
 
 void CommonCalcPeriodicTorsionForceKernel::copyParametersToContext(ContextImpl& context, const PeriodicTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -727,7 +730,7 @@ private:
 };
 
 void CommonCalcRBTorsionForceKernel::initialize(const System& system, const RBTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -763,7 +766,7 @@ double CommonCalcRBTorsionForceKernel::execute(ContextImpl& context, bool includ
 }
 
 void CommonCalcRBTorsionForceKernel::copyParametersToContext(ContextImpl& context, const RBTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -828,7 +831,7 @@ CommonCalcCustomTorsionForceKernel::~CommonCalcCustomTorsionForceKernel() {
 }
 
 void CommonCalcCustomTorsionForceKernel::initialize(const System& system, const CustomTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -903,6 +906,7 @@ void CommonCalcCustomTorsionForceKernel::initialize(const System& system, const 
 }
 
 double CommonCalcCustomTorsionForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -918,7 +922,7 @@ double CommonCalcCustomTorsionForceKernel::execute(ContextImpl& context, bool in
 }
 
 void CommonCalcCustomTorsionForceKernel::copyParametersToContext(ContextImpl& context, const CustomTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -976,7 +980,7 @@ private:
 };
 
 void CommonCalcCMAPTorsionForceKernel::initialize(const System& system, const CMAPTorsionForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumTorsions()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumTorsions()/numContexts;
@@ -1039,6 +1043,7 @@ void CommonCalcCMAPTorsionForceKernel::copyParametersToContext(ContextImpl& cont
 
     // Update the maps.
 
+    ContextSelector selector(cc);
     vector<mm_float4> coeffVec;
     vector<double> energy;
     vector<vector<double> > c;
@@ -1101,13 +1106,13 @@ private:
 };
 
 CommonCalcCustomExternalForceKernel::~CommonCalcCustomExternalForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
 }
 
 void CommonCalcCustomExternalForceKernel::initialize(const System& system, const CustomExternalForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumParticles()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumParticles()/numContexts;
@@ -1183,6 +1188,7 @@ void CommonCalcCustomExternalForceKernel::initialize(const System& system, const
 }
 
 double CommonCalcCustomExternalForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -1198,7 +1204,7 @@ double CommonCalcCustomExternalForceKernel::execute(ContextImpl& context, bool i
 }
 
 void CommonCalcCustomExternalForceKernel::copyParametersToContext(ContextImpl& context, const CustomExternalForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumParticles()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumParticles()/numContexts;
@@ -1251,13 +1257,13 @@ private:
 };
 
 CommonCalcCustomCompoundBondForceKernel::~CommonCalcCustomCompoundBondForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
 }
 
 void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, const CustomCompoundBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumBonds()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumBonds()/numContexts;
@@ -1368,6 +1374,7 @@ void CommonCalcCustomCompoundBondForceKernel::initialize(const System& system, c
 }
 
 double CommonCalcCustomCompoundBondForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -1383,7 +1390,7 @@ double CommonCalcCustomCompoundBondForceKernel::execute(ContextImpl& context, bo
 }
 
 void CommonCalcCustomCompoundBondForceKernel::copyParametersToContext(ContextImpl& context, const CustomCompoundBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumBonds()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumBonds()/numContexts;
@@ -1454,13 +1461,13 @@ private:
 };
 
 CommonCalcCustomCentroidBondForceKernel::~CommonCalcCustomCentroidBondForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
 }
 
 void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, const CustomCentroidBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     numBonds = force.getNumBonds();
     if (numBonds == 0)
         return;
@@ -1679,6 +1686,7 @@ void CommonCalcCustomCentroidBondForceKernel::initialize(const System& system, c
 double CommonCalcCustomCentroidBondForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
     if (numBonds == 0)
         return 0.0;
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -1702,7 +1710,7 @@ double CommonCalcCustomCentroidBondForceKernel::execute(ContextImpl& context, bo
 }
 
 void CommonCalcCustomCentroidBondForceKernel::copyParametersToContext(ContextImpl& context, const CustomCentroidBondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (numBonds != force.getNumBonds())
         throw OpenMMException("updateParametersInContext: The number of bonds has changed");
     if (numBonds == 0)
@@ -1772,7 +1780,7 @@ private:
 };
 
 CommonCalcCustomNonbondedForceKernel::~CommonCalcCustomNonbondedForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
     if (forceCopy != NULL)
@@ -1780,7 +1788,7 @@ CommonCalcCustomNonbondedForceKernel::~CommonCalcCustomNonbondedForceKernel() {
 }
 
 void CommonCalcCustomNonbondedForceKernel::initialize(const System& system, const CustomNonbondedForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int forceIndex;
     for (forceIndex = 0; forceIndex < system.getNumForces() && &system.getForce(forceIndex) != &force; ++forceIndex)
         ;
@@ -2199,6 +2207,7 @@ double CommonCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
         // When using a neighbor list, run the whole calculation on a single device.
         return 0.0;
     }
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -2274,7 +2283,7 @@ double CommonCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
 }
 
 void CommonCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const CustomNonbondedForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numParticles = force.getNumParticles();
     if (numParticles != cc.getNumAtoms())
         throw OpenMMException("updateParametersInContext: The number of particles has changed");
@@ -2321,7 +2330,7 @@ private:
 };
 
 void CommonCalcGBSAOBCForceKernel::initialize(const System& system, const GBSAOBCForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (cc.getNumContexts() > 1)
         throw OpenMMException("GBSAOBCForce does not support using multiple devices");
     int forceIndex;
@@ -2380,6 +2389,7 @@ void CommonCalcGBSAOBCForceKernel::initialize(const System& system, const GBSAOB
 }
 
 double CommonCalcGBSAOBCForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
     bool deviceIsCpu = cc.getIsCPU();
     if (!hasCreatedKernels) {
@@ -2496,7 +2506,7 @@ double CommonCalcGBSAOBCForceKernel::execute(ContextImpl& context, bool includeF
 void CommonCalcGBSAOBCForceKernel::copyParametersToContext(ContextImpl& context, const GBSAOBCForce& force) {
     // Make sure the new parameters are acceptable.
     
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numParticles = force.getNumParticles();
     if (numParticles != cc.getNumAtoms())
         throw OpenMMException("updateParametersInContext: The number of particles has changed");
@@ -2555,7 +2565,7 @@ private:
 };
 
 CommonCalcCustomGBForceKernel::~CommonCalcCustomGBForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
     if (computedValues != NULL)
@@ -2569,7 +2579,7 @@ CommonCalcCustomGBForceKernel::~CommonCalcCustomGBForceKernel() {
 }
 
 void CommonCalcCustomGBForceKernel::initialize(const System& system, const CustomGBForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (cc.getNumContexts() > 1)
         throw OpenMMException("CustomGBForce does not support using multiple devices");
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
@@ -3388,6 +3398,7 @@ void CommonCalcCustomGBForceKernel::initialize(const System& system, const Custo
 }
 
 double CommonCalcCustomGBForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     bool deviceIsCpu = cc.getIsCPU();
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
     int elementSize = (cc.getUseDoublePrecision() ? sizeof(double) : sizeof(float));
@@ -3596,7 +3607,7 @@ double CommonCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
 }
 
 void CommonCalcCustomGBForceKernel::copyParametersToContext(ContextImpl& context, const CustomGBForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numParticles = force.getNumParticles();
     if (numParticles != cc.getNumAtoms())
         throw OpenMMException("updateParametersInContext: The number of particles has changed");
@@ -3694,7 +3705,7 @@ private:
 };
 
 CommonCalcCustomHbondForceKernel::~CommonCalcCustomHbondForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (donorParams != NULL)
         delete donorParams;
     if (acceptorParams != NULL)
@@ -3718,7 +3729,7 @@ static void applyDonorAndAcceptorForces(stringstream& applyToDonor, stringstream
 void CommonCalcCustomHbondForceKernel::initialize(const System& system, const CustomHbondForce& force) {
     // Record the lists of donors and acceptors, and the parameters for each one.
 
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumDonors()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumDonors()/numContexts;
@@ -4046,6 +4057,7 @@ void CommonCalcCustomHbondForceKernel::initialize(const System& system, const Cu
 double CommonCalcCustomHbondForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
     if (numDonors == 0 || numAcceptors == 0)
         return 0.0;
+    ContextSelector selector(cc);
     if (globals.isInitialized()) {
         bool changed = false;
         for (int i = 0; i < (int) globalParamNames.size(); i++) {
@@ -4110,7 +4122,7 @@ double CommonCalcCustomHbondForceKernel::execute(ContextImpl& context, bool incl
 }
 
 void CommonCalcCustomHbondForceKernel::copyParametersToContext(ContextImpl& context, const CustomHbondForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numContexts = cc.getNumContexts();
     int startIndex = cc.getContextIndex()*force.getNumDonors()/numContexts;
     int endIndex = (cc.getContextIndex()+1)*force.getNumDonors()/numContexts;
@@ -4188,13 +4200,13 @@ private:
 };
 
 CommonCalcCustomManyParticleForceKernel::~CommonCalcCustomManyParticleForceKernel() {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (params != NULL)
         delete params;
 }
 
 void CommonCalcCustomManyParticleForceKernel::initialize(const System& system, const CustomManyParticleForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     if (!cc.getSupports64BitGlobalAtomics())
         throw OpenMMException("CustomManyParticleForce requires a device that supports 64 bit atomic operations");
     int numParticles = force.getNumParticles();
@@ -4510,6 +4522,7 @@ void CommonCalcCustomManyParticleForceKernel::initialize(const System& system, c
 }
 
 double CommonCalcCustomManyParticleForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (!hasInitializedKernel) {
         hasInitializedKernel = true;
         
@@ -4636,7 +4649,7 @@ double CommonCalcCustomManyParticleForceKernel::execute(ContextImpl& context, bo
 }
 
 void CommonCalcCustomManyParticleForceKernel::copyParametersToContext(ContextImpl& context, const CustomManyParticleForce& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     int numParticles = force.getNumParticles();
     if (numParticles != cc.getNumAtoms())
         throw OpenMMException("updateParametersInContext: The number of particles has changed");
@@ -4728,6 +4741,7 @@ void CommonCalcGayBerneForceKernel::initialize(const System& system, const GayBe
 
     // Initialize interactions.
 
+    ContextSelector selector(cc);
     int numParticles = force.getNumParticles();
     sigParams.initialize<mm_float4>(cc, cc.getPaddedNumAtoms(), "sigParams");
     epsParams.initialize<mm_float2>(cc, cc.getPaddedNumAtoms(), "epsParams");
@@ -4839,6 +4853,7 @@ void CommonCalcGayBerneForceKernel::initialize(const System& system, const GayBe
 }
 
 double CommonCalcGayBerneForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (!hasInitializedKernels) {
         hasInitializedKernels = true;
         sortAtoms();
@@ -4955,6 +4970,7 @@ void CommonCalcGayBerneForceKernel::copyParametersToContext(ContextImpl& context
     
     // Record the per-particle parameters.
     
+    ContextSelector selector(cc);
     vector<mm_float4> sigParamsVector(cc.getPaddedNumAtoms(), mm_float4(0, 0, 0, 0));
     vector<mm_float2> epsParamsVector(cc.getPaddedNumAtoms(), mm_float2(0, 0));
     vector<mm_float4> scaleVector(cc.getPaddedNumAtoms(), mm_float4(0, 0, 0, 0));
@@ -5073,6 +5089,7 @@ private:
 };
 
 void CommonCalcCustomCVForceKernel::initialize(const System& system, const CustomCVForce& force, ContextImpl& innerContext) {
+    ContextSelector selector(cc);
     int numCVs = force.getNumCollectiveVariables();
     for (int i = 0; i < force.getNumGlobalParameters(); i++)
         globalParameterNames.push_back(force.getGlobalParameterName(i));
@@ -5165,6 +5182,7 @@ void CommonCalcCustomCVForceKernel::initialize(const System& system, const Custo
 }
 
 double CommonCalcCustomCVForceKernel::execute(ContextImpl& context, ContextImpl& innerContext, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     copyState(context, innerContext);
     int numCVs = variableNames.size();
     int numAtoms = cc.getNumAtoms();
@@ -5210,6 +5228,7 @@ double CommonCalcCustomCVForceKernel::execute(ContextImpl& context, ContextImpl&
 }
 
 void CommonCalcCustomCVForceKernel::copyState(ContextImpl& context, ContextImpl& innerContext) {
+    ContextSelector selector(cc);
     int numAtoms = cc.getNumAtoms();
     ComputeContext& cc2 = getInnerComputeContext(innerContext);
     if (!hasInitializedListeners) {
@@ -5257,14 +5276,14 @@ void CommonCalcCustomCVForceKernel::copyParametersToContext(ContextImpl& context
 
 void CommonIntegrateVerletStepKernel::initialize(const System& system, const VerletIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     ComputeProgram program = cc.compileProgram(CommonKernelSources::verlet);
     kernel1 = program->createKernel("integrateVerletPart1");
     kernel2 = program->createKernel("integrateVerletPart2");
 }
 
 void CommonIntegrateVerletStepKernel::execute(ContextImpl& context, const VerletIntegrator& integrator) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
@@ -5322,7 +5341,7 @@ double CommonIntegrateVerletStepKernel::computeKineticEnergy(ContextImpl& contex
 
 void CommonIntegrateLangevinStepKernel::initialize(const System& system, const LangevinIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     cc.getIntegrationUtilities().initRandomNumberGenerator(integrator.getRandomNumberSeed());
     ComputeProgram program = cc.compileProgram(CommonKernelSources::langevin);
     kernel1 = program->createKernel("integrateLangevinPart1");
@@ -5332,7 +5351,7 @@ void CommonIntegrateLangevinStepKernel::initialize(const System& system, const L
 }
 
 void CommonIntegrateLangevinStepKernel::execute(ContextImpl& context, const LangevinIntegrator& integrator) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
@@ -5409,7 +5428,7 @@ double CommonIntegrateLangevinStepKernel::computeKineticEnergy(ContextImpl& cont
 
 void CommonIntegrateLangevinMiddleStepKernel::initialize(const System& system, const LangevinMiddleIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     cc.getIntegrationUtilities().initRandomNumberGenerator(integrator.getRandomNumberSeed());
     ComputeProgram program = cc.compileProgram(CommonKernelSources::langevinMiddle);
     kernel1 = program->createKernel("integrateLangevinMiddlePart1");
@@ -5427,6 +5446,7 @@ void CommonIntegrateLangevinMiddleStepKernel::initialize(const System& system, c
 }
 
 void CommonIntegrateLangevinMiddleStepKernel::execute(ContextImpl& context, const LangevinMiddleIntegrator& integrator) {
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
@@ -5502,6 +5522,7 @@ double CommonIntegrateLangevinMiddleStepKernel::computeKineticEnergy(ContextImpl
 
 void CommonIntegrateNoseHooverStepKernel::initialize(const System& system, const NoseHooverIntegrator& integrator) {
     cc.initializeContexts();
+    ContextSelector selector(cc);
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
     map<string, string> defines;
     defines["BOLTZ"] = cc.doubleToString(BOLTZ);
@@ -5562,6 +5583,7 @@ void CommonIntegrateNoseHooverStepKernel::initialize(const System& system, const
 }
 
 void CommonIntegrateNoseHooverStepKernel::execute(ContextImpl& context, const NoseHooverIntegrator& integrator, bool &forcesAreValid) {
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
     double dt = integrator.getStepSize();
@@ -5859,9 +5881,8 @@ std::pair<double, double> CommonIntegrateNoseHooverStepKernel::propagateChain(Co
 }
 
 double CommonIntegrateNoseHooverStepKernel::computeHeatBathEnergy(ContextImpl& context, const NoseHooverChain &nhc) {
-
+    ContextSelector selector(cc);
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
-
     int chainID = nhc.getChainID();
     int chainLength = nhc.getChainLength();
 
@@ -5942,9 +5963,8 @@ double CommonIntegrateNoseHooverStepKernel::computeHeatBathEnergy(ContextImpl& c
 }
 
 std::pair<double, double> CommonIntegrateNoseHooverStepKernel::computeMaskedKineticEnergy(ContextImpl& context, const NoseHooverChain &nhc, bool downloadValue) {
-
+    ContextSelector selector(cc);
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
-
     int chainID = nhc.getChainID();
     const auto & nhcAtoms = nhc.getThermostatedAtoms();
     const auto & nhcPairs = nhc.getThermostatedPairs();
@@ -6068,6 +6088,7 @@ void CommonIntegrateNoseHooverStepKernel::scaleVelocities(ContextImpl& context, 
 }
 
 void CommonIntegrateNoseHooverStepKernel::createCheckpoint(ContextImpl& context, ostream& stream) const {
+    ContextSelector selector(cc);
     int numChains = chainState.size();
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
     stream.write((char*) &numChains, sizeof(int));
@@ -6090,6 +6111,7 @@ void CommonIntegrateNoseHooverStepKernel::createCheckpoint(ContextImpl& context,
 }
 
 void CommonIntegrateNoseHooverStepKernel::loadCheckpoint(ContextImpl& context, istream& stream) {
+    ContextSelector selector(cc);
     int numChains;
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
     stream.read((char*) &numChains, sizeof(int));
@@ -6116,6 +6138,7 @@ void CommonIntegrateNoseHooverStepKernel::loadCheckpoint(ContextImpl& context, i
 }
 
 void CommonIntegrateNoseHooverStepKernel::getChainStates(ContextImpl& context, vector<vector<double> >& positions, vector<vector<double> >& velocities) const {
+    ContextSelector selector(cc);
     int numChains = chainState.size();
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
     positions.clear();
@@ -6144,6 +6167,7 @@ void CommonIntegrateNoseHooverStepKernel::getChainStates(ContextImpl& context, v
 }
 
 void CommonIntegrateNoseHooverStepKernel::setChainStates(ContextImpl& context, const vector<vector<double> >& positions, const vector<vector<double> >& velocities) {
+    ContextSelector selector(cc);
     int numChains = positions.size();
     bool useDouble = cc.getUseDoublePrecision() || cc.getUseMixedPrecision();
     chainState.clear();
@@ -6169,7 +6193,7 @@ void CommonIntegrateNoseHooverStepKernel::setChainStates(ContextImpl& context, c
 
 void CommonIntegrateBrownianStepKernel::initialize(const System& system, const BrownianIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     cc.getIntegrationUtilities().initRandomNumberGenerator(integrator.getRandomNumberSeed());
     ComputeProgram program = cc.compileProgram(CommonKernelSources::brownian);
     kernel1 = program->createKernel("integrateBrownianPart1");
@@ -6178,7 +6202,7 @@ void CommonIntegrateBrownianStepKernel::initialize(const System& system, const B
 }
 
 void CommonIntegrateBrownianStepKernel::execute(ContextImpl& context, const BrownianIntegrator& integrator) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
@@ -6254,7 +6278,7 @@ double CommonIntegrateBrownianStepKernel::computeKineticEnergy(ContextImpl& cont
 
 void CommonIntegrateVariableVerletStepKernel::initialize(const System& system, const VariableVerletIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     ComputeProgram program = cc.compileProgram(CommonKernelSources::verlet);
     kernel1 = program->createKernel("integrateVerletPart1");
     kernel2 = program->createKernel("integrateVerletPart2");
@@ -6263,7 +6287,7 @@ void CommonIntegrateVariableVerletStepKernel::initialize(const System& system, c
 }
 
 double CommonIntegrateVariableVerletStepKernel::execute(ContextImpl& context, const VariableVerletIntegrator& integrator, double maxTime) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
@@ -6354,7 +6378,7 @@ double CommonIntegrateVariableVerletStepKernel::computeKineticEnergy(ContextImpl
 
 void CommonIntegrateVariableLangevinStepKernel::initialize(const System& system, const VariableLangevinIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     cc.getIntegrationUtilities().initRandomNumberGenerator(integrator.getRandomNumberSeed());
     ComputeProgram program = cc.compileProgram(CommonKernelSources::langevin);
     kernel1 = program->createKernel("integrateLangevinPart1");
@@ -6366,7 +6390,7 @@ void CommonIntegrateVariableLangevinStepKernel::initialize(const System& system,
 }
 
 double CommonIntegrateVariableLangevinStepKernel::execute(ContextImpl& context, const VariableLangevinIntegrator& integrator, double maxTime) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int paddedNumAtoms = cc.getPaddedNumAtoms();
@@ -6535,7 +6559,7 @@ private:
 
 void CommonIntegrateCustomStepKernel::initialize(const System& system, const CustomIntegrator& integrator) {
     cc.initializeContexts();
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     cc.getIntegrationUtilities().initRandomNumberGenerator(integrator.getRandomNumberSeed());
     numGlobalVariables = integrator.getNumGlobalVariables();
     int elementSize = (cc.getUseDoublePrecision() || cc.getUseMixedPrecision() ? sizeof(double) : sizeof(float));
@@ -6595,7 +6619,7 @@ string CommonIntegrateCustomStepKernel::createPerDofComputation(const string& va
 }
 
 void CommonIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context, CustomIntegrator& integrator, bool& forcesAreValid) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
     int numSteps = integrator.getNumComputations();
@@ -7060,6 +7084,7 @@ void CommonIntegrateCustomStepKernel::findExpressionsForDerivs(const ExpressionT
 }
 
 void CommonIntegrateCustomStepKernel::execute(ContextImpl& context, CustomIntegrator& integrator, bool& forcesAreValid) {
+    ContextSelector selector(cc);
     prepareForComputation(context, integrator, forcesAreValid);
     IntegrationUtilities& integration = cc.getIntegrationUtilities();
     int numAtoms = cc.getNumAtoms();
@@ -7240,6 +7265,7 @@ bool CommonIntegrateCustomStepKernel::evaluateCondition(int step) {
 }
 
 double CommonIntegrateCustomStepKernel::computeKineticEnergy(ContextImpl& context, CustomIntegrator& integrator, bool& forcesAreValid) {
+    ContextSelector selector(cc);
     prepareForComputation(context, integrator, forcesAreValid);
     cc.clearBuffer(sumBuffer);
     kineticEnergyKernel->setArg(8, cc.getIntegrationUtilities().getRandom());
@@ -7316,6 +7342,7 @@ void CommonIntegrateCustomStepKernel::setGlobalVariables(ContextImpl& context, c
 }
 
 void CommonIntegrateCustomStepKernel::getPerDofVariable(ContextImpl& context, int variable, vector<Vec3>& values) const {
+    ContextSelector selector(cc);
     values.resize(perDofValues[variable].getSize());
     const vector<int>& order = cc.getAtomIndex();
     if (cc.getUseDoublePrecision() || cc.getUseMixedPrecision()) {
@@ -7359,7 +7386,7 @@ void CommonIntegrateCustomStepKernel::setPerDofVariable(ContextImpl& context, in
 }
 
 void CommonRemoveCMMotionKernel::initialize(const System& system, const CMMotionRemover& force) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     frequency = force.getFrequency();
     int numAtoms = cc.getNumAtoms();
     cmMomentum.initialize<mm_float4>(cc, cc.getPaddedNumAtoms(), "cmMomentum");
@@ -7380,7 +7407,7 @@ void CommonRemoveCMMotionKernel::initialize(const System& system, const CMMotion
 }
 
 void CommonRemoveCMMotionKernel::execute(ContextImpl& context) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     kernel1->execute(cc.getNumAtoms(), 64);
     kernel2->execute(cc.getNumAtoms(), 64);
 }
@@ -7408,6 +7435,7 @@ private:
 void CommonCalcRMSDForceKernel::initialize(const System& system, const RMSDForce& force) {
     // Create data structures.
     
+    ContextSelector selector(cc);
     bool useDouble = cc.getUseDoublePrecision();
     int elementSize = (useDouble ? sizeof(double) : sizeof(float));
     int numParticles = force.getParticles().size();
@@ -7475,6 +7503,7 @@ void CommonCalcRMSDForceKernel::recordParameters(const RMSDForce& force) {
 }
 
 double CommonCalcRMSDForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     if (cc.getUseDoublePrecision())
         return executeImpl<double>(context);
     return executeImpl<float>(context);
@@ -7553,6 +7582,7 @@ double CommonCalcRMSDForceKernel::executeImpl(ContextImpl& context) {
 }
 
 void CommonCalcRMSDForceKernel::copyParametersToContext(ContextImpl& context, const RMSDForce& force) {
+    ContextSelector selector(cc);
     if (referencePos.getSize() != force.getReferencePositions().size())
         throw OpenMMException("updateParametersInContext: The number of reference positions has changed");
     int numParticles = force.getParticles().size();
@@ -7569,7 +7599,7 @@ void CommonCalcRMSDForceKernel::copyParametersToContext(ContextImpl& context, co
 }
 
 void CommonApplyAndersenThermostatKernel::initialize(const System& system, const AndersenThermostat& thermostat) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     randomSeed = thermostat.getRandomNumberSeed();
     ComputeProgram program = cc.compileProgram(CommonKernelSources::andersenThermostat);
     kernel = program->createKernel("applyAndersenThermostat");
@@ -7596,7 +7626,7 @@ void CommonApplyAndersenThermostatKernel::initialize(const System& system, const
 }
 
 void CommonApplyAndersenThermostatKernel::execute(ContextImpl& context) {
-    cc.setAsCurrent();
+    ContextSelector selector(cc);
     kernel->setArg(1, (float) context.getParameter(AndersenThermostat::CollisionFrequency()));
     kernel->setArg(2, (float) (BOLTZ*context.getParameter(AndersenThermostat::Temperature())));
     double stepSize = context.getIntegrator().getStepSize();
@@ -7609,6 +7639,7 @@ void CommonApplyAndersenThermostatKernel::execute(ContextImpl& context) {
 }
 
 void CommonApplyMonteCarloBarostatKernel::initialize(const System& system, const Force& thermostat) {
+    ContextSelector selector(cc);
     savedPositions.initialize(cc, cc.getPaddedNumAtoms(), cc.getUseDoublePrecision() ? sizeof(mm_double4) : sizeof(mm_float4), "savedPositions");
     savedLongForces.initialize<long long>(cc, cc.getPaddedNumAtoms()*3, "savedLongForces");
     try {
@@ -7623,6 +7654,7 @@ void CommonApplyMonteCarloBarostatKernel::initialize(const System& system, const
 }
 
 void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ) {
+    ContextSelector selector(cc);
     if (!hasInitializedKernels) {
         hasInitializedKernels = true;
 
@@ -7646,10 +7678,6 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
 
         // Initialize the kernel arguments.
 
-//KERNEL void scalePositions(float scaleX, float scaleY, float scaleZ, int numMolecules, real4 periodicBoxSize,
-//        real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, GLOBAL real4* RESTRICT posq,
-//        GLOBAL const int* RESTRICT moleculeAtoms, GLOBAL const int* RESTRICT moleculeStartIndex) {
-        
         kernel->addArg();
         kernel->addArg();
         kernel->addArg();
@@ -7664,9 +7692,6 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
     cc.getLongForceBuffer().copyTo(savedLongForces);
     if (savedFloatForces.isInitialized())
         cc.getFloatForceBuffer().copyTo(savedFloatForces);
-//    int bytesToCopy = cc.getPosq().getSize()*(cc.getUseDoublePrecision() ? sizeof(mm_double4) : sizeof(mm_float4));
-//    cc.getQueue().enqueueCopyBuffer(cc.getPosq().getDeviceBuffer(), savedPositions.getDeviceBuffer(), 0, 0, bytesToCopy);
-//    cc.getQueue().enqueueCopyBuffer(cc.getForce().getDeviceBuffer(), savedForces.getDeviceBuffer(), 0, 0, bytesToCopy);
     kernel->setArg(0, (float) scaleX);
     kernel->setArg(1, (float) scaleY);
     kernel->setArg(2, (float) scaleZ);
@@ -7678,12 +7703,9 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
 }
 
 void CommonApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& context) {
+    ContextSelector selector(cc);
     savedPositions.copyTo(cc.getPosq());
     savedLongForces.copyTo(cc.getLongForceBuffer());
     if (savedFloatForces.isInitialized())
         savedFloatForces.copyTo(cc.getFloatForceBuffer());
-
-//    int bytesToCopy = cc.getPosq().getSize()*(cc.getUseDoublePrecision() ? sizeof(mm_double4) : sizeof(mm_float4));
-//    cc.getQueue().enqueueCopyBuffer(savedPositions.getDeviceBuffer(), cc.getPosq().getDeviceBuffer(), 0, 0, bytesToCopy);
-//    cc.getQueue().enqueueCopyBuffer(savedForces.getDeviceBuffer(), cc.getForce().getDeviceBuffer(), 0, 0, bytesToCopy);
 }

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019 Stanford University and the Authors.           *
+ * Portions copyright (c) 2019-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -25,6 +25,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "openmm/common/ComputeContext.h"
+#include "openmm/common/ContextSelector.h"
 #include "openmm/System.h"
 #include "openmm/VirtualSite.h"
 #include "openmm/internal/ContextImpl.h"
@@ -362,6 +363,7 @@ bool ComputeContext::invalidateMolecules(ComputeForceInfo* force) {
     // atoms to their original order, rebuild the list of identical molecules, and sort them
     // again.
 
+    ContextSelector selector(*this);
     vector<mm_int4> newCellOffsets(numAtoms);
     if (getUseDoublePrecision()) {
         vector<mm_double4> oldPosq(paddedNumAtoms);
@@ -598,6 +600,7 @@ void ComputeContext::reorderAtomsImpl() {
 
     // Update the arrays.
 
+    ContextSelector selector(*this);
     for (int i = 0; i < numAtoms; i++) {
         atomIndex[i] = originalIndex[i];
         posCellOffsets[i] = newCellOffsets[i];

--- a/platforms/common/src/IntegrationUtilities.cpp
+++ b/platforms/common/src/IntegrationUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -26,6 +26,7 @@
 
 #include "openmm/common/IntegrationUtilities.h"
 #include "openmm/common/ComputeContext.h"
+#include "openmm/common/ContextSelector.h"
 #include "CommonKernelSources.h"
 #include "openmm/internal/OSRngSeed.h"
 #include "openmm/HarmonicAngleForce.h"
@@ -736,6 +737,7 @@ void IntegrationUtilities::applyVelocityConstraints(double tol) {
 }
 
 void IntegrationUtilities::computeVirtualSites() {
+    ContextSelector selector(context);
     if (numVsites > 0)
         vsitePositionKernel->execute(numVsites);
 }
@@ -812,6 +814,7 @@ void IntegrationUtilities::loadCheckpoint(istream& stream) {
 }
 
 double IntegrationUtilities::computeKineticEnergy(double timeShift) {
+    ContextSelector selector(context);
     int numParticles = context.getNumAtoms();
     if (timeShift != 0) {
         // Copy the velocities into the posDelta array while we temporarily modify them.

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -101,6 +101,16 @@ public:
      */
     void setAsCurrent();
     /**
+     * Push the CUcontext associated with this object to be the current context.  If the context is not
+     * valid, this returns without doing anything.
+     */
+    void pushAsCurrent();
+    /**
+     * Pop the CUcontext associated with this object off the stack of contexts.  If the context is not
+     * valid, this returns without doing anything.
+     */
+    void popAsCurrent();
+    /**
      * Get the CUdevice associated with this object.
      */
     CUdevice getDevice() {

--- a/platforms/cuda/src/CudaArray.cpp
+++ b/platforms/cuda/src/CudaArray.cpp
@@ -26,6 +26,7 @@
 
 #include "CudaArray.h"
 #include "CudaContext.h"
+#include "openmm/common/ContextSelector.h"
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -41,7 +42,7 @@ CudaArray::CudaArray(CudaContext& context, int size, int elementSize, const std:
 
 CudaArray::~CudaArray() {
     if (pointer != 0 && ownsMemory && context->getContextIsValid()) {
-        context->setAsCurrent();
+        ContextSelector selector(*context);
         CUresult result = cuMemFree(pointer);
         if (result != CUDA_SUCCESS) {
             std::stringstream str;
@@ -59,6 +60,7 @@ void CudaArray::initialize(ComputeContext& context, int size, int elementSize, c
     this->elementSize = elementSize;
     this->name = name;
     ownsMemory = true;
+    ContextSelector selector(*this->context);
     CUresult result = cuMemAlloc(&pointer, size*elementSize);
     if (result != CUDA_SUCCESS) {
         std::stringstream str;
@@ -72,6 +74,7 @@ void CudaArray::resize(int size) {
         throw OpenMMException("CudaArray has not been initialized");
     if (!ownsMemory)
         throw OpenMMException("Cannot resize an array that does not own its storage");
+    ContextSelector selector(*context);
     CUresult result = cuMemFree(pointer);
     if (result != CUDA_SUCCESS) {
         std::stringstream str;

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -240,9 +240,10 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
         int canAccess;
         cuDeviceCanAccessPeer(&canAccess, getDevice(), platformData.contexts[0]->getDevice());
         if (canAccess) {
-            platformData.contexts[0]->setAsCurrent();
-            CHECK_RESULT(cuCtxEnablePeerAccess(getContext(), 0));
-            setAsCurrent();
+            {
+                ContextSelector selector2(*platformData.contexts[0]);
+                CHECK_RESULT(cuCtxEnablePeerAccess(getContext(), 0));
+            }
             CHECK_RESULT(cuCtxEnablePeerAccess(platformData.contexts[0]->getContext(), 0));
         }
     }

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -38,6 +38,7 @@
 #include "CudaNonbondedUtilities.h"
 #include "CudaProgram.h"
 #include "openmm/common/ComputeArray.h"
+#include "openmm/common/ContextSelector.h"
 #include "SHA1.h"
 #include "openmm/Platform.h"
 #include "openmm/System.h"
@@ -190,6 +191,8 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
 
             if (cuCtxCreate(&context, flags, device) == CUDA_SUCCESS) {
                 this->deviceIndex = trialDeviceIndex;
+                CUcontext popped;
+                cuCtxPopCurrent(&popped);
                 break;
             }
         }
@@ -231,6 +234,7 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
     computeCapability = major+0.1*minor;
 
     contextIsValid = true;
+    ContextSelector selector(*this);
     CHECK_RESULT(cuCtxSetCacheConfig(CU_FUNC_CACHE_PREFER_SHARED));
     if (contextIndex > 0) {
         int canAccess;
@@ -397,7 +401,7 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
 }
 
 CudaContext::~CudaContext() {
-    setAsCurrent();
+    pushAsCurrent();
     for (auto force : forces)
         delete force;
     for (auto listener : reorderListeners)
@@ -416,6 +420,7 @@ CudaContext::~CudaContext() {
         delete bonded;
     if (nonbonded != NULL)
         delete nonbonded;
+    popAsCurrent();
     string errorMessage = "Error deleting Context";
     if (contextIsValid && !isLinkedContext) {
         cuProfilerStop();
@@ -425,7 +430,7 @@ CudaContext::~CudaContext() {
 }
 
 void CudaContext::initialize() {
-    cuCtxSetCurrent(context);
+    ContextSelector selector(*this);
     string errorMessage = "Error initializing Context";
     int numEnergyBuffers = max(numThreadBlocks*ThreadBlockSize, nonbonded->getNumEnergyBuffers());
     if (useDoublePrecision) {
@@ -476,6 +481,17 @@ void CudaContext::initializeContexts() {
 void CudaContext::setAsCurrent() {
     if (contextIsValid)
         cuCtxSetCurrent(context);
+}
+
+void CudaContext::pushAsCurrent() {
+    if (contextIsValid)
+        cuCtxPushCurrent(context);
+}
+
+void CudaContext::popAsCurrent() {
+    CUcontext popped;
+    if (contextIsValid)
+        cuCtxPopCurrent(&popped);
 }
 
 CUmodule CudaContext::createModule(const string source, const char* optimizationFlags) {

--- a/platforms/cuda/src/CudaIntegrationUtilities.cpp
+++ b/platforms/cuda/src/CudaIntegrationUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2021 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -26,6 +26,7 @@
 
 #include "CudaIntegrationUtilities.h"
 #include "CudaContext.h"
+#include "openmm/common/ContextSelector.h"
 
 using namespace OpenMM;
 using namespace std;
@@ -46,7 +47,7 @@ CudaIntegrationUtilities::CudaIntegrationUtilities(CudaContext& context, const S
 }
 
 CudaIntegrationUtilities::~CudaIntegrationUtilities() {
-    context.setAsCurrent();
+    ContextSelector selector(context);
     if (ccmaConvergedMemory != NULL) {
         cuMemFreeHost(ccmaConvergedMemory);
         cuEventDestroy(ccmaEvent);
@@ -66,6 +67,7 @@ CudaArray& CudaIntegrationUtilities::getStepSize() {
 }
 
 void CudaIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, double tol) {
+    ContextSelector selector(context);
     ComputeKernel settleKernel, shakeKernel, ccmaForceKernel;
     if (constrainVelocities) {
         settleKernel = settleVelKernel;
@@ -131,6 +133,7 @@ void CudaIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, do
 }
 
 void CudaIntegrationUtilities::distributeForcesFromVirtualSites() {
+    ContextSelector selector(context);
     if (numVsites > 0) {
         vsiteForceKernel->setArg(2, context.getLongForceBuffer());
         vsiteForceKernel->execute(numVsites);

--- a/platforms/cuda/tests/TestCudaFFT3D.cpp
+++ b/platforms/cuda/tests/TestCudaFFT3D.cpp
@@ -59,6 +59,7 @@ void testTransform(bool realToComplex, int xsize, int ysize, int zsize) {
             platform.getPropertyDefaultValue(CudaPlatform::CudaHostCompiler()), platform.getPropertyDefaultValue(CudaPlatform::CudaDisablePmeStream()), "false", true, 1, NULL);
     CudaContext& context = *platformData.contexts[0];
     context.initialize();
+    context.setAsCurrent();
     OpenMM_SFMT::SFMT sfmt;
     init_gen_rand(0, sfmt);
     vector<Real2> original(xsize*ysize*zsize);

--- a/platforms/cuda/tests/TestCudaNonbondedForce.cpp
+++ b/platforms/cuda/tests/TestCudaNonbondedForce.cpp
@@ -172,7 +172,7 @@ bool canRunHugeTest() {
 
     // Only run the huge test if the device has at least 4 GB of memory.
 
-    return (memory >= 4*(1<<30));
+    return (memory >= 4L*(1<<30));
 }
 
 void runPlatformTests() {

--- a/platforms/cuda/tests/TestCudaRandom.cpp
+++ b/platforms/cuda/tests/TestCudaRandom.cpp
@@ -59,6 +59,7 @@ void testGaussian() {
             platform.getPropertyDefaultValue(CudaPlatform::CudaHostCompiler()), platform.getPropertyDefaultValue(CudaPlatform::CudaDisablePmeStream()), "false", true, 1, NULL);
     CudaContext& context = *platformData.contexts[0];
     context.initialize();
+    context.setAsCurrent();
     context.getIntegrationUtilities().initRandomNumberGenerator(0);
     CudaArray& random = context.getIntegrationUtilities().getRandom();
     context.getIntegrationUtilities().prepareRandomNumbers(random.getSize());

--- a/platforms/cuda/tests/TestCudaSort.cpp
+++ b/platforms/cuda/tests/TestCudaSort.cpp
@@ -69,6 +69,7 @@ void verifySorting(vector<float> array) {
             platform.getPropertyDefaultValue(CudaPlatform::CudaHostCompiler()), platform.getPropertyDefaultValue(CudaPlatform::CudaDisablePmeStream()), "false", true, 1, NULL);
     CudaContext& context = *platformData.contexts[0];
     context.initialize();
+    context.setAsCurrent();
     CudaArray data(context, array.size(), 4, "sortData");
     data.upload(array);
     CudaSort sort(context, new SortTrait(), array.size());

--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
@@ -1413,6 +1413,7 @@ void CommonCalcAmoebaMultipoleForceKernel::ensureMultipolesValid(ContextImpl& co
 }
 
 void CommonCalcAmoebaMultipoleForceKernel::getLabFramePermanentDipoles(ContextImpl& context, vector<Vec3>& dipoles) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     int numParticles = cc.getNumAtoms();
     dipoles.resize(numParticles);
@@ -1433,6 +1434,7 @@ void CommonCalcAmoebaMultipoleForceKernel::getLabFramePermanentDipoles(ContextIm
 
 
 void CommonCalcAmoebaMultipoleForceKernel::getInducedDipoles(ContextImpl& context, vector<Vec3>& dipoles) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     int numParticles = cc.getNumAtoms();
     dipoles.resize(numParticles);
@@ -1453,6 +1455,7 @@ void CommonCalcAmoebaMultipoleForceKernel::getInducedDipoles(ContextImpl& contex
 
 
 void CommonCalcAmoebaMultipoleForceKernel::getTotalDipoles(ContextImpl& context, vector<Vec3>& dipoles) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     int numParticles = cc.getNumAtoms();
     dipoles.resize(numParticles);
@@ -1494,6 +1497,7 @@ void CommonCalcAmoebaMultipoleForceKernel::getTotalDipoles(ContextImpl& context,
 }
 
 void CommonCalcAmoebaMultipoleForceKernel::getElectrostaticPotential(ContextImpl& context, const vector<Vec3>& inputGrid, vector<double>& outputElectrostaticPotential) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     int numPoints = inputGrid.size();
     int elementSize = (cc.getUseDoublePrecision() ? sizeof(double) : sizeof(float));
@@ -1648,6 +1652,7 @@ void CommonCalcAmoebaMultipoleForceKernel::computeSystemMultipoleMoments(Context
 
 
 void CommonCalcAmoebaMultipoleForceKernel::getSystemMultipoleMoments(ContextImpl& context, vector<double>& outputMultipoleMoments) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     if (cc.getUseDoublePrecision())
         computeSystemMultipoleMoments<double, mm_double4, mm_double4>(context, outputMultipoleMoments);
@@ -3174,6 +3179,7 @@ void CommonCalcHippoNonbondedForceKernel::createFieldKernel(const string& intera
 }
 
 double CommonCalcHippoNonbondedForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
+    ContextSelector selector(cc);
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
     if (!hasInitializedKernels) {
         hasInitializedKernels = true;
@@ -3389,6 +3395,7 @@ void CommonCalcHippoNonbondedForceKernel::addTorquesToForces() {
 }
 
 void CommonCalcHippoNonbondedForceKernel::getInducedDipoles(ContextImpl& context, vector<Vec3>& dipoles) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     int numParticles = cc.getNumAtoms();
     dipoles.resize(numParticles);
@@ -3436,6 +3443,7 @@ void CommonCalcHippoNonbondedForceKernel::ensureMultipolesValid(ContextImpl& con
 }
 
 void CommonCalcHippoNonbondedForceKernel::getLabFramePermanentDipoles(ContextImpl& context, vector<Vec3>& dipoles) {
+    ContextSelector selector(cc);
     ensureMultipolesValid(context);
     int numParticles = cc.getNumAtoms();
     dipoles.resize(numParticles);


### PR DESCRIPTION
This reworks management of CUDA contexts as suggested in #3256.  Instead of calling `setAsCurrent()` on a ComputeContext to make it the current context, you call `pushAsCurrent()`.  You then have to call `popAsCurrent()` when you're done.  To simplify that process, I created a ContextSelector class that does it automatically.  Where before you would have written

```c++
cc.setAsCurrent();
```

you now write

```c++
ContextSelector selector(cc);
```

The constructor for the object pushes the context onto the stack.  Then when it goes out of scope, its destructor pops it back off again.