### PR TITLE
Fix barostat frequency check

### DIFF
--- a/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
@@ -49,7 +49,7 @@ void MonteCarloAnisotropicBarostat::setDefaultPressure(const Vec3& pressure) {
 }
 
 void MonteCarloAnisotropicBarostat::setFrequency(int freq) {
-    if (freq <= 0)
+    if (freq < 0)
         throw OpenMMException("Frequency must be positive");
     frequency = freq;
 }

--- a/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
@@ -50,7 +50,7 @@ void MonteCarloAnisotropicBarostat::setDefaultPressure(const Vec3& pressure) {
 
 void MonteCarloAnisotropicBarostat::setFrequency(int freq) {
     if (freq < 0)
-        throw OpenMMException("Frequency must be positive");
+        throw OpenMMException("Frequency cannot be negative");
     frequency = freq;
 }
 

--- a/openmmapi/src/MonteCarloBarostat.cpp
+++ b/openmmapi/src/MonteCarloBarostat.cpp
@@ -51,7 +51,7 @@ void MonteCarloBarostat::setDefaultPressure(double pressure) {
 
 void MonteCarloBarostat::setFrequency(int freq) {
     if (freq < 0)
-        throw OpenMMException("Frequency must be positive");
+        throw OpenMMException("Frequency cannot be negative");
     frequency = freq;
 }
 

--- a/openmmapi/src/MonteCarloBarostat.cpp
+++ b/openmmapi/src/MonteCarloBarostat.cpp
@@ -50,7 +50,7 @@ void MonteCarloBarostat::setDefaultPressure(double pressure) {
 }
 
 void MonteCarloBarostat::setFrequency(int freq) {
-    if (freq <= 0)
+    if (freq < 0)
         throw OpenMMException("Frequency must be positive");
     frequency = freq;
 }

--- a/openmmapi/src/MonteCarloFlexibleBarostat.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostat.cpp
@@ -50,7 +50,7 @@ void MonteCarloFlexibleBarostat::setDefaultPressure(double pressure) {
 
 void MonteCarloFlexibleBarostat::setFrequency(int freq) {
     if (freq < 0)
-        throw OpenMMException("Frequency must be positive");
+        throw OpenMMException("Frequency cannot be negative");
     frequency = freq;
 }
 

--- a/openmmapi/src/MonteCarloFlexibleBarostat.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostat.cpp
@@ -49,7 +49,7 @@ void MonteCarloFlexibleBarostat::setDefaultPressure(double pressure) {
 }
 
 void MonteCarloFlexibleBarostat::setFrequency(int freq) {
-    if (freq <= 0)
+    if (freq < 0)
         throw OpenMMException("Frequency must be positive");
     frequency = freq;
 }

--- a/openmmapi/src/MonteCarloMembraneBarostat.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostat.cpp
@@ -57,7 +57,7 @@ void MonteCarloMembraneBarostat::setDefaultSurfaceTension(double surfaceTension)
 
 void MonteCarloMembraneBarostat::setFrequency(int freq) {
     if (freq < 0)
-        throw OpenMMException("Frequency must be positive");
+        throw OpenMMException("Frequency cannot be negative");
     frequency = freq;
 }
 

--- a/openmmapi/src/MonteCarloMembraneBarostat.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostat.cpp
@@ -56,7 +56,7 @@ void MonteCarloMembraneBarostat::setDefaultSurfaceTension(double surfaceTension)
 }
 
 void MonteCarloMembraneBarostat::setFrequency(int freq) {
-    if (freq <= 0)
+    if (freq < 0)
         throw OpenMMException("Frequency must be positive");
     frequency = freq;
 }


### PR DESCRIPTION
Fixes https://github.com/openmm/openmm/issues/3408 by allowing the barostat frequency to be 0 for `MonteCarloBarostat`, `MonteCarloFlexibleBarostat`, `MonteCarloMembraneBarostat`, and `MonteCarloAnisotropicBarostat`.