### PR TITLE
Workaround for error in finding broken URLs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -650,7 +650,7 @@ jobs:
         shell: bash -l {0}
         env:
           # Pipe-seperated list of domains to skip
-          SKIP_DOMAIN: support.amd.com
+          SKIP_DOMAIN: support.amd.com|www.pnas.org
         run: |
           set +e
           # Linkinator accepts regex for its --skip argument, so we


### PR DESCRIPTION
The docs build has been failing because linkinator incorrectly reports https://www.pnas.org/content/105/17/6290 as being broken.  I [reported the issue](https://github.com/JustinBeckwith/linkinator/issues/386), but so far haven't received any reply.  For now, I'm telling it to skip checking any URLs at www.pnas.org.