### PR TITLE
Generate more informative error message if residue template not found

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -1086,15 +1086,14 @@ class ForceField(object):
         # Find the template matching each residue, compiling a list of residues for which no templates are available.
         bondedToAtom = self._buildBondedToAtomList(topology)
         templates = list() # list of templates matching the corresponding residues
-        for chain in topology.chains():
-            for residue in chain.residues():
-                # Attempt to match one of the existing templates.
-                [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
-                # Raise an exception if we have found no templates that match.
-                if matches is None:
-                    raise ValueError('No template found for chainid <%s> resid <%s> resname <%s> (residue index within topology %d).\n%s' % (chain.id, res.id, res.name, res.index, _findMatchErrors(self, res)))
-                else:
-                    templates.append(template)
+        for residue in topology.residues():
+            # Attempt to match one of the existing templates.
+            [template, matches] = self._getResidueTemplateMatches(residue, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
+            # Raise an exception if we have found no templates that match.
+            if matches is None:
+                raise ValueError('No template found for chainid <%s> resid <%s> resname <%s> (residue index within topology %d).\n%s' % (residue.chain.id, residue.id, residue.name, residue.index, _findMatchErrors(self, residue)))
+            else:
+                templates.append(template)
 
         return templates
 


### PR DESCRIPTION
Fixes #3557.

Instead of generating error messages that index the residue within the entire topology when a residue template is not found:
```
ValueError: No template found for residue 1168 (ASN). The set of atoms matches ASN, but the bonds are different.
```
we now generate a more useful error message:
```
ValueError: No template found for chainid <G>, resid <213>, resname <ASN> (residue index in topology 1168). 
The set of atoms matches ASN, but the bonds are different.
```