### PR TITLE
Vectorize nonbonded interactions with no cutoff

### DIFF
--- a/platforms/cpu/include/CpuCustomNonbondedForce.h
+++ b/platforms/cpu/include/CpuCustomNonbondedForce.h
@@ -48,7 +48,7 @@ public:
 
          --------------------------------------------------------------------------------------- */
 
-       CpuCustomNonbondedForce(ThreadPool& threads);
+       CpuCustomNonbondedForce(ThreadPool& threads, const CpuNeighborList& neighbors);
 
        void initialize(const Lepton::ParsedExpression& energyExpression, const Lepton::ParsedExpression& forceExpression,
                        const std::vector<std::string>& parameterNames, const std::vector<std::set<int> >& exclusions,
@@ -68,11 +68,10 @@ public:
          Set the force to use a cutoff.
 
          @param distance            the cutoff distance
-         @param neighbors           the neighbor list to use
 
          --------------------------------------------------------------------------------------- */
 
-      void setUseCutoff(double distance, const CpuNeighborList& neighbors);
+      void setUseCutoff(double distance);
 
       /**---------------------------------------------------------------------------------------
 
@@ -212,7 +211,7 @@ public:
 /**
  * This function is called to create an instance of an appropriate subclass for the current CPU.
  */
-CpuCustomNonbondedForce* createCpuCustomNonbondedForce(ThreadPool& threads);
+CpuCustomNonbondedForce* createCpuCustomNonbondedForce(ThreadPool& threads, const CpuNeighborList& neighbors);
 
 } // namespace OpenMM
 

--- a/platforms/cpu/include/CpuNeighborList.h
+++ b/platforms/cpu/include/CpuNeighborList.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2018 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -48,11 +48,31 @@ public:
     class Voxels;
     class NeighborIterator;
     CpuNeighborList(int blockSize);
+    /**
+     * Compute the neighbor list based on the current positions of atoms.
+     * 
+     * @param numAtoms            the number of atoms in the system
+     * @param atomLocations       the positions of the atoms
+     * @param exclusions          exclusions[i] contains the indices of all atoms with which atom i should not interact
+     * @param periodicBoxVectors  the current periodic box vectors
+     * @param usePeriodic         whether to apply periodic boundary conditions
+     * @param maxDistance         the neighbor list will contain all pairs that are within this distance of each other
+     * @param threads             used for parallelization
+     */
     void computeNeighborList(int numAtoms, const AlignedArray<float>& atomLocations, const std::vector<std::set<int> >& exclusions,
             const Vec3* periodicBoxVectors, bool usePeriodic, float maxDistance, ThreadPool& threads);
+    /**
+     * Build a dense neighbor list, in which every atom interacts with every other (except exclusions), regardless of distance.
+     * 
+     * @param numAtoms            the number of atoms in the system
+     * @param exclusions          exclusions[i] contains the indices of all atoms with which atom i should not interact
+     */
     void createDenseNeighborList(int numAtoms, const std::vector<std::set<int> >& exclusions);
     int getNumBlocks() const;
     int getBlockSize() const;
+    /**
+     * Get an object for iterating over the neighbors of an atom block.
+     */
     NeighborIterator getNeighborIterator(int blockIndex) const;
     const std::vector<int32_t>& getSortedAtoms() const;
     const std::vector<int>& getBlockNeighbors(int blockIndex) const;
@@ -74,7 +94,7 @@ private:
     int blockSize;
     std::vector<int> sortedAtoms;
     std::vector<float> sortedPositions;
-    std::vector<std::vector<int> > blockNeighbors;
+    std::vector<std::vector<int> > blockNeighbors, blockExclusionIndices;
     std::vector<std::vector<BlockExclusionMask> > blockExclusions;
     // The following variables are used to make information accessible to the individual threads.
     float minx, maxx, miny, maxy, minz, maxz;
@@ -84,21 +104,43 @@ private:
     const float* atomLocations;
     Vec3 periodicBoxVectors[3];
     int numAtoms;
-    bool usePeriodic;
+    bool usePeriodic, dense;
     float maxDistance;
     std::atomic<int> atomicCounter;
 };
 
 class OPENMM_EXPORT_CPU CpuNeighborList::NeighborIterator {
 public:
+    /**
+     * This constructor is used for standard neighbor lists.  Do not call it directly.  Obtain a
+     * NeighborIterator by calling getNeighborIterator() on a neighbor list.
+     */
     NeighborIterator(const std::vector<int>& neighbors, const std::vector<BlockExclusionMask>& exclusions);
+    /**
+     * This constructor is used for dense neighbor lists.  Do not call it directly.  Obtain a
+     * NeighborIterator by calling getNeighborIterator() on a neighbor list.
+     */
+    NeighborIterator(int firstAtom, int lastAtom, const std::vector<int>& exclusionIndices, const std::vector<BlockExclusionMask>& exclusions);
+    /**
+     * Advance the iterator to the next neighbor.
+     * 
+     * @return false if there are no more neighbors, true otherwise.
+     */
     bool next();
+    /**
+     * Get the index of the current neighbor.
+     */
     int getNeighbor() const;
+    /**
+     * Get bit flags marking which atoms in the block the current atom is excluded from interacting with.
+     */
     BlockExclusionMask getExclusions() const;
 private:
-    int currentAtom, currentIndex;
+    bool dense;
+    int currentAtom, currentIndex, lastAtom;
     BlockExclusionMask currentExclusions;
     const std::vector<int>* neighbors;
+    const std::vector<int>* exclusionIndices;
     const std::vector<BlockExclusionMask>* exclusions;
 };
 

--- a/platforms/cpu/include/CpuNeighborList.h
+++ b/platforms/cpu/include/CpuNeighborList.h
@@ -46,12 +46,14 @@ namespace OpenMM {
 class OPENMM_EXPORT_CPU CpuNeighborList {
 public:
     class Voxels;
+    class NeighborIterator;
     CpuNeighborList(int blockSize);
     void computeNeighborList(int numAtoms, const AlignedArray<float>& atomLocations, const std::vector<std::set<int> >& exclusions,
             const Vec3* periodicBoxVectors, bool usePeriodic, float maxDistance, ThreadPool& threads);
     void createDenseNeighborList(int numAtoms, const std::vector<std::set<int> >& exclusions);
     int getNumBlocks() const;
     int getBlockSize() const;
+    NeighborIterator getNeighborIterator(int blockIndex) const;
     const std::vector<int32_t>& getSortedAtoms() const;
     const std::vector<int>& getBlockNeighbors(int blockIndex) const;
 
@@ -85,6 +87,19 @@ private:
     bool usePeriodic;
     float maxDistance;
     std::atomic<int> atomicCounter;
+};
+
+class OPENMM_EXPORT_CPU CpuNeighborList::NeighborIterator {
+public:
+    NeighborIterator(const std::vector<int>& neighbors, const std::vector<BlockExclusionMask>& exclusions);
+    bool next();
+    int getNeighbor() const;
+    BlockExclusionMask getExclusions() const;
+private:
+    int currentAtom, currentIndex;
+    BlockExclusionMask currentExclusions;
+    const std::vector<int>* neighbors;
+    const std::vector<BlockExclusionMask>* exclusions;
 };
 
 } // namespace OpenMM

--- a/platforms/cpu/include/CpuNeighborList.h
+++ b/platforms/cpu/include/CpuNeighborList.h
@@ -49,6 +49,7 @@ public:
     CpuNeighborList(int blockSize);
     void computeNeighborList(int numAtoms, const AlignedArray<float>& atomLocations, const std::vector<std::set<int> >& exclusions,
             const Vec3* periodicBoxVectors, bool usePeriodic, float maxDistance, ThreadPool& threads);
+    void createDenseNeighborList(int numAtoms, const std::vector<std::set<int> >& exclusions);
     int getNumBlocks() const;
     int getBlockSize() const;
     const std::vector<int32_t>& getSortedAtoms() const;

--- a/platforms/cpu/include/CpuNonbondedForce.h
+++ b/platforms/cpu/include/CpuNonbondedForce.h
@@ -44,10 +44,12 @@ class CpuNonbondedForce {
       /**---------------------------------------------------------------------------------------
       
          Constructor
+
+         @param neighbors           the neighbor list to use
       
          --------------------------------------------------------------------------------------- */
 
-       CpuNonbondedForce();
+       CpuNonbondedForce(const CpuNeighborList& neighbors);
        
         /**
          * Virtual destructor.
@@ -60,12 +62,11 @@ class CpuNonbondedForce {
          Set the force to use a cutoff.
       
          @param distance            the cutoff distance
-         @param neighbors           the neighbor list to use
          @param solventDielectric   the dielectric constant of the bulk solvent
       
          --------------------------------------------------------------------------------------- */
       
-      void setUseCutoff(float distance, const CpuNeighborList& neighbors, float solventDielectric);
+      void setUseCutoff(float distance, float solventDielectric);
 
       /**---------------------------------------------------------------------------------------
       
@@ -213,19 +214,6 @@ protected:
 
         static const float TWO_OVER_SQRT_PI;
         static const int NUM_TABLE_POINTS;
-
-      /**---------------------------------------------------------------------------------------
-      
-         Calculate LJ Coulomb pair ixn between two atoms
-      
-         @param atom1            the index of the first atom
-         @param atom2            the index of the second atom
-         @param forces           force array (forces added)
-         @param totalEnergy      total energy
-            
-         --------------------------------------------------------------------------------------- */
-          
-      void calculateOneIxn(int atom1, int atom2, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize);
             
       /**---------------------------------------------------------------------------------------
       

--- a/platforms/cpu/include/CpuNonbondedForceFvec.h
+++ b/platforms/cpu/include/CpuNonbondedForceFvec.h
@@ -36,7 +36,7 @@
 namespace OpenMM {
 
 enum BlockType {EWALD, NON_EWALD}; // :TODO: Better name for non-ewald.
-enum PeriodicType {NoPeriodic, PeriodicPerAtom, PeriodicPerInteraction, PeriodicTriclinic};
+enum PeriodicType {NoCutoff, NoPeriodic, PeriodicPerAtom, PeriodicPerInteraction, PeriodicTriclinic};
 
 /**
  * Generic SIMD implementation of CpuNonbondedForce. The templating allows the same
@@ -50,6 +50,10 @@ public:
      * Store how many elements are contained in each block of atoms.
      */
     static constexpr int blockSize = sizeof(FVEC) / sizeof(float);
+    /**
+     * Constructor.
+     */
+    CpuNonbondedForceFvec(const CpuNeighborList& neighbors);
 
 protected:
     /**---------------------------------------------------------------------------------------
@@ -94,6 +98,10 @@ protected:
       FVEC approximateFunctionFromTable(const std::vector<float>& table, FVEC x, FVEC inverse) const;
 
 };
+
+template <typename FVEC>
+CpuNonbondedForceFvec<FVEC>::CpuNonbondedForceFvec(const CpuNeighborList& neighbors) : CpuNonbondedForce(neighbors) {
+}
 
 /**
  * Use a table lookup to approximate a function specific function.
@@ -166,7 +174,9 @@ void CpuNonbondedForceFvec<FVEC>::calculateBlockIxnHandler(int blockIndex, float
     }
     
     // Call the appropriate version depending on what calculation is required for periodic boundary conditions.
-    if (periodicType == NoPeriodic)
+    if (!cutoff)
+        calculateBlockIxnImpl<NoCutoff, BLOCK_TYPE>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == NoPeriodic)
         calculateBlockIxnImpl<NoPeriodic, BLOCK_TYPE>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
     else if (periodicType == PeriodicPerAtom)
         calculateBlockIxnImpl<PeriodicPerAtom, BLOCK_TYPE>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
@@ -198,8 +208,7 @@ void CpuNonbondedForceFvec<FVEC>::calculateBlockIxnImpl(int blockIndex, float* f
     // the cycles are spent anyway.
     FVEC blockAtomSigma = {};
     FVEC blockAtomEpsilon = {};
-    for (int i=0; i<blockSize; ++i)
-    {
+    for (int i = 0; i < blockSize; ++i) {
         ((float*)&blockAtomSigma)[i] = atomParameters[blockAtom[i]].first;
         ((float*)&blockAtomEpsilon)[i] = atomParameters[blockAtom[i]].second;
     }
@@ -217,19 +226,19 @@ void CpuNonbondedForceFvec<FVEC>::calculateBlockIxnImpl(int blockIndex, float* f
 
     for (int i = 0; i < (int) neighbors.size(); i++) {
         // Load the next neighbor.
-        
+
         int atom = neighbors[i];
-        
+
         // Compute the distances to the block atoms.
-        
+
         FVEC dx, dy, dz, r2;
         fvec4 atomPos(posq+4*atom);
         if (PERIODIC_TYPE == PeriodicPerAtom)
             atomPos -= floor((atomPos-blockCenter)*invBoxSize+0.5f)*boxSize;
         getDeltaR<PERIODIC_TYPE>(atomPos, blockAtomX, blockAtomY, blockAtomZ, dx, dy, dz, r2, boxSize, invBoxSize);
-
-        const auto exclNotMask = FVEC::expandBitsToMask(~exclusions[i]);
-        const auto include = blendZero(r2 < cutoffDistanceSquared, exclNotMask);
+        auto include = FVEC::expandBitsToMask(~exclusions[i]);
+        if (PERIODIC_TYPE != NoCutoff)
+            include = blendZero(r2 < cutoffDistanceSquared, include);
         if (!any(include))
             continue; // No interactions to compute.
 

--- a/platforms/cpu/include/CpuPlatform.h
+++ b/platforms/cpu/include/CpuPlatform.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2018 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -99,6 +99,7 @@ public:
     bool isPeriodic;
     CpuRandom random;
     std::map<std::string, std::string> propertyValues;
+    int numParticles;
     CpuNeighborList* neighborList;
     double cutoff, paddedCutoff;
     bool anyExclusions, deterministicForces;

--- a/platforms/cpu/include/CpuPlatform.h
+++ b/platforms/cpu/include/CpuPlatform.h
@@ -91,6 +91,18 @@ class CpuPlatform::PlatformData {
 public:
     PlatformData(int numParticles, int numThreads, bool deterministicForces);
     ~PlatformData();
+    /**
+     * Request that a neighbor list be built and maintained.
+     * 
+     * @param cutoffDistance  the cutoff distance for particle pairs to be included in the neighbor list.
+     *                        If this is 0, a dense neighbor list is built that includes all particle pairs
+     *                        regardless of distance.
+     * @param padding         a padding distance that should be added to the cutoff so the neighbor list
+     *                        does not need to be rebuilt every step
+     * @param useExclusions   whether to omit specific excluded interactions
+     * @param exclusionList   if useExclusions is true, exclusionList[i] should contain the indices of all
+     *                        particles with which particle i should not interact
+     */
     void requestNeighborList(double cutoffDistance, double padding, bool useExclusions, const std::vector<std::set<int> >& exclusionList);
     int requestPosqIndex();
     AlignedArray<float> posq;

--- a/platforms/cpu/src/CpuCustomNonbondedForceAvx.cpp
+++ b/platforms/cpu/src/CpuCustomNonbondedForceAvx.cpp
@@ -31,7 +31,7 @@ using namespace OpenMM;
 #include "openmm/internal/vectorizeAvx.h"
 
 CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(ThreadPool& threads, const CpuNeighborList& neighbors) {
-    return new CpuCustomNonbondedForceFvec<fvec8, 8>(threads);
+    return new CpuCustomNonbondedForceFvec<fvec8, 8>(threads, neighbors);
 }
 
 #else

--- a/platforms/cpu/src/CpuCustomNonbondedForceAvx.cpp
+++ b/platforms/cpu/src/CpuCustomNonbondedForceAvx.cpp
@@ -25,15 +25,17 @@
 #include "CpuCustomNonbondedForceFvec.h"
 #include "openmm/OpenMMException.h"
 
+using namespace OpenMM;
+
 #ifdef __AVX__
 #include "openmm/internal/vectorizeAvx.h"
 
-OpenMM::CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(OpenMM::ThreadPool& threads) {
-    return new OpenMM::CpuCustomNonbondedForceFvec<fvec8, 8>(threads);
+CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(ThreadPool& threads, const CpuNeighborList& neighbors) {
+    return new CpuCustomNonbondedForceFvec<fvec8, 8>(threads);
 }
 
 #else
-OpenMM::CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(OpenMM::ThreadPool& threads) {
-   throw OpenMM::OpenMMException("Internal error: OpenMM was compiled without AVX support");
+CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(ThreadPool& threads, const CpuNeighborList& neighbors) {
+   throw OpenMMException("Internal error: OpenMM was compiled without AVX support");
 }
 #endif

--- a/platforms/cpu/src/CpuCustomNonbondedForceFvec.cpp
+++ b/platforms/cpu/src/CpuCustomNonbondedForceFvec.cpp
@@ -25,12 +25,14 @@
 #include "CpuCustomNonbondedForceFvec.h"
 #include "openmm/internal/hardware.h"
 
-OpenMM::CpuCustomNonbondedForce* createCpuCustomNonbondedForceVec4(OpenMM::ThreadPool& threads);
-OpenMM::CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(OpenMM::ThreadPool& threads);
+using namespace OpenMM;
 
-OpenMM::CpuCustomNonbondedForce* OpenMM::createCpuCustomNonbondedForce(OpenMM::ThreadPool& threads) {
+CpuCustomNonbondedForce* createCpuCustomNonbondedForceVec4(ThreadPool& threads, const CpuNeighborList& neighbors);
+CpuCustomNonbondedForce* createCpuCustomNonbondedForceAvx(ThreadPool& threads, const CpuNeighborList& neighbors);
+
+CpuCustomNonbondedForce* OpenMM::createCpuCustomNonbondedForce(ThreadPool& threads, const CpuNeighborList& neighbors) {
     if (isAvxSupported())
-        return createCpuCustomNonbondedForceAvx(threads);
+        return createCpuCustomNonbondedForceAvx(threads, neighbors);
     else
-        return createCpuCustomNonbondedForceVec4(threads);
+        return createCpuCustomNonbondedForceVec4(threads, neighbors);
 }

--- a/platforms/cpu/src/CpuCustomNonbondedForceVec4.cpp
+++ b/platforms/cpu/src/CpuCustomNonbondedForceVec4.cpp
@@ -23,6 +23,8 @@
 
 #include "CpuCustomNonbondedForceFvec.h"
 
-OpenMM::CpuCustomNonbondedForce* createCpuCustomNonbondedForceVec4(OpenMM::ThreadPool& threads) {
-    return new OpenMM::CpuCustomNonbondedForceFvec<fvec4, 4>(threads);
+using namespace OpenMM;
+
+CpuCustomNonbondedForce* createCpuCustomNonbondedForceVec4(ThreadPool& threads, const CpuNeighborList& neighbors) {
+    return new CpuCustomNonbondedForceFvec<fvec4, 4>(threads, neighbors);
 }

--- a/platforms/cpu/src/CpuGayBerneForce.cpp
+++ b/platforms/cpu/src/CpuGayBerneForce.cpp
@@ -76,9 +76,15 @@ CpuGayBerneForce::CpuGayBerneForce(const GayBerneForce& force) {
         particleExclusions[e.particle2].insert(e.particle1);
     }
     nonbondedMethod = force.getNonbondedMethod();
-    cutoffDistance = force.getCutoffDistance();
-    switchingDistance = force.getSwitchingDistance();
-    useSwitchingFunction = force.getUseSwitchingFunction();
+    if (nonbondedMethod == GayBerneForce::NoCutoff) {
+        cutoffDistance = 0.0;
+        useSwitchingFunction = false;
+    }
+    else {
+        cutoffDistance = force.getCutoffDistance();
+        switchingDistance = force.getSwitchingDistance();
+        useSwitchingFunction = force.getUseSwitchingFunction();
+    }
 
     // Allocate workspace for calculations.
 
@@ -157,7 +163,7 @@ void CpuGayBerneForce::threadComputeForce(ThreadPool& threads, int threadIndex, 
 
     // Compute this thread's subset of interactions.
     
-    if (neighborList == NULL) {
+    if (cutoffDistance == 0.0) {
         while (true) {
             int i = atomicCounter++;
             if (i >= numParticles)

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -970,7 +970,7 @@ void CpuCalcCustomNonbondedForceKernel::createInteraction(const CustomNonbondedF
 
     // Create the object that computes the interaction.
 
-    nonbonded = createCpuCustomNonbondedForce(data.threads);
+    nonbonded = createCpuCustomNonbondedForce(data.threads, *data.neighborList);
     nonbonded->initialize(energyExpression, forceExpression, parameterNames, exclusions, energyParamDerivExpressions,
             computedValueNames, computedValueExpressions);
     if (interactionGroups.size() > 0)
@@ -984,7 +984,7 @@ double CpuCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool inc
     double energy = 0;
     bool periodic = (nonbondedMethod == CutoffPeriodic);
     if (nonbondedMethod != NoCutoff)
-        nonbonded->setUseCutoff(nonbondedCutoff, *data.neighborList);
+        nonbonded->setUseCutoff(nonbondedCutoff);
     if (periodic) {
         double minAllowedSize = 2*nonbondedCutoff;
         if (boxVectors[0][0] < minAllowedSize || boxVectors[1][1] < minAllowedSize || boxVectors[2][2] < minAllowedSize)

--- a/platforms/cpu/src/CpuNeighborList.cpp
+++ b/platforms/cpu/src/CpuNeighborList.cpp
@@ -576,6 +576,10 @@ const std::vector<CpuNeighborList::BlockExclusionMask>& CpuNeighborList::getBloc
     
 }
 
+CpuNeighborList::NeighborIterator CpuNeighborList::getNeighborIterator(int blockIndex) const {
+    return NeighborIterator(blockNeighbors[blockIndex], blockExclusions[blockIndex]);
+}
+
 void CpuNeighborList::threadComputeNeighborList(ThreadPool& threads, int threadIndex) {
     // Compute the positions of atoms along the Hilbert curve.
 
@@ -655,6 +659,27 @@ void CpuNeighborList::threadComputeNeighborList(ThreadPool& threads, int threadI
                 blockExclusions[i][k] |= thisAtomFlags->second;
         }
     }
+}
+
+CpuNeighborList::NeighborIterator::NeighborIterator(const vector<int>& neighbors, const vector<BlockExclusionMask>& exclusions) :
+        neighbors(&neighbors), exclusions(&exclusions), currentIndex(-1) {
+}
+
+bool CpuNeighborList::NeighborIterator::next() {
+    if (++currentIndex < neighbors->size()) {
+        currentAtom = (*neighbors)[currentIndex];
+        currentExclusions = (*exclusions)[currentIndex];
+        return true;
+    }
+    return false;
+}
+
+int CpuNeighborList::NeighborIterator::getNeighbor() const {
+    return currentAtom;
+}
+
+CpuNeighborList::BlockExclusionMask CpuNeighborList::NeighborIterator::getExclusions() const {
+    return currentExclusions;
 }
 
 } // namespace OpenMM

--- a/platforms/cpu/src/CpuNonbondedForce.cpp
+++ b/platforms/cpu/src/CpuNonbondedForce.cpp
@@ -47,8 +47,9 @@ const int CpuNonbondedForce::NUM_TABLE_POINTS = 2048;
 
    --------------------------------------------------------------------------------------- */
 
-CpuNonbondedForce::CpuNonbondedForce() : cutoff(false), useSwitch(false), periodic(false), periodicExceptions(false), ewald(false), pme(false), ljpme(false), tableIsValid(false), expTableIsValid(false),
-    cutoffDistance(0.0f), alphaDispersionEwald(0.0f), alphaEwald(0.0f) {
+CpuNonbondedForce::CpuNonbondedForce(const CpuNeighborList& neighbors) : neighborList(&neighbors), cutoff(false), useSwitch(false), periodic(false),
+        periodicExceptions(false), ewald(false), pme(false), ljpme(false), tableIsValid(false), expTableIsValid(false), cutoffDistance(0.0f),
+        alphaDispersionEwald(0.0f), alphaEwald(0.0f) {
 }
 
 CpuNonbondedForce::~CpuNonbondedForce() {
@@ -59,18 +60,16 @@ CpuNonbondedForce::~CpuNonbondedForce() {
    Set the force to use a cutoff.
 
    @param distance            the cutoff distance
-   @param neighbors           the neighbor list to use
    @param solventDielectric   the dielectric constant of the bulk solvent
 
      --------------------------------------------------------------------------------------- */
 
-void CpuNonbondedForce::setUseCutoff(float distance, const CpuNeighborList& neighbors, float solventDielectric) {
+void CpuNonbondedForce::setUseCutoff(float distance, float solventDielectric) {
     if (distance != cutoffDistance)
         tableIsValid = false;
     cutoff = true;
     cutoffDistance = distance;
     inverseRcut6 = pow(cutoffDistance, -6);
-    neighborList = &neighbors;
     krf = pow(cutoffDistance, -3.0f)*(solventDielectric-1.0)/(2.0*solventDielectric+1.0);
     crf = (1.0/cutoffDistance)*(3.0*solventDielectric)/(2.0*solventDielectric+1.0);
     if(alphaDispersionEwald != 0.0f){
@@ -486,7 +485,7 @@ void CpuNonbondedForce::threadComputeDirect(ThreadPool& threads, int threadIndex
             }
         }
     }
-    else if (cutoff) {
+    else {
         // Compute the interactions from the neighbor list.
 
         while (true) {
@@ -496,72 +495,6 @@ void CpuNonbondedForce::threadComputeDirect(ThreadPool& threads, int threadIndex
             calculateBlockIxn(nextBlock, forces, energyPtr, boxSize, invBoxSize);
         }
     }
-    else {
-        // Loop over all atom pairs
-
-        while (true) {
-            int i = atomicCounter++;
-            if (i >= numberOfAtoms)
-                break;
-            for (int j = i+1; j < numberOfAtoms; j++)
-                if (exclusions[j].find(i) == exclusions[j].end())
-                    calculateOneIxn(i, j, forces, energyPtr, boxSize, invBoxSize);
-        }
-    }
-}
-
-void CpuNonbondedForce::calculateOneIxn(int ii, int jj, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize) {
-    // get deltaR, R2, and R between 2 atoms
-
-    fvec4 deltaR;
-    fvec4 posI(posq+4*ii);
-    fvec4 posJ(posq+4*jj);
-    float r2;
-    getDeltaR(posJ, posI, deltaR, r2, periodic, boxSize, invBoxSize);
-    if (cutoff && r2 >= cutoffDistance*cutoffDistance)
-        return;
-    float r = sqrtf(r2);
-    float inverseR = 1/r;
-    float switchValue = 1, switchDeriv = 0;
-    if (useSwitch && r > switchingDistance) {
-        float t = (r-switchingDistance)/(cutoffDistance-switchingDistance);
-        switchValue = 1+t*t*t*(-10+t*(15-t*6));
-        switchDeriv = t*t*(-30+t*(60-t*30))/(cutoffDistance-switchingDistance);
-    }
-    float sig       = atomParameters[ii].first + atomParameters[jj].first;
-    float sig2      = inverseR*sig;
-    sig2     *= sig2;
-    float sig6      = sig2*sig2*sig2;
-
-    float eps       = atomParameters[ii].second*atomParameters[jj].second;
-    float dEdR      = switchValue*eps*(12.0f*sig6 - 6.0f)*sig6;
-    float chargeProd = ONE_4PI_EPS0*posq[4*ii+3]*posq[4*jj+3];
-    if (cutoff)
-        dEdR += (float) (chargeProd*(inverseR-2.0f*krf*r2));
-    else
-        dEdR += (float) (chargeProd*inverseR);
-    dEdR *= inverseR*inverseR;
-    float energy = eps*(sig6-1.0f)*sig6;
-    if (useSwitch) {
-        dEdR -= energy*switchDeriv*inverseR;
-        energy *= switchValue;
-    }
-
-    // accumulate energies
-
-    if (totalEnergy) {
-        if (cutoff)
-            energy += (float) (chargeProd*(inverseR+krf*r2-crf));
-        else
-            energy += (float) (chargeProd*inverseR);
-        *totalEnergy += energy;
-    }
-
-    // accumulate forces
-
-    fvec4 result = deltaR*dEdR;
-    (fvec4(forces+4*ii)+result).store(forces+4*ii);
-    (fvec4(forces+4*jj)-result).store(forces+4*jj);
 }
 
 void CpuNonbondedForce::getDeltaR(const fvec4& posI, const fvec4& posJ, fvec4& deltaR, float& r2, bool periodic, const fvec4& boxSize, const fvec4& invBoxSize) const {

--- a/platforms/cpu/src/CpuNonbondedForceAvx.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceAvx.cpp
@@ -23,17 +23,18 @@
  */
 
 #include "CpuNonbondedForceFvec.h"
+#include "CpuNeighborList.h"
 #include "openmm/OpenMMException.h"
 
 #ifdef __AVX__
 #include "openmm/internal/vectorizeAvx.h"
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx() {
-    return new OpenMM::CpuNonbondedForceFvec<fvec8>();
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx(const OpenMM::CpuNeighborList& neighbors) {
+    return new OpenMM::CpuNonbondedForceFvec<fvec8>(neighbors);
 }
 
 #else
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx() {
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx(const OpenMM::CpuNeighborList& neighbors) {
    throw OpenMM::OpenMMException("Internal error: OpenMM was compiled without AVX support");
 }
 #endif

--- a/platforms/cpu/src/CpuNonbondedForceAvx2.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceAvx2.cpp
@@ -23,13 +23,14 @@
  */
 
 #include "CpuNonbondedForceFvec.h"
+#include "CpuNeighborList.h"
 #include "openmm/OpenMMException.h"
 
 #ifdef __AVX2__
 
 #include "openmm/internal/vectorizeAvx2.h"
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2() {
-    return new OpenMM::CpuNonbondedForceFvec<fvecAvx2>();
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2(const OpenMM::CpuNeighborList& neighbors) {
+    return new OpenMM::CpuNonbondedForceFvec<fvecAvx2>(neighbors);
 }
 
 #else
@@ -38,7 +39,7 @@ bool isAvx2Supported() {
     return false;
 }
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2() {
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2(const OpenMM::CpuNeighborList& neighbors) {
    throw OpenMM::OpenMMException("Internal error: OpenMM was compiled without AVX2 support");
 }
 #endif

--- a/platforms/cpu/src/CpuNonbondedForceFvec.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceFvec.cpp
@@ -26,15 +26,17 @@
 #include "CpuNeighborList.h"
 #include "openmm/internal/hardware.h"
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec4(const OpenMM::CpuNeighborList& neighbors);
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx(const OpenMM::CpuNeighborList& neighbors);
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2(const OpenMM::CpuNeighborList& neighbors);
+using namespace OpenMM;
+
+CpuNonbondedForce* createCpuNonbondedForceVec4(const CpuNeighborList& neighbors);
+CpuNonbondedForce* createCpuNonbondedForceAvx(const CpuNeighborList& neighbors);
+CpuNonbondedForce* createCpuNonbondedForceAvx2(const CpuNeighborList& neighbors);
 
 bool isAvx2Supported();
 
 #include <iostream>
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec(const OpenMM::CpuNeighborList& neighbors) {
+CpuNonbondedForce* createCpuNonbondedForceVec(const CpuNeighborList& neighbors) {
     if (isAvx2Supported())
         return createCpuNonbondedForceAvx2(neighbors);
     else if (isAvxSupported())

--- a/platforms/cpu/src/CpuNonbondedForceFvec.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceFvec.cpp
@@ -23,21 +23,22 @@
  */
 
 #include "CpuNonbondedForceFvec.h"
+#include "CpuNeighborList.h"
 #include "openmm/internal/hardware.h"
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec4();
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx();
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2();
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec4(const OpenMM::CpuNeighborList& neighbors);
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx(const OpenMM::CpuNeighborList& neighbors);
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceAvx2(const OpenMM::CpuNeighborList& neighbors);
 
 bool isAvx2Supported();
 
 #include <iostream>
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec() {
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec(const OpenMM::CpuNeighborList& neighbors) {
     if (isAvx2Supported())
-        return createCpuNonbondedForceAvx2();
+        return createCpuNonbondedForceAvx2(neighbors);
     else if (isAvxSupported())
-        return createCpuNonbondedForceAvx();
+        return createCpuNonbondedForceAvx(neighbors);
     else
-        return createCpuNonbondedForceVec4();
+        return createCpuNonbondedForceVec4(neighbors);
 }

--- a/platforms/cpu/src/CpuNonbondedForceVec4.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceVec4.cpp
@@ -23,10 +23,11 @@
  */
 
 #include "CpuNonbondedForceFvec.h"
+#include "CpuNeighborList.h"
 
 // Very minimal file. It exists purely to be able to compile it in SIMD-4.
 
-OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec4()   {
-    return new OpenMM::CpuNonbondedForceFvec<fvec4>();
+OpenMM::CpuNonbondedForce* createCpuNonbondedForceVec4(const OpenMM::CpuNeighborList& neighbors) {
+    return new OpenMM::CpuNonbondedForceFvec<fvec4>(neighbors);
 }
 

--- a/platforms/cpu/src/CpuPlatform.cpp
+++ b/platforms/cpu/src/CpuPlatform.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -148,7 +148,8 @@ const CpuPlatform::PlatformData& CpuPlatform::getPlatformData(const ContextImpl&
 }
 
 CpuPlatform::PlatformData::PlatformData(int numParticles, int numThreads, bool deterministicForces) : posq(4*numParticles), threads(numThreads),
-        deterministicForces(deterministicForces), neighborList(NULL), cutoff(0.0), paddedCutoff(0.0), anyExclusions(false), currentPosqIndex(-1), nextPosqIndex(0) {
+        deterministicForces(deterministicForces), numParticles(numParticles), neighborList(NULL), cutoff(0.0), paddedCutoff(0.0), anyExclusions(false),
+        currentPosqIndex(-1), nextPosqIndex(0) {
     numThreads = threads.getNumThreads();
     threadForce.resize(numThreads);
     for (int i = 0; i < numThreads; i++)
@@ -166,8 +167,13 @@ CpuPlatform::PlatformData::~PlatformData() {
 }
 
 void CpuPlatform::PlatformData::requestNeighborList(double cutoffDistance, double padding, bool useExclusions, const vector<set<int> >& exclusionList) {
-    if (neighborList == NULL)
+    if (neighborList == NULL) {
         neighborList = new CpuNeighborList(getVectorWidth());
+        if (cutoffDistance == 0.0)
+            neighborList->createDenseNeighborList(numParticles, exclusionList);
+    }
+    else if ((cutoffDistance == 0.0) != (cutoff == 0.0))
+        throw OpenMMException("All nonbonded Forces must agree on whether to apply a cutoff");
     if (cutoffDistance > cutoff)
         cutoff = cutoffDistance;
     if (cutoffDistance+padding > paddedCutoff)

--- a/platforms/reference/src/ReferenceTabulatedFunction.cpp
+++ b/platforms/reference/src/ReferenceTabulatedFunction.cpp
@@ -252,8 +252,7 @@ int ReferenceDiscrete1DFunction::getNumArguments() const {
 
 double ReferenceDiscrete1DFunction::evaluate(const double* arguments) const {
     int i = (int) round(arguments[0]);
-    if (i < 0 || i >= values.size())
-        throw OpenMMException("ReferenceDiscrete1DFunction: argument out of range");
+    i = max(0, min((int) values.size()-1, i));
     return values[i];
 }
 
@@ -276,8 +275,8 @@ int ReferenceDiscrete2DFunction::getNumArguments() const {
 double ReferenceDiscrete2DFunction::evaluate(const double* arguments) const {
     int i = (int) round(arguments[0]);
     int j = (int) round(arguments[1]);
-    if (i < 0 || i >= xsize || j < 0 || j >= ysize)
-        throw OpenMMException("ReferenceDiscrete2DFunction: argument out of range");
+    i = max(0, min(xsize-1, i));
+    j = max(0, min(ysize-1, j));
     return values[i+j*xsize];
 }
 
@@ -301,8 +300,9 @@ double ReferenceDiscrete3DFunction::evaluate(const double* arguments) const {
     int i = (int) round(arguments[0]);
     int j = (int) round(arguments[1]);
     int k = (int) round(arguments[2]);
-    if (i < 0 || i >= xsize || j < 0 || j >= ysize || k < 0 || k >= zsize)
-        throw OpenMMException("ReferenceDiscrete3DFunction: argument out of range");
+    i = max(0, min(xsize-1, i));
+    j = max(0, min(ysize-1, j));
+    k = max(0, min(zsize-1, k));
     return values[i+(j+k*ysize)*xsize];
 }
 


### PR DESCRIPTION
Previously, NonbondedForce and CustomNonbondedForce were only vectorized on the CPU platform when using a cutoff.  When not using a cutoff, interactions were computed one at a time.  This PR vectorizes them, which leads to very large speedups (about 2-7x depending on the case).