### PR TITLE
Barostat does not translate into a single periodic box

### DIFF
--- a/platforms/common/src/kernels/monteCarloBarostat.cc
+++ b/platforms/common/src/kernels/monteCarloBarostat.cc
@@ -24,17 +24,12 @@ KERNEL void scalePositions(float scaleX, float scaleY, float scaleZ, int numMole
         center.y *= invNumAtoms;
         center.z *= invNumAtoms;
 
-        // Move it into the first periodic box.
-
-        real3 oldCenter = center;
-        APPLY_PERIODIC_TO_POS(center)
-        real3 delta = make_real3(oldCenter.x-center.x, oldCenter.y-center.y, oldCenter.z-center.z);
-
         // Now scale the position of the molecule center.
 
-        delta.x = center.x*(scaleX-1)-delta.x;
-        delta.y = center.y*(scaleY-1)-delta.y;
-        delta.z = center.z*(scaleZ-1)-delta.z;
+        real3 delta;
+        delta.x = center.x*(scaleX-1);
+        delta.y = center.y*(scaleY-1);
+        delta.z = center.z*(scaleZ-1);
         for (int atom = first; atom < last; atom++) {
             real4 pos = posq[moleculeAtoms[atom]];
             pos.x += delta.x;

--- a/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
@@ -82,15 +82,9 @@ void ReferenceMonteCarloBarostat::applyBarostat(vector<Vec3>& atomPositions, con
         }
         pos /= molecule.size();
 
-        // Move it into the first periodic box.
-
-        Vec3 newPos = pos;
-        newPos -= boxVectors[2]*floor(newPos[2]/boxVectors[2][2]);
-        newPos -= boxVectors[1]*floor(newPos[1]/boxVectors[1][1]);
-        newPos -= boxVectors[0]*floor(newPos[0]/boxVectors[0][0]);
-
         // Now scale the position of the molecule center.
 
+        Vec3 newPos = pos;
         newPos[0] *= scaleX;
         newPos[1] *= scaleY;
         newPos[2] *= scaleZ;

--- a/tests/TestMonteCarloAnisotropicBarostat.h
+++ b/tests/TestMonteCarloAnisotropicBarostat.h
@@ -301,18 +301,6 @@ void testTriclinic() {
     for (int i = 0; i < 3; i++) {
         ASSERT_EQUAL_VEC(Vec3(xscale*initialBox[i][0], yscale*initialBox[i][1], zscale*initialBox[i][2]), box[i], 1e-5);
     }
-
-    // The barostat should have put all particles inside the first periodic box.  One integration step
-    // has happened since then, so they may have moved slightly outside it.
-
-    for (int i = 0; i < numParticles; i++) {
-        Vec3 pos = state.getPositions()[i];
-        ASSERT(pos[2]/box[2][2] > -1 && pos[2]/box[2][2] < 2);
-        pos -= box[2]*floor(pos[2]/box[2][2]);
-        ASSERT(pos[1]/box[1][1] > -1 && pos[1]/box[1][1] < 2);
-        pos -= box[1]*floor(pos[1]/box[1][1]);
-        ASSERT(pos[0]/box[0][0] > -1 && pos[0]/box[0][0] < 2);
-    }
 }
 
 /**


### PR DESCRIPTION
Fixes #2898.

Previously every time a barostat attempted a step, it would begin by translating all the molecules into a single periodic box.  I'm not sure why I originally wrote it that way.  I thought it was necessary, but looking at it now I can't see any reason it would be.  I removed the code to do the translation and all the tests still pass.