### PR TITLE
copy() works better for Python subclasses of C++ classes

### DIFF
--- a/wrappers/python/src/swig_doxygen/swigInputBuilder.py
+++ b/wrappers/python/src/swig_doxygen/swigInputBuilder.py
@@ -270,7 +270,7 @@ class SwigInputBuilder:
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")
 
-        self.fOut.write("%factory(OpenMM::Force* OpenMM::Force::__copy__")
+        self.fOut.write("%factory(OpenMM::Force* OpenMM_XmlSerializer__cloneForce")
         for name in sorted(forceSubclassList):
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")
@@ -285,7 +285,7 @@ class SwigInputBuilder:
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")
 
-        self.fOut.write("%factory(OpenMM::Integrator* OpenMM::Integrator::__copy__")
+        self.fOut.write("%factory(OpenMM::Integrator* OpenMM_XmlSerializer__cloneIntegrator")
         for name in sorted(integratorSubclassList):
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")
@@ -305,7 +305,7 @@ class SwigInputBuilder:
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")
 
-        self.fOut.write("%factory(OpenMM::TabulatedFunction* OpenMM::TabulatedFunction::__copy__")
+        self.fOut.write("%factory(OpenMM::TabulatedFunction* OpenMM_XmlSerializer__cloneTabulatedFunction")
         for name in sorted(tabulatedFunctionSubclassList):
             self.fOut.write(",\n         OpenMM::%s" % name)
         self.fOut.write(");\n\n")

--- a/wrappers/python/tests/TestPickle.py
+++ b/wrappers/python/tests/TestPickle.py
@@ -68,6 +68,30 @@ class TestPickle(unittest.TestCase):
             force_copy = pickle.loads(pickle.dumps(force))
             self.check_copy(force, force_copy)
 
+    def testCopyIntegrator(self):
+        """Test copying a Python object whose class extends Integrator."""
+        integrator1 = MTSIntegrator(4*femtoseconds, [(2,1), (1,2), (0,8)])
+        integrator1.extraField = 5
+        integrator2 = copy.deepcopy(integrator1)
+        self.assertEqual(XmlSerializer.serialize(integrator1), XmlSerializer.serialize(integrator2))
+        self.assertEqual(MTSIntegrator, type(integrator2))
+        self.assertEqual(5, integrator2.extraField)
+        self.assertEqual(1, integrator2.getNumPerDofVariables())
+
+    def testCopyForce(self):
+        """Test copying a Python object whose class extends Force."""
+        class ScaledForce(CustomNonbondedForce):
+            def __init__(self, scale):
+                super().__init__(f'{scale}*r')
+                self.scale = scale
+
+        f1 = ScaledForce(3)
+        f2 = copy.deepcopy(f1)
+        self.assertEqual(XmlSerializer.serialize(f1), XmlSerializer.serialize(f2))
+        self.assertEqual(ScaledForce, type(f2))
+        self.assertEqual(3, f2.scale)
+        self.assertEqual('3*r', f2.getEnergyFunction())
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Implements #1911.

If you define a Python class that extends a C++ Force or Integrator class, `copy()` and `deepcopy()` now work better than before.  They return an instance of the correct Python class, not the C++ parent class, and any fields defined in Python get copied.

This appears to work correctly in my tests, but there's a lot of subtlety in the interaction between C++ and Python.  Please watch for any errors related to this and report anything you find.  Also remember that this only affects copying.  If you serialize an object to XML and deserialize it, you'll still get the C++ class.  The XML representation doesn't have enough information to reconstruct an instance of a Python class.