### PR TITLE
Try to fix errors setting up CI builds

### DIFF
--- a/devtools/ci/gh-actions/scripts/install_amd_opencl.sh
+++ b/devtools/ci/gh-actions/scripts/install_amd_opencl.sh
@@ -18,6 +18,7 @@ echo libamdocl64.so > ${OPENCL_VENDOR_PATH}/amdocl64.icd
 export LD_LIBRARY_PATH=${AMDAPPSDK}/lib/x86_64:${LD_LIBRARY_PATH:-}
 chmod +x ${AMDAPPSDK}/bin/x86_64/clinfo
 ${AMDAPPSDK}/bin/x86_64/clinfo
+sudo apt-get update
 sudo apt-get install -y libgl1-mesa-dev
 
 echo "OPENCL_VENDOR_PATH=${OPENCL_VENDOR_PATH}" >> ${GITHUB_ENV}


### PR DESCRIPTION
The AMD OpenCL build has been failing for a while.  I'm trying to get it working again.

The M1 Mac build is also failing for reasons I don't understand.  Here's the relevant part of the log:

```
Ensuring installer...
  Can we use bundled Miniconda?
  Can we download a custom installer by URL?
  ... will download a custom installer by URL.
  Ensuring Installer...
  Checking for cached Miniforge3-MacOSX-arm64.sh@0.0.0-a2d8cad428e2d23deaa456f3311b6d36ac7f3da6dde71365e519b8e85c586e5f...
  Found Miniforge3-MacOSX-arm64.sh cache at /Users/lilmac/Projects/GH-Runner/actions-runner/_work/_tool/Miniforge3-MacOSX-arm64.sh/0.0.0-a2d8cad428e2d23deaa456f3311b6d36ac7f3da6dde71365e519b8e85c586e5f/x64!
Running installer...
Error: Unknown installer extension: 
```

@mikemhenry do you have any idea what the problem is?