### PR TITLE
Call add_dll_directory() as context manager

### DIFF
--- a/wrappers/python/openmm/__init__.py
+++ b/wrappers/python/openmm/__init__.py
@@ -16,7 +16,8 @@ if sys.platform == 'win32':
     os.environ['PATH'] = '%(lib)s;%(lib)s\plugins;%(path)s' % {
         'lib': version.openmm_library_path, 'path': _path}
     try:
-        os.add_dll_directory(version.openmm_library_path)
+        with os.add_dll_directory(version.openmm_library_path):
+            from . import _openmm
     except:
         pass
 


### PR DESCRIPTION
This revises how the library path is specified on Windows, as suggested in https://github.com/conda-forge/openmm-feedstock/pull/70#issuecomment-1046253738.

cc @jaimergp @isuruf 