### PR TITLE
Fixed error in computing charges for Gromacs implicit solvent

### DIFF
--- a/wrappers/python/openmm/app/gromacstopfile.py
+++ b/wrappers/python/openmm/app/gromacstopfile.py
@@ -614,7 +614,9 @@ class GromacsTopFile(object):
             passed for the constraints argument
         implicitSolvent : object=None
             If not None, the implicit solvent model to use.  The only allowed
-            value is OBC2.
+            value is OBC2.  This option is deprecated, since Gromacs 2019 and later
+            no longer support implicit solvent.  It will be removed in a future
+            release.
         soluteDielectric : float=1.0
             The solute dielectric constant to use in the implicit solvent model.
         solventDielectric : float=78.5
@@ -934,7 +936,6 @@ class GromacsTopFile(object):
                             epsilon = float(params[7])
                             lj.addParticle([math.sqrt(4*epsilon*sigma**6), math.sqrt(4*epsilon*sigma**12)])
 
-                for fields in moleculeType.atoms:
                     if implicitSolvent is OBC2:
                         if fields[1] not in self._implicitTypes:
                             raise ValueError('No implicit solvent parameters specified for atom type: '+fields[1])

--- a/wrappers/python/tests/TestGromacsTopFile.py
+++ b/wrappers/python/tests/TestGromacsTopFile.py
@@ -161,10 +161,14 @@ class TestGromacsTopFile(unittest.TestCase):
                     found_matching_solvent_dielectric = True
                 if force.getSoluteDielectric() == 0.9:
                     found_matching_solute_dielectric = True
+                gbcharges = [force.getParticleParameters(i)[0] for i in range(system.getNumParticles())]
             if isinstance(force, NonbondedForce):
                 self.assertEqual(force.getReactionFieldDielectric(), 1.0)
+                nbcharges = [force.getParticleParameters(i)[0] for i in range(system.getNumParticles())]
         self.assertTrue(found_matching_solvent_dielectric and
                         found_matching_solute_dielectric)
+        for q1, q2 in zip(gbcharges, nbcharges):
+            self.assertEqual(q1, q2)
 
     def test_HydrogenMass(self):
         """Test that altering the mass of hydrogens works correctly."""


### PR DESCRIPTION
Fixes #3334.  I also added a deprecation notice indicating that implicit solvent support with GromacsTopFile will be removed in a future release, since Gromacs dropped support for it a couple of years ago.  See #3006.