### PR TITLE
Removed code for CUDA devices without shuffle

### DIFF
--- a/platforms/cuda/src/CudaNonbondedUtilities.cpp
+++ b/platforms/cuda/src/CudaNonbondedUtilities.cpp
@@ -556,95 +556,38 @@ CUfunction CudaNonbondedUtilities::createInteractionKernel(const string& source,
     }
     replacements["LOAD_ATOM1_PARAMETERS"] = load1.str();
 
-    int cudaVersion;
-    cuDriverGetVersion(&cudaVersion);
-    bool useShuffle = (context.getComputeCapability() >= 3.0 && cudaVersion >= 5050);
-
     // Part 1. Defines for on diagonal exclusion tiles
-    stringstream loadLocal1;
-    if(useShuffle) {
-        // not needed if using shuffles as we can directly fetch from register
-    } else {
-        for (const ParameterInfo& param : params) {
-            if (param.getNumComponents() == 1)
-                loadLocal1<<"localData[LOCAL_ID]."<<param.getName()<<" = "<<param.getName()<<"1;\n";
-            else {
-                for (int j = 0; j < param.getNumComponents(); ++j)
-                    loadLocal1<<"localData[LOCAL_ID]."<<param.getName()<<"_"<<suffixes[j]<<" = "<<param.getName()<<"1."<<suffixes[j]<<";\n";
-            }
-        }
-    }
-    replacements["LOAD_LOCAL_PARAMETERS_FROM_1"] = loadLocal1.str();
 
     stringstream broadcastWarpData;
-    if (useShuffle) {
-        broadcastWarpData << "posq2.x = real_shfl(shflPosq.x, j);\n";
-        broadcastWarpData << "posq2.y = real_shfl(shflPosq.y, j);\n";
-        broadcastWarpData << "posq2.z = real_shfl(shflPosq.z, j);\n";
-        broadcastWarpData << "posq2.w = real_shfl(shflPosq.w, j);\n";
-        for (const ParameterInfo& param : params) {
-            broadcastWarpData << param.getType() << " shfl" << param.getName() << ";\n";
-            for (int j = 0; j < param.getNumComponents(); j++) {
-                if (param.getNumComponents() == 1)
-                    broadcastWarpData << "shfl" << param.getName() << "=real_shfl(" << param.getName() <<"1,j);\n";
-                else
-                    broadcastWarpData << "shfl" << param.getName()+"."+suffixes[j] << "=real_shfl(" << param.getName()+"1."+suffixes[j] <<",j);\n";
-            }
+    broadcastWarpData << "posq2.x = real_shfl(shflPosq.x, j);\n";
+    broadcastWarpData << "posq2.y = real_shfl(shflPosq.y, j);\n";
+    broadcastWarpData << "posq2.z = real_shfl(shflPosq.z, j);\n";
+    broadcastWarpData << "posq2.w = real_shfl(shflPosq.w, j);\n";
+    for (const ParameterInfo& param : params) {
+        broadcastWarpData << param.getType() << " shfl" << param.getName() << ";\n";
+        for (int j = 0; j < param.getNumComponents(); j++) {
+            if (param.getNumComponents() == 1)
+                broadcastWarpData << "shfl" << param.getName() << "=real_shfl(" << param.getName() <<"1,j);\n";
+            else
+                broadcastWarpData << "shfl" << param.getName()+"."+suffixes[j] << "=real_shfl(" << param.getName()+"1."+suffixes[j] <<",j);\n";
         }
-    } else {
-        // not used if not shuffling
     }
     replacements["BROADCAST_WARP_DATA"] = broadcastWarpData.str();
     
     // Part 2. Defines for off-diagonal exclusions, and neighborlist tiles. 
     stringstream declareLocal2;
-    if (useShuffle) {
-        for (const ParameterInfo& param : params)
-            declareLocal2<<param.getType()<<" shfl"<<param.getName()<<";\n";
-    }
-    else {
-        // not used if using shared memory
-    }
+    for (const ParameterInfo& param : params)
+        declareLocal2<<param.getType()<<" shfl"<<param.getName()<<";\n";
     replacements["DECLARE_LOCAL_PARAMETERS"] = declareLocal2.str();
 
     stringstream loadLocal2;
-    if (useShuffle) {
-        for (const ParameterInfo& param : params)
-            loadLocal2<<"shfl"<<param.getName()<<" = global_"<<param.getName()<<"[j];\n";
-    }
-    else {
-        for (const ParameterInfo& param : params) {
-            if (param.getNumComponents() == 1)
-                loadLocal2<<"localData[LOCAL_ID]."<<param.getName()<<" = global_"<<param.getName()<<"[j];\n";
-            else {
-                loadLocal2<<param.getType()<<" temp_"<<param.getName()<<" = global_"<<param.getName()<<"[j];\n";
-                for (int j = 0; j < param.getNumComponents(); ++j)
-                    loadLocal2<<"localData[LOCAL_ID]."<<param.getName()<<"_"<<suffixes[j]<<" = temp_"<<param.getName()<<"."<<suffixes[j]<<";\n";
-            }
-        }
-    }
+    for (const ParameterInfo& param : params)
+        loadLocal2<<"shfl"<<param.getName()<<" = global_"<<param.getName()<<"[j];\n";
     replacements["LOAD_LOCAL_PARAMETERS_FROM_GLOBAL"] = loadLocal2.str();
    
     stringstream load2j;
-    if (useShuffle) {
-        for (const ParameterInfo& param : params)
-            load2j<<param.getType()<<" "<<param.getName()<<"2 = shfl"<<param.getName()<<";\n";
-    }
-    else {
-        for (const ParameterInfo& param : params) {
-            if (param.getNumComponents() == 1)
-                load2j<<param.getType()<<" "<<param.getName()<<"2 = localData[atom2]."<<param.getName()<<";\n";
-            else {
-                load2j<<param.getType()<<" "<<param.getName()<<"2 = make_"<<param.getType()<<"(";
-                for (int j = 0; j < param.getNumComponents(); ++j) {
-                    if (j > 0)
-                        load2j<<", ";
-                    load2j<<"localData[atom2]."<<param.getName()<<"_"<<suffixes[j];
-                }
-                load2j<<");\n";
-            }
-        }
-    }
+    for (const ParameterInfo& param : params)
+        load2j<<param.getType()<<" "<<param.getName()<<"2 = shfl"<<param.getName()<<";\n";
     replacements["LOAD_ATOM2_PARAMETERS"] = load2j.str();
 
     stringstream load2g;
@@ -654,11 +597,7 @@ CUfunction CudaNonbondedUtilities::createInteractionKernel(const string& source,
     
     stringstream clearLocal;
     for (const ParameterInfo& param : params) {
-        if (useShuffle)
-            clearLocal<<"shfl";
-        else
-            clearLocal<<"localData[atom2].";
-        clearLocal<<param.getName()<<" = ";
+        clearLocal<<"shfl"<<param.getName()<<" = ";
         if (param.getNumComponents() == 1)
             clearLocal<<"0;\n";
         else
@@ -680,29 +619,25 @@ CUfunction CudaNonbondedUtilities::createInteractionKernel(const string& source,
     replacements["SAVE_DERIVATIVES"] = saveDerivs.str();
 
     stringstream shuffleWarpData;
-    if(useShuffle) {
-        shuffleWarpData << "shflPosq.x = real_shfl(shflPosq.x, tgx+1);\n";
-        shuffleWarpData << "shflPosq.y = real_shfl(shflPosq.y, tgx+1);\n";
-        shuffleWarpData << "shflPosq.z = real_shfl(shflPosq.z, tgx+1);\n";
-        shuffleWarpData << "shflPosq.w = real_shfl(shflPosq.w, tgx+1);\n";
-        shuffleWarpData << "shflForce.x = real_shfl(shflForce.x, tgx+1);\n";
-        shuffleWarpData << "shflForce.y = real_shfl(shflForce.y, tgx+1);\n";
-        shuffleWarpData << "shflForce.z = real_shfl(shflForce.z, tgx+1);\n";
-        for (const ParameterInfo& param : params) {
-            if (param.getNumComponents() == 1)
-                shuffleWarpData<<"shfl"<<param.getName()<<"=real_shfl(shfl"<<param.getName()<<", tgx+1);\n";
-            else {
-                for (int j = 0; j < param.getNumComponents(); j++) {
-                    // looks something like shflsigmaEpsilon.x = real_shfl(shflsigmaEpsilon.x,tgx+1);
-                    shuffleWarpData<<"shfl"<<param.getName()
-                        <<"."<<suffixes[j]<<"=real_shfl(shfl"
-                        <<param.getName()<<"."<<suffixes[j]
-                        <<", tgx+1);\n";
-                }
+    shuffleWarpData << "shflPosq.x = real_shfl(shflPosq.x, tgx+1);\n";
+    shuffleWarpData << "shflPosq.y = real_shfl(shflPosq.y, tgx+1);\n";
+    shuffleWarpData << "shflPosq.z = real_shfl(shflPosq.z, tgx+1);\n";
+    shuffleWarpData << "shflPosq.w = real_shfl(shflPosq.w, tgx+1);\n";
+    shuffleWarpData << "shflForce.x = real_shfl(shflForce.x, tgx+1);\n";
+    shuffleWarpData << "shflForce.y = real_shfl(shflForce.y, tgx+1);\n";
+    shuffleWarpData << "shflForce.z = real_shfl(shflForce.z, tgx+1);\n";
+    for (const ParameterInfo& param : params) {
+        if (param.getNumComponents() == 1)
+            shuffleWarpData<<"shfl"<<param.getName()<<"=real_shfl(shfl"<<param.getName()<<", tgx+1);\n";
+        else {
+            for (int j = 0; j < param.getNumComponents(); j++) {
+                // looks something like shflsigmaEpsilon.x = real_shfl(shflsigmaEpsilon.x,tgx+1);
+                shuffleWarpData<<"shfl"<<param.getName()
+                    <<"."<<suffixes[j]<<"=real_shfl(shfl"
+                    <<param.getName()<<"."<<suffixes[j]
+                    <<", tgx+1);\n";
             }
         }
-    } else {
-        // not used otherwise
     }
     replacements["SHUFFLE_WARP_DATA"] = shuffleWarpData.str();
 
@@ -715,8 +650,7 @@ CUfunction CudaNonbondedUtilities::createInteractionKernel(const string& source,
         defines["USE_EXCLUSIONS"] = "1";
     if (isSymmetric)
         defines["USE_SYMMETRIC"] = "1";
-    if (useShuffle)
-        defines["ENABLE_SHUFFLE"] = "1";
+    defines["ENABLE_SHUFFLE"] = "1";
     if (includeForces)
         defines["INCLUDE_FORCES"] = "1";
     if (includeEnergy)


### PR DESCRIPTION
This removes obsolete code that existed to support very old GPUs (pre-Kepler) that didn't support shuffle instructions.  The code had been broken for a while, but no one seems to have noticed.