### PR TITLE
Fixed incorrect context handling

### DIFF
--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -421,12 +421,12 @@ CudaContext::~CudaContext() {
         delete bonded;
     if (nonbonded != NULL)
         delete nonbonded;
+    if (contextIsValid && !isLinkedContext)
+        cuProfilerStop();
     popAsCurrent();
     string errorMessage = "Error deleting Context";
-    if (contextIsValid && !isLinkedContext) {
-        cuProfilerStop();
+    if (contextIsValid && !isLinkedContext)
         cuCtxDestroy(context);
-    }
     contextIsValid = false;
 }
 


### PR DESCRIPTION
This fixes an error that was introduced in #3258.  We didn't have a valid context set while calling `cuProfilerStop()`.  It didn't actually cause any problems as far as I can tell, but it caused `cuda-memcheck` to report lots of errors.