### PR TITLE
Remove generic patterns in Doxyfiles

### DIFF
--- a/docs-source/api-c++/Doxyfile.in
+++ b/docs-source/api-c++/Doxyfile.in
@@ -614,10 +614,10 @@ EXCLUDE_SYMLINKS       = NO
 # against the file with absolute path, so to exclude all test directories
 # for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/* \
-                         */openmmapi/src/* \
-                         */internal/* \
-                         */.svn/* \
+EXCLUDE_PATTERNS       = @CMAKE_SOURCE_DIR@/*/tests/* \
+                         @CMAKE_SOURCE_DIR@/*/openmmapi/src/* \
+                         @CMAKE_SOURCE_DIR@/*/internal/* \
+                         @CMAKE_SOURCE_DIR@/*/.svn/* \
                          *amoebaKernels.h \
                          *DrudeKernels.h \
                          *RpmdKernels.h \

--- a/plugins/amoeba/wrappers/Doxyfile.in
+++ b/plugins/amoeba/wrappers/Doxyfile.in
@@ -607,10 +607,10 @@ EXCLUDE_SYMLINKS       = NO
 # against the file with absolute path, so to exclude all test directories 
 # for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/* \
-                         */openmmapi/src/* \
-                         */internal/* \
-                         */.svn/* \
+EXCLUDE_PATTERNS       = @CMAKE_SOURCE_DIR@/*/tests/* \
+                         @CMAKE_SOURCE_DIR@/*/openmmapi/src/* \
+                         @CMAKE_SOURCE_DIR@/*/internal/* \
+                         @CMAKE_SOURCE_DIR@/*/.svn/* \
                          *amoebaKernels.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names 

--- a/wrappers/Doxyfile.in
+++ b/wrappers/Doxyfile.in
@@ -608,10 +608,10 @@ EXCLUDE_SYMLINKS       = NO
 # against the file with absolute path, so to exclude all test directories 
 # for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/* \
-                         */openmmapi/src/* \
-                         */internal/* \
-                         */.svn/* \
+EXCLUDE_PATTERNS       = @CMAKE_SOURCE_DIR@/*/tests/* \
+                         @CMAKE_SOURCE_DIR@/*/openmmapi/src/* \
+                         @CMAKE_SOURCE_DIR@/*/internal/* \
+                         @CMAKE_SOURCE_DIR@/*/.svn/* \
                          *amoebaKernels.h \
                          *DrudeKernels.h \
                          *RpmdKernels.h \

--- a/wrappers/python/src/swig_doxygen/doxygen/Doxyfile.in
+++ b/wrappers/python/src/swig_doxygen/doxygen/Doxyfile.in
@@ -614,10 +614,10 @@ EXCLUDE_SYMLINKS       = NO
 # against the file with absolute path, so to exclude all test directories 
 # for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */tests/* \
-                         */openmmapi/src/* \
-                         */internal/* \
-                         */.svn/* \
+EXCLUDE_PATTERNS       = @CMAKE_SOURCE_DIR@/*/tests/* \
+                         @CMAKE_SOURCE_DIR@/*/openmmapi/src/* \
+                         @CMAKE_SOURCE_DIR@/*/internal/* \
+                         @CMAKE_SOURCE_DIR@/*/.svn/* \
                          *amoebaKernels.h \
                          *DrudeKernels.h \
                          *RpmdKernels.h \


### PR DESCRIPTION
Without this restriction in the patterns, the compilation fails if the project folder has parent folders called "tests", "internal" or other words used in these generic patterns.