### PR TITLE
Fix GIL for OpenMM::CustomCVForce::getCollectiveVariableValues

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
@@ -65,3 +65,17 @@
     }
     PyEval_RestoreThread(_savePythonThreadState);
 }
+
+%exception OpenMM::CustomCVForce::getCollectiveVariableValues {
+    PyThreadState* _savePythonThreadState = PyEval_SaveThread();
+    try {
+        $action
+    } catch (std::exception &e) {
+        PyEval_RestoreThread(_savePythonThreadState);
+        PyObject* mm = PyImport_AddModule("openmm");
+        PyObject* openmm_exception = PyObject_GetAttrString(mm, "OpenMMException");
+        PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
+        return NULL;
+    }
+    PyEval_RestoreThread(_savePythonThreadState);
+}


### PR DESCRIPTION
Release the GIL when calling `OpenMM::CustomCVForce::getCollectiveVariableValues`, for the same reason as https://github.com/openmm/openmm/pull/3061 and https://github.com/openmm/openmm/pull/3424

Fix https://github.com/openmm/openmm-ml/issues/22.