### PR TITLE
Add Fortran type translation for `long long`

### DIFF
--- a/wrappers/generateWrappers.py
+++ b/wrappers/generateWrappers.py
@@ -900,6 +900,7 @@ class FortranHeaderGenerator(WrapperGenerator):
         WrapperGenerator.__init__(self, inputDirname, output)
         self.typeTranslations = {'int': 'integer*4',
                                  'bool': 'integer*4',
+				 'long long': 'integer*8',
                                  'double': 'real*8',
                                  'char *': 'character(*)',
                                  'const char *': 'character(*)',

--- a/wrappers/generateWrappers.py
+++ b/wrappers/generateWrappers.py
@@ -900,7 +900,7 @@ class FortranHeaderGenerator(WrapperGenerator):
         WrapperGenerator.__init__(self, inputDirname, output)
         self.typeTranslations = {'int': 'integer*4',
                                  'bool': 'integer*4',
-				 'long long': 'integer*8',
+                                 'long long': 'integer*8',
                                  'double': 'real*8',
                                  'char *': 'character(*)',
                                  'const char *': 'character(*)',


### PR DESCRIPTION
There are some methods with `long long` types, which were introduced in #3248. However, Fortran cannot recognize such type, making compiling errors with Fortran code.

I have added the translation for `long long` to `integer*8` in the translation list. Making the Fortran wrappers compatible.