### PR TITLE
Fix GIL for OpenMM::Context::setVelocitiesToTemperature

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
@@ -51,3 +51,17 @@
     }
     PyEval_RestoreThread(_savePythonThreadState);
 }
+
+%exception OpenMM::Context::setVelocitiesToTemperature {
+    PyThreadState* _savePythonThreadState = PyEval_SaveThread();
+    try {
+        $action
+    } catch (std::exception &e) {
+        PyEval_RestoreThread(_savePythonThreadState);
+        PyObject* mm = PyImport_AddModule("openmm");
+        PyObject* openmm_exception = PyObject_GetAttrString(mm, "OpenMMException");
+        PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
+        return NULL;
+    }
+    PyEval_RestoreThread(_savePythonThreadState);
+}


### PR DESCRIPTION
Release the GIL when calling `OpenMM::Context::setVelocitiesToTemperature`, for the same reason as https://github.com/openmm/openmm/pull/3061

Fix https://github.com/openmm/openmm-torch/issues/61.