### PR TITLE
Fixed error when invalidating molecules

### DIFF
--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -389,6 +389,7 @@ bool ComputeContext::invalidateMolecules(ComputeForceInfo* force) {
         vector<mm_double4> oldVelm(paddedNumAtoms);
         vector<mm_double4> newVelm(paddedNumAtoms, mm_double4(0,0,0,0));
         getPosq().download(oldPosq);
+        getPosqCorrection().download(oldPosqCorrection);
         getVelm().download(oldVelm);
         for (int i = 0; i < numAtoms; i++) {
             int index = atomIndex[i];


### PR DESCRIPTION
Fixes #3447.  The error occurred when you called `updateParametersInContext()`, and the changed parameters caused the previous atom ordering to no longer be valid.  In that case, if you were using mixed precision, the array of corrections to positions could get corrupted.