### PR TITLE
Fix possible bug in `AmberPrmTopFile.createSystem()`

### DIFF
--- a/wrappers/python/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/openmm/app/amberprmtopfile.py
@@ -288,7 +288,7 @@ class AmberPrmtopFile(object):
                     sys.setParticleMass(atom2.index, hydrogenMass)
                     sys.setParticleMass(atom1.index, sys.getParticleMass(atom1.index)-transferMass)
         for force in sys.getForces():
-            if isinstance(force, mm.NonbondedForce):
+            if isinstance(force, (mm.NonbondedForce, mm.CustomNonbondedForce)):
                 force.setEwaldErrorTolerance(ewaldErrorTolerance)
                 if switchDistance and nonbondedMethod is not ff.NoCutoff:
                     # make sure it's legal

--- a/wrappers/python/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/openmm/app/amberprmtopfile.py
@@ -288,8 +288,9 @@ class AmberPrmtopFile(object):
                     sys.setParticleMass(atom2.index, hydrogenMass)
                     sys.setParticleMass(atom1.index, sys.getParticleMass(atom1.index)-transferMass)
         for force in sys.getForces():
-            if isinstance(force, (mm.NonbondedForce, mm.CustomNonbondedForce)):
+            if isinstance(force, mm.NonbondedForce):
                 force.setEwaldErrorTolerance(ewaldErrorTolerance)
+            if isinstance(force, (mm.NonbondedForce, mm.CustomNonbondedForce)):
                 if switchDistance and nonbondedMethod is not ff.NoCutoff:
                     # make sure it's legal
                     if (_strip_optunit(switchDistance, u.nanometer) >=

--- a/wrappers/python/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/openmm/app/amberprmtopfile.py
@@ -290,19 +290,19 @@ class AmberPrmtopFile(object):
         for force in sys.getForces():
             if isinstance(force, mm.NonbondedForce):
                 force.setEwaldErrorTolerance(ewaldErrorTolerance)
+                if switchDistance and nonbondedMethod is not ff.NoCutoff:
+                    # make sure it's legal
+                    if (_strip_optunit(switchDistance, u.nanometer) >=
+                            _strip_optunit(nonbondedCutoff, u.nanometer)):
+                        raise ValueError('switchDistance is too large compared '
+                                         'to the cutoff!')
+                    if _strip_optunit(switchDistance, u.nanometer) < 0:
+                        # Detects negatives for both Quantity and float
+                        raise ValueError('switchDistance must be non-negative!')
+                    force.setUseSwitchingFunction(True)
+                    force.setSwitchingDistance(switchDistance)
+
         if removeCMMotion:
             sys.addForce(mm.CMMotionRemover())
-
-        if switchDistance and nonbondedMethod is not ff.NoCutoff:
-            # make sure it's legal
-            if (_strip_optunit(switchDistance, u.nanometer) >=
-                    _strip_optunit(nonbondedCutoff, u.nanometer)):
-                raise ValueError('switchDistance is too large compared '
-                                 'to the cutoff!')
-            if _strip_optunit(switchDistance, u.nanometer) < 0:
-                # Detects negatives for both Quantity and float
-                raise ValueError('switchDistance must be non-negative!')
-            force.setUseSwitchingFunction(True)
-            force.setSwitchingDistance(switchDistance)
 
         return sys


### PR DESCRIPTION
May resolve #3488 if my diagnosis is correct

The repro in the linked issue becomes:
```python3
In [1]: from openmm import app, unit

In [2]: sys = app.AmberPrmtopFile("gbsa.tmp.prmtop").createSystem(
   ...:     nonbondedMethod=app.CutoffNonPeriodic,
   ...:     implicitSolvent=app.OBC2,
   ...:     switchDistance=0.7 * unit.nanometer,
   ...: )
/Users/mwt/miniconda3/envs/openff-interchange-env/lib/python3.8/site-packages/openmm/app/internal/amber_file_parser.py:1102: UserWarning: Non-optimal GB parameters detected for GB model OBC2
  warnings.warn(

In [3]: import openmm

In [4]: for force in sys.getForces():
   ...:     if type(force) == openmm.NonbondedForce:
   ...:         print(force.getSwitchingDistance())
0.7 nm
