### PR TITLE
Pin linkinator to 3.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -666,12 +666,12 @@ jobs:
           )")
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator ./${d}/ --recurse --timeout=20000 --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
+            npx linkinator@3.0.0 ./${d}/ --recurse --timeout=20000 --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
             ((exitcode+=$?))
             echo "::endgroup::"
           done
           echo "::group:: Check README"
-          npx linkinator ./README.md --markdown --skip "$SKIP_REGEX"
+          npx linkinator@3.0.0 ./README.md --markdown --skip "$SKIP_REGEX"
           ((exitcode+=$?))
           echo "::endgroup::"
           exit $exitcode


### PR DESCRIPTION
This should fix the failing docs builds.  They are caused by a [bug in recent versions of linkinator](https://github.com/JustinBeckwith/linkinator/issues/374), so I pinned it to a slightly older version that doesn't have the bug.  Hopefully they will eventually fix it, and then we can remove the pin.