### PR TITLE
Fix for nullptr dereferencing that caused test failures

### DIFF
--- a/openmmapi/src/CompoundIntegrator.cpp
+++ b/openmmapi/src/CompoundIntegrator.cpp
@@ -107,8 +107,10 @@ void CompoundIntegrator::initialize(ContextImpl& context) {
 }
 
 void CompoundIntegrator::cleanup() {
-    for (int i = 0; i < integrators.size(); i++)
+    for (int i = 0; i < integrators.size(); i++) {
         integrators[i]->cleanup();
+        integrators[i]->context = nullptr;
+    }
 }
 
 vector<string> CompoundIntegrator::getKernelNames() {

--- a/openmmapi/src/ContextImpl.cpp
+++ b/openmmapi/src/ContextImpl.cpp
@@ -94,7 +94,7 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
     // Validate the list of properties.
 
     map<string, string> validatedProperties;
-    if(platform) {
+    if (platform != NULL) {
         const vector<string>& platformProperties = platform->getPropertyNames();
         for (auto& prop : properties) {
             string property = prop.first;
@@ -157,7 +157,6 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
     for (int i = candidatePlatforms.size()-1; i >= 0; i--) {
         try {
             this->platform = platform = candidatePlatforms[i].second;
-
             if (originalContext == NULL)
                 platform->contextCreated(*this, validatedProperties);
             else

--- a/openmmapi/src/ContextImpl.cpp
+++ b/openmmapi/src/ContextImpl.cpp
@@ -91,25 +91,6 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
         constraintAtoms.insert(atoms);
     }
     
-    // Validate the list of properties.
-
-    const vector<string>& platformProperties = platform->getPropertyNames();
-    map<string, string> validatedProperties;
-    for (auto& prop : properties) {
-        string property = prop.first;
-        if (platform->deprecatedPropertyReplacements.find(property) != platform->deprecatedPropertyReplacements.end())
-            property = platform->deprecatedPropertyReplacements[property];
-        bool valid = false;
-        for (auto& p : platformProperties)
-            if (p == property) {
-                valid = true;
-                break;
-            }
-        if (!valid)
-            throw OpenMMException("Illegal property name: "+prop.first);
-        validatedProperties[property] = prop.second;
-    }
-    
     // Find the list of kernels required.
     
     vector<string> kernelNames;
@@ -152,6 +133,25 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
     for (int i = candidatePlatforms.size()-1; i >= 0; i--) {
         try {
             this->platform = platform = candidatePlatforms[i].second;
+
+            // Validate the list of properties.
+            const vector<string>& platformProperties = platform->getPropertyNames();
+            map<string, string> validatedProperties;
+            for (auto& prop : properties) {
+                string property = prop.first;
+                if (platform->deprecatedPropertyReplacements.find(property) != platform->deprecatedPropertyReplacements.end())
+                    property = platform->deprecatedPropertyReplacements[property];
+                bool valid = false;
+                for (auto& p : platformProperties)
+                    if (p == property) {
+                        valid = true;
+                        break;
+                    }
+                if (!valid)
+                    throw OpenMMException("Illegal property name: "+prop.first);
+                validatedProperties[property] = prop.second;
+            }
+
             if (originalContext == NULL)
                 platform->contextCreated(*this, validatedProperties);
             else


### PR DESCRIPTION
This fixes a bug that caused `TestReferenceCompoundIntegrator`, `TestSerializeState` and `TestSerializeNoseHooverIntegrator` to fail (maybe some others too).

Interestingly enough, for me it segfaults when compiled with `-O3`, but not when compiled with `-O0`. And it's very surprising that this is the case, because one would think that dereferencing `NULL` would trigger a segfault in both cases.

The nature of the `TestSerializeState` bug is that the
```cpp
platform->getPropertyNames();
```
is invoked before `platform` is checked for `NULL`. The `TestSerializeNoseHooverIntegrator` invokes the `Context` constructor without specifying a platform, so it triggers this bug.

And the nature of the `TestReferenceCompoundIntegrator` bug is that `CompoundIntegrator::cleanup` doesn't erase the ptr to `context` in its children, and so they later attempt to call `ContextImpl::integratorDeleted` on a deleted context.

Also, this might be the cause of segfaults happening in #3513