### PR TITLE
Further optimization to updating long range correction

### DIFF
--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -2272,6 +2272,8 @@ double CommonCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
             cc.getWorkThread().addTask(new LongRangeTask(cc, context.getOwner(), longRangeCorrectionData, longRangeCoefficient, longRangeCoefficientDerivs, forceCopy));
             hasInitializedLongRangeCorrection = true;
         }
+        else
+            hasInitializedLongRangeCorrection = false;
     }
     if (interactionGroupData.isInitialized()) {
         if (!hasInitializedKernel) {


### PR DESCRIPTION
After a global parameter changes, it doesn't recompute the long range correction coefficient until the next time it needs to compute energy.  In some cases this can save a lot of work.