### PR TITLE
Fixed inconsistency in computing kinetic energy

### DIFF
--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -113,7 +113,7 @@ static double computeShiftedKineticEnergy(ContextImpl& context, vector<double>& 
     int numParticles = context.getSystem().getNumParticles();
     
     // Compute the shifted velocities.
-    
+
     vector<Vec3> shiftedVel(numParticles);
     for (int i = 0; i < numParticles; ++i) {
         if (masses[i] > 0)
@@ -123,11 +123,13 @@ static double computeShiftedKineticEnergy(ContextImpl& context, vector<double>& 
     }
     
     // Apply constraints to them.
-    
-    vector<double> inverseMasses(numParticles);
-    for (int i = 0; i < numParticles; i++)
-        inverseMasses[i] = (masses[i] == 0 ? 0 : 1/masses[i]);
-    extractConstraints(context).applyToVelocities(posData, shiftedVel, inverseMasses, 1e-4);
+
+    if (timeShift != 0) {
+        vector<double> inverseMasses(numParticles);
+        for (int i = 0; i < numParticles; i++)
+            inverseMasses[i] = (masses[i] == 0 ? 0 : 1/masses[i]);
+        extractConstraints(context).applyToVelocities(posData, shiftedVel, inverseMasses, 1e-4);
+    }
     
     // Compute the kinetic energy.
     

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -262,8 +262,9 @@ void ReferenceUpdateStateDataKernel::computeShiftedVelocities(ContextImpl& conte
     }
     
     // Apply constraints to them.
-    
-    extractConstraints(context).applyToVelocities(posData, velocities, inverseMasses, 1e-4);
+
+    if (timeShift != 0)
+        extractConstraints(context).applyToVelocities(posData, velocities, inverseMasses, 1e-4);
 }
 
 void ReferenceUpdateStateDataKernel::getForces(ContextImpl& context, std::vector<Vec3>& forces) {


### PR DESCRIPTION
Fixes #3570.  Many integrators apply a half step offset to the velocities when computing kinetic energy.  After updating the velocities, it needs to apply constraints to them to make sure the updated velocities still respect the constraints.

LangevinMiddleIntegrator does not apply an offset, but on the CPU and Reference platforms it was still applying constraints.  In the example from that issue, the velocities being loaded into the Context did not respect the constraints.  This led to different kinetic energies being reported by different platforms.

I changed Reference and CPU to behave the same way OpenCL and CUDA do: if no offset is applied, do not apply constraints.  That means if you call `setVelocities()` or `setState()`, the kinetic energy will exactly match the velocities you set, even if they include a component along a constrained direction.