### PR TITLE
Improve performance running on multiple GPUs

### DIFF
--- a/platforms/cuda/include/CudaParallelKernels.h
+++ b/platforms/cuda/include/CudaParallelKernels.h
@@ -91,6 +91,7 @@ private:
     CUfunction sumKernel;
     CUevent event;
     std::vector<CUevent> peerCopyEvent;
+    std::vector<CUevent> peerCopyEventLocal;
     std::vector<CUstream> peerCopyStream;
 };
 

--- a/platforms/cuda/include/CudaParallelKernels.h
+++ b/platforms/cuda/include/CudaParallelKernels.h
@@ -90,7 +90,8 @@ private:
     long long* pinnedForceBuffer;
     CUfunction sumKernel;
     CUevent event;
-    CUstream peerCopyStream;
+    std::vector<CUevent> peerCopyEvent;
+    std::vector<CUstream> peerCopyStream;
 };
 
 /**


### PR DESCRIPTION
cc @aizvorski @dmclark17

I'm trying to make the improvements discussed in #3333.  So far I've done the first part, using multiple streams to broadcast the positions.  Unfortunately, I don't have any hardware to properly test it on.  The best I can do is "parallelize" the computation across multiple contexts on a single GPU.  That's hopefully enough to verify I haven't broken anything, but it doesn't tell us anything about performance.

Can you try this out?  If you can check the following it would be a big help.

- Does it affect performance?  If so, how?
- Try running it in the profiler.  How does it look?  Hopefully we should now see multiple memcpy operations happening in parallel, and also each GPU should begin computing as soon as it has the positions, even if the transfer to another GPU is still in progress.
- Try running the test cases on multiple GPUs, just to verify it really still works.  You can do that by passing the `DeviceIndex` value as the second argument on the command line:

```
./TestCudaNonbondedForce single 0,1,2,3
```