### PR TITLE
resolve scipy 1.8.0 io.netcdf deprecation warning

### DIFF
--- a/wrappers/python/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/openmm/app/internal/amber_file_parser.py
@@ -790,7 +790,7 @@ def readAmberSystem(topology, prmtop_filename=None, prmtop_loader=None, shake=No
         for (iAtom, jAtom, k, rMin) in prmtop.getBondsNoH():
             force.addBond(iAtom, jAtom, rMin, 2*k)
     system.addForce(force)
-    
+
     # Add Urey-Bradley terms.
     if len(prmtop.getUreyBradleys()) > 0:
         if verbose: print("Adding Urey-Bradley terms...")
@@ -1434,9 +1434,14 @@ class AmberNetcdfRestart(object):
     """
     def __init__(self, filename, asNumpy=False):
         try:
-            from scipy.io.netcdf import NetCDFFile
+            from scipy.io import NetCDFFile
         except ImportError:
-            raise ImportError('scipy is necessary to parse NetCDF restarts')
+            # scipy < 1.8.0
+            try:
+                from scipy.io.netcdf import NetCDFFile
+            except ImportError:
+                raise ImportError('scipy is necessary to parse NetCDF '
+                                  'restarts')
 
         self.filename = filename
         self.velocities = self.boxVectors = self.time = None

--- a/wrappers/python/tests/TestAmberInpcrdFile.py
+++ b/wrappers/python/tests/TestAmberInpcrdFile.py
@@ -5,11 +5,15 @@ from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
 try:
-    from scipy.io import netcdf
+    from scipy.io import NetCDFFile
     SCIPY_IMPORT_FAILED = False
-except:
-    SCIPY_IMPORT_FAILED = True
-
+except ImportError:
+    try:
+        # scipy < 1.8.0
+        from scipy.io import netcdf
+        SCIPY_IMPORT_FAILED = False
+    except:
+        SCIPY_IMPORT_FAILED = True
 
 def compareByElement(array1, array2, cmp):
     for x, y in zip(array1, array2):


### PR DESCRIPTION
With the release of scipy `1.8.0` some deprecation warning showed up for `openmm` when running tests on a downstream project:
```
  /home/sroet/miniconda3/envs/python3/lib/python3.9/site-packages/openmm/app/internal/amber_file_parser.py:1377: DeprecationWarning: Please use `NetCDFFile` from the `scipy.io` namespace, the `scipy.io.netcdf` namespace is deprecated.
    from scipy.io.netcdf import NetCDFFile
```

This solves them for all the `scipy.io` that I could find with the `grep -r -n scipy.io --include='*.py'`