### PR TITLE
DCDFile reports CHARMM version 21 instead of 24

### DIFF
--- a/wrappers/python/openmm/app/dcdfile.py
+++ b/wrappers/python/openmm/app/dcdfile.py
@@ -92,7 +92,7 @@ class DCDFile(object):
                 raise ValueError('Cannot append to a DCD file that contains a different number of atoms')
         else:
             header = struct.pack('<i4c9if', 84, b'C', b'O', b'R', b'D', 0, firstStep, interval, 0, 0, 0, 0, 0, 0, dt)
-            header += struct.pack('<13i', boxFlag, 0, 0, 0, 0, 0, 0, 0, 0, 24, 84, 164, 2)
+            header += struct.pack('<13i', boxFlag, 0, 0, 0, 0, 0, 0, 0, 0, 21, 84, 164, 2)
             header += struct.pack('<80s', b'Created by OpenMM')
             header += struct.pack('<80s', b'Created '+time.asctime(time.localtime(time.time())).encode('ascii'))
             header += struct.pack('<4i', 164, 4, len(list(topology.atoms())), 4)


### PR DESCRIPTION
Fixes #3507.  This should produce DCD files that are read correctly by cpptraj.  @drroe does this look correct to you?