### PR TITLE
Draft: Changed some counters from int32 to int64 in CUDA and OpenCL

### DIFF
--- a/openmmapi/src/CustomIntegratorUtilities.cpp
+++ b/openmmapi/src/CustomIntegratorUtilities.cpp
@@ -45,7 +45,7 @@ using namespace std;
 void CustomIntegratorUtilities::parseCondition(const string& expression, string& lhs, string& rhs, Comparison& comparison) {
     string operators[] = {"=", "<", ">", "!=", "<=", ">="};
     for (int i = 5; i >= 0; i--) {
-        int index = expression.find(operators[i]);
+        size_t index = expression.find(operators[i]);
         if (index != string::npos) {
             lhs = expression.substr(0, index);
             rhs = expression.substr(index+operators[i].size());

--- a/platforms/common/include/openmm/common/ArrayInterface.h
+++ b/platforms/common/include/openmm/common/ArrayInterface.h
@@ -150,7 +150,7 @@ public:
      *                 have restrictions on non-blocking copies, such as that the source data must be
      *                 in page-locked memory.
      */
-    virtual void uploadSubArray(const void* data, int offset, int elements, bool blocking=true) = 0;
+    virtual void uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking=true) = 0;
     /**
      * Copy the values in the array to host memory.
      * 

--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -679,7 +679,7 @@ private:
     class ForceInfo;
     double prefactor, surfaceAreaFactor, cutoff;
     bool hasCreatedKernels;
-    int maxTiles;
+    long long maxTiles;
     ComputeContext& cc;
     ForceInfo* info;
     ComputeArray params, charges, bornSum, bornRadii, bornForce, obcChain;
@@ -722,7 +722,8 @@ private:
     class ForceInfo;
     double cutoff;
     bool hasInitializedKernels, needParameterGradient, needEnergyParamDerivs;
-    int maxTiles, numComputedValues;
+    long long maxTiles;
+    int numComputedValues;
     ComputeContext& cc;
     ForceInfo* info;
     ComputeParameterSet* params;

--- a/platforms/common/include/openmm/common/ComputeArray.h
+++ b/platforms/common/include/openmm/common/ComputeArray.h
@@ -131,7 +131,7 @@ public:
      *                 have restrictions on non-blocking copies, such as that the source data must be
      *                 in page-locked memory.
      */
-    void uploadSubArray(const void* data, int offset, int elements, bool blocking=true);
+    void uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking=true);
     /**
      * Copy the values in the array to host memory.
      * 

--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -403,7 +403,7 @@ public:
     /**
      * Convert a number to a string in a format suitable for including in a kernel.
      */
-    std::string intToString(int value) const;
+    std::string intToString(long long value) const;
     /**
      * Get whether the periodic box is triclinic.
      */

--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -489,6 +489,11 @@ public:
      * expense of reduced simulation performance.
      */
     virtual void flushQueue() = 0;
+    /**
+     * Wait until all work has been completed.
+     * This is useful for debugging.
+     */
+    virtual void synchronize() = 0;
 protected:
     struct Molecule;
     struct MoleculeGroup;

--- a/platforms/common/include/openmm/common/NonbondedUtilities.h
+++ b/platforms/common/include/openmm/common/NonbondedUtilities.h
@@ -161,11 +161,11 @@ public:
     /**
      * Get the index of the first tile this context is responsible for processing.
      */
-    virtual int getStartTileIndex() const = 0;
+    virtual long long getStartTileIndex() const = 0;
     /**
      * Get the total number of tiles this context is responsible for processing.
      */
-    virtual int getNumTiles() const = 0;
+    virtual long long getNumTiles() const = 0;
     /**
      * Set whether to add padding to the cutoff distance when building the neighbor list.
      * This increases the size of the neighbor list (and thus the cost of computing interactions),

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -2554,7 +2554,7 @@ double CommonCalcGBSAOBCForceKernel::execute(ContextImpl& context, bool includeF
 
         hasCreatedKernels = true;
         maxTiles = (nb.getUseCutoff() ? nb.getInteractingTiles().getSize() : 0);
-        int numAtomBlocks = cc.getPaddedNumAtoms()/32;
+        long long numAtomBlocks = cc.getPaddedNumAtoms()/32;
         map<string, string> defines;
         if (nb.getUseCutoff())
             defines["USE_CUTOFF"] = "1";
@@ -3567,11 +3567,11 @@ double CommonCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
         // has not yet been initialized then.
 
         {
-            int numExclusionTiles = nb.getExclusionTiles().getSize();
+            long long numExclusionTiles = nb.getExclusionTiles().getSize();
             pairValueDefines["NUM_TILES_WITH_EXCLUSIONS"] = cc.intToString(numExclusionTiles);
             int numContexts = cc.getNumContexts();
-            int startExclusionIndex = cc.getContextIndex()*numExclusionTiles/numContexts;
-            int endExclusionIndex = (cc.getContextIndex()+1)*numExclusionTiles/numContexts;
+            long long startExclusionIndex = cc.getContextIndex()*numExclusionTiles/numContexts;
+            long long endExclusionIndex = (cc.getContextIndex()+1)*numExclusionTiles/numContexts;
             pairValueDefines["FIRST_EXCLUSION_TILE"] = cc.intToString(startExclusionIndex);
             pairValueDefines["LAST_EXCLUSION_TILE"] = cc.intToString(endExclusionIndex);
             pairValueDefines["CUTOFF"] = cc.doubleToString(cutoff);
@@ -3581,11 +3581,11 @@ double CommonCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
             pairValueDefines.clear();
         }
         {
-            int numExclusionTiles = nb.getExclusionTiles().getSize();
+            long long numExclusionTiles = nb.getExclusionTiles().getSize();
             pairEnergyDefines["NUM_TILES_WITH_EXCLUSIONS"] = cc.intToString(numExclusionTiles);
             int numContexts = cc.getNumContexts();
-            int startExclusionIndex = cc.getContextIndex()*numExclusionTiles/numContexts;
-            int endExclusionIndex = (cc.getContextIndex()+1)*numExclusionTiles/numContexts;
+            long long startExclusionIndex = cc.getContextIndex()*numExclusionTiles/numContexts;
+            long long endExclusionIndex = (cc.getContextIndex()+1)*numExclusionTiles/numContexts;
             pairEnergyDefines["FIRST_EXCLUSION_TILE"] = cc.intToString(startExclusionIndex);
             pairEnergyDefines["LAST_EXCLUSION_TILE"] = cc.intToString(endExclusionIndex);
             pairEnergyDefines["CUTOFF"] = cc.doubleToString(cutoff);

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -2596,7 +2596,7 @@ double CommonCalcGBSAOBCForceKernel::execute(ContextImpl& context, bool includeF
             computeBornSumKernel->addArg(nb.getInteractingAtoms());
         }
         else
-            computeBornSumKernel->addArg(numAtomBlocks*(numAtomBlocks+1)/2);
+            computeBornSumKernel->addArg(numAtomBlocks*((long long)numAtomBlocks+1)/2);
         computeBornSumKernel->addArg(nb.getExclusionTiles());
         force1Kernel = program->createKernel("computeGBSAForce1");
         force1Kernel->addArg(useLong ? cc.getLongForceBuffer() : cc.getForceBuffers());
@@ -2617,7 +2617,7 @@ double CommonCalcGBSAOBCForceKernel::execute(ContextImpl& context, bool includeF
             force1Kernel->addArg(nb.getInteractingAtoms());
         }
         else
-            force1Kernel->addArg(numAtomBlocks*(numAtomBlocks+1)/2);
+            force1Kernel->addArg(numAtomBlocks*((long long)numAtomBlocks+1)/2);
         force1Kernel->addArg(nb.getExclusionTiles());
         program = cc.compileProgram(CommonKernelSources::gbsaObcReductions, defines);
         reduceBornSumKernel = program->createKernel("reduceBornSum");
@@ -3615,7 +3615,7 @@ double CommonCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
             pairValueKernel->addArg(nb.getInteractingAtoms());
         }
         else
-            pairValueKernel->addArg(numAtomBlocks*(numAtomBlocks+1)/2);
+            pairValueKernel->addArg(numAtomBlocks*((long long)numAtomBlocks+1)/2);
         if (globals.isInitialized())
             pairValueKernel->addArg(globals);
         for (int i = 0; i < (int) params->getParameterInfos().size(); i++) {
@@ -3664,7 +3664,7 @@ double CommonCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
             pairEnergyKernel->addArg(nb.getInteractingAtoms());
         }
         else
-            pairEnergyKernel->addArg(numAtomBlocks*(numAtomBlocks+1)/2);
+            pairEnergyKernel->addArg(numAtomBlocks*((long long)numAtomBlocks+1)/2);
         if (globals.isInitialized())
             pairEnergyKernel->addArg(globals);
         for (int i = 0; i < (int) params->getParameterInfos().size(); i++) {

--- a/platforms/common/src/ComputeArray.cpp
+++ b/platforms/common/src/ComputeArray.cpp
@@ -84,7 +84,7 @@ ComputeContext& ComputeArray::getContext() {
     return impl->getContext();
 }
 
-void ComputeArray::uploadSubArray(const void* data, int offset, int elements, bool blocking) {
+void ComputeArray::uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking) {
     if (impl == NULL)
         throw OpenMMException("ComputeArray has not been initialized");
     impl->uploadSubArray(data, offset, elements, blocking);

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -70,7 +70,7 @@ string ComputeContext::replaceStrings(const string& input, const std::map<std::s
     }
     string result = input;
     for (auto& pair : replacements) {
-        int index = 0;
+        size_t index = 0;
         int size = pair.first.size();
         do {
             index = result.find(pair.first, index);

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -98,7 +98,7 @@ string ComputeContext::doubleToString(double value) const {
     return s.str();
 }
 
-string ComputeContext::intToString(int value) const {
+string ComputeContext::intToString(long long value) const {
     stringstream s;
     s << value;
     return s.str();

--- a/platforms/common/src/kernels/customGBEnergyN2.cc
+++ b/platforms/common/src/kernels/customGBEnergyN2.cc
@@ -38,8 +38,8 @@ KERNEL void computeN2Energy(
 
     // First loop: process tiles that contain exclusions.
     
-    mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+(mm_long)warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+((mm_long)warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;

--- a/platforms/common/src/kernels/customGBEnergyN2.cc
+++ b/platforms/common/src/kernels/customGBEnergyN2.cc
@@ -19,11 +19,11 @@ KERNEL void computeN2Energy(
         GLOBAL const real4* RESTRICT posq, GLOBAL const unsigned int* RESTRICT exclusions,
         GLOBAL const int2* exclusionTiles, int needEnergy,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const int* RESTRICT interactingAtoms
 #else
-        unsigned int numTiles
+        mm_long numTiles
 #endif
         PARAMETER_ARGUMENTS) {
     const unsigned int totalWarps = GLOBAL_SIZE/TILE_SIZE;
@@ -38,9 +38,9 @@ KERNEL void computeN2Energy(
 
     // First loop: process tiles that contain exclusions.
     
-    const int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -191,14 +191,14 @@ KERNEL void computeN2Energy(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    unsigned int numTiles = interactionCount[0];
+    mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (warp*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : (mm_long)numTiles)/totalWarps);
-    int end = (int) ((warp+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : (mm_long)numTiles)/totalWarps);
+    mm_long pos = (warp*((mm_long)numTiles)/totalWarps);
+    mm_long end = ((warp+1)*((mm_long)numTiles)/totalWarps);
 #else
-    int pos = (int) (warp*(mm_long)numTiles/totalWarps);
-    int end = (int) ((warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long pos = (warp*(mm_long)numTiles/totalWarps);
+    mm_long end = ((warp+1)*(mm_long)numTiles/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -224,10 +224,10 @@ KERNEL void computeN2Energy(
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -237,7 +237,7 @@ KERNEL void computeN2Energy(
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/platforms/common/src/kernels/customGBEnergyN2.cc
+++ b/platforms/common/src/kernels/customGBEnergyN2.cc
@@ -223,7 +223,7 @@ KERNEL void computeN2Energy(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/common/src/kernels/customGBEnergyN2_cpu.cc
+++ b/platforms/common/src/kernels/customGBEnergyN2_cpu.cc
@@ -19,11 +19,11 @@ KERNEL void computeN2Energy(
         GLOBAL const real4* RESTRICT posq, GLOBAL const unsigned int* RESTRICT exclusions,
         GLOBAL const int2* exclusionTiles, int needEnergy,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const int* RESTRICT interactingAtoms
 #else
-        unsigned int numTiles
+        mm_long numTiles
 #endif
         PARAMETER_ARGUMENTS) {
     mixed energy = 0;
@@ -34,9 +34,9 @@ KERNEL void computeN2Energy(
 
     // First loop: process tiles that contain exclusions.
     
-    const int firstExclusionTile = FIRST_EXCLUSION_TILE+GROUP_ID*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
-    const int lastExclusionTile = FIRST_EXCLUSION_TILE+(GROUP_ID+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+GROUP_ID*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(GROUP_ID+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -209,14 +209,14 @@ KERNEL void computeN2Energy(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    const unsigned int numTiles = interactionCount[0];
+    const mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (GROUP_ID*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
-    int end = (int) ((GROUP_ID+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
+    mm_long pos = (GROUP_ID*numTiles/NUM_GROUPS);
+    mm_long end = ((GROUP_ID+1)*numTiles/NUM_GROUPS);
 #else
-    int pos = (int) (GROUP_ID*(mm_long)numTiles/NUM_GROUPS);
-    int end = (int) ((GROUP_ID+1)*(mm_long)numTiles/NUM_GROUPS);
+    mm_long pos = (GROUP_ID*(mm_long)numTiles/NUM_GROUPS);
+    mm_long end = ((GROUP_ID+1)*(mm_long)numTiles/NUM_GROUPS);
 #endif
     int nextToSkip = -1;
     int currentSkipIndex = 0;
@@ -238,10 +238,10 @@ KERNEL void computeN2Energy(
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -249,7 +249,7 @@ KERNEL void computeN2Energy(
         while (nextToSkip < pos) {
             if (currentSkipIndex < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[currentSkipIndex++];
-                nextToSkip = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                nextToSkip = tile.x + (long long)tile.y*NUM_BLOCKS - tile.y*((long long)tile.y+1)/2;
             }
             else
                 nextToSkip = end;

--- a/platforms/common/src/kernels/customGBEnergyN2_cpu.cc
+++ b/platforms/common/src/kernels/customGBEnergyN2_cpu.cc
@@ -237,7 +237,7 @@ KERNEL void computeN2Energy(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/common/src/kernels/customGBValueN2.cc
+++ b/platforms/common/src/kernels/customGBValueN2.cc
@@ -9,11 +9,11 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
         GLOBAL real* RESTRICT global_value,
 #endif
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const int* RESTRICT interactingAtoms
 #else
-        unsigned int numTiles
+        mm_long numTiles
 #endif
         PARAMETER_ARGUMENTS) {
     const unsigned int totalWarps = GLOBAL_SIZE/TILE_SIZE;
@@ -26,9 +26,9 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
 
     // First loop: process tiles that contain exclusions.
     
-    const int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -162,14 +162,14 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    unsigned int numTiles = interactionCount[0];
+    mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (warp*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : (mm_long)numTiles)/totalWarps);
-    int end = (int) ((warp+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : (mm_long)numTiles)/totalWarps);
+    mm_long pos = (warp*(mm_long)numTiles)/totalWarps;
+    mm_long end = ((warp+1)*(mm_long)numTiles)/totalWarps;
 #else
-    int pos = (int) (warp*(mm_long)numTiles/totalWarps);
-    int end = (int) ((warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long pos = (warp*(mm_long)numTiles/totalWarps);
+    mm_long end = ((warp+1)*(mm_long)numTiles/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -193,10 +193,10 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -206,7 +206,7 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/platforms/common/src/kernels/customGBValueN2.cc
+++ b/platforms/common/src/kernels/customGBValueN2.cc
@@ -192,7 +192,7 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/common/src/kernels/customGBValueN2.cc
+++ b/platforms/common/src/kernels/customGBValueN2.cc
@@ -26,8 +26,8 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
 
     // First loop: process tiles that contain exclusions.
     
-    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+(mm_long)warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+((mm_long)warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;

--- a/platforms/common/src/kernels/customGBValueN2_cpu.cc
+++ b/platforms/common/src/kernels/customGBValueN2_cpu.cc
@@ -202,7 +202,7 @@ KERNEL void computeN2Value(GLOBAL const real4* RESTRICT posq, GLOBAL const unsig
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/common/src/kernels/customNonbondedGroups.cc
+++ b/platforms/common/src/kernels/customNonbondedGroups.cc
@@ -170,7 +170,7 @@ KERNEL void prepareToBuildNeighborList(GLOBAL int* RESTRICT rebuildNeighborList,
  * Filter the list of tiles to include only ones that have interactions within the
  * padded cutoff.
  */
-KERNEL void buildNeighborList(GLOBAL int* RESTRICT rebuildNeighborList, GLOBAL mm_long* RESTRICT numGroupTiles,
+KERNEL void buildNeighborList(GLOBAL int* RESTRICT rebuildNeighborList, GLOBAL mm_ulong* RESTRICT numGroupTiles,
         GLOBAL const real4* RESTRICT posq, GLOBAL const int4* RESTRICT groupData, GLOBAL int4* RESTRICT filteredGroupData,
         real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ) {
     
@@ -224,7 +224,7 @@ KERNEL void buildNeighborList(GLOBAL int* RESTRICT rebuildNeighborList, GLOBAL m
         if (anyInteraction[local_warp]) {
             SYNC_WARPS;
             if (tgx == 0)
-                tileIndex[local_warp] = ATOMIC_ADD(numGroupTiles, 1);
+                tileIndex[local_warp] = ATOMIC_ADD(numGroupTiles, (mm_ulong)1);
             SYNC_WARPS;
             filteredGroupData[TILE_SIZE*tileIndex[local_warp]+tgx] = atomData;
         }

--- a/platforms/common/src/kernels/gbsaObc.cc
+++ b/platforms/common/src/kernels/gbsaObc.cc
@@ -196,7 +196,7 @@ KERNEL void computeBornSum(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
@@ -591,7 +591,7 @@ KERNEL void computeGBSAForce1(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/common/src/kernels/gbsaObc_cpu.cc
+++ b/platforms/common/src/kernels/gbsaObc_cpu.cc
@@ -202,7 +202,7 @@ KERNEL void computeBornSum(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
@@ -626,7 +626,7 @@ KERNEL void computeGBSAForce1(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*(((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/common/src/kernels/gbsaObc_cpu.cc
+++ b/platforms/common/src/kernels/gbsaObc_cpu.cc
@@ -16,20 +16,20 @@ KERNEL void computeBornSum(
 #endif
         GLOBAL const real4* RESTRICT posq, GLOBAL const real* RESTRICT charge, GLOBAL const float2* RESTRICT global_params,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const int* RESTRICT interactingAtoms,
 #else
-        unsigned int numTiles,
+        mm_long numTiles,
 #endif
         GLOBAL const int2* exclusionTiles) {
     LOCAL AtomData1 localData[TILE_SIZE];
 
     // First loop: process tiles that contain exclusions.
     
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+GROUP_ID*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(GROUP_ID+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+GROUP_ID*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(GROUP_ID+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -175,14 +175,14 @@ KERNEL void computeBornSum(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    unsigned int numTiles = interactionCount[0];
+    mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (GROUP_ID*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
-    int end = (int) ((GROUP_ID+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
+    mm_long pos = (GROUP_ID*numTiles/NUM_GROUPS);
+    mm_long end = ((GROUP_ID+1)*numTiles/NUM_GROUPS);
 #else
-    int pos = (int) (GROUP_ID*(mm_long)numTiles/NUM_GROUPS);
-    int end = (int) ((GROUP_ID+1)*(mm_long)numTiles/NUM_GROUPS);
+    mm_long pos = (GROUP_ID*(mm_long)numTiles/NUM_GROUPS);
+    mm_long end = ((GROUP_ID+1)*(mm_long)numTiles/NUM_GROUPS);
 #endif
     int nextToSkip = -1;
     int currentSkipIndex = 0;
@@ -203,10 +203,10 @@ KERNEL void computeBornSum(
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -214,7 +214,7 @@ KERNEL void computeBornSum(
         while (nextToSkip < pos) {
             if (currentSkipIndex < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[currentSkipIndex++];
-                nextToSkip = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                nextToSkip = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 nextToSkip = end;
@@ -410,11 +410,11 @@ KERNEL void computeGBSAForce1(
         GLOBAL mixed* RESTRICT energyBuffer, GLOBAL const real4* RESTRICT posq, GLOBAL const real* RESTRICT charge,
         GLOBAL const real* RESTRICT global_bornRadii, int needEnergy,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const int* RESTRICT interactingAtoms,
 #else
-        unsigned int numTiles,
+        mm_long numTiles,
 #endif
         GLOBAL const int2* exclusionTiles) {
     mixed energy = 0;
@@ -422,9 +422,9 @@ KERNEL void computeGBSAForce1(
 
     // First loop: process tiles that contain exclusions.
     
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+GROUP_ID*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(GROUP_ID+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+GROUP_ID*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(GROUP_ID+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/NUM_GROUPS;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -599,14 +599,14 @@ KERNEL void computeGBSAForce1(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    unsigned int numTiles = interactionCount[0];
+    mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (GROUP_ID*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
-    int end = (int) ((GROUP_ID+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
+    mm_long pos = (GROUP_ID*numTiles/NUM_GROUPS);
+    mm_long end = ((GROUP_ID+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : numTiles)/NUM_GROUPS);
 #else
-    int pos = (int) (GROUP_ID*(mm_long)numTiles/NUM_GROUPS);
-    int end = (int) ((GROUP_ID+1)*(mm_long)numTiles/NUM_GROUPS);
+    mm_long pos = (GROUP_ID*(mm_long)numTiles/NUM_GROUPS);
+    mm_long end = ((GROUP_ID+1)*(mm_long)numTiles/NUM_GROUPS);
 #endif
     int nextToSkip = -1;
     int currentSkipIndex = 0;
@@ -627,10 +627,10 @@ KERNEL void computeGBSAForce1(
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*(((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -638,7 +638,7 @@ KERNEL void computeGBSAForce1(
         while (nextToSkip < pos) {
             if (currentSkipIndex < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[currentSkipIndex++];
-                nextToSkip = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                nextToSkip = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 nextToSkip = end;

--- a/platforms/common/src/kernels/pme.cc
+++ b/platforms/common/src/kernels/pme.cc
@@ -285,8 +285,8 @@ KERNEL void gridSpreadCharge(GLOBAL const real4* RESTRICT posq, GLOBAL real* RES
  * For each grid point, find the range of sorted atoms associated with that point.
  */
 KERNEL void findAtomRangeForGrid(GLOBAL int2* RESTRICT pmeAtomGridIndex, GLOBAL int* RESTRICT pmeAtomRange, GLOBAL const real4* RESTRICT posq) {
-    int start = (NUM_ATOMS*GLOBAL_ID)/GLOBAL_SIZE;
-    int end = (NUM_ATOMS*(GLOBAL_ID+1))/GLOBAL_SIZE;
+    int start = (NUM_ATOMS*(long long)GLOBAL_ID)/GLOBAL_SIZE;
+    int end = (NUM_ATOMS*(long long)(GLOBAL_ID+1))/GLOBAL_SIZE;
     int last = (start == 0 ? -1 : pmeAtomGridIndex[start-1].y);
     for (int i = start; i < end; ++i) {
         int2 atomData = pmeAtomGridIndex[i];
@@ -312,8 +312,8 @@ KERNEL void findAtomRangeForGrid(GLOBAL int2* RESTRICT pmeAtomGridIndex, GLOBAL 
  * some work in the charge spreading kernel.
  */
 KERNEL void recordZIndex(GLOBAL int2* RESTRICT pmeAtomGridIndex, GLOBAL const real4* RESTRICT posq, real4 periodicBoxSize, real4 recipBoxVecZ) {
-    int start = (NUM_ATOMS*GLOBAL_ID)/GLOBAL_SIZE;
-    int end = (NUM_ATOMS*(GLOBAL_ID+1))/GLOBAL_SIZE;
+    int start = (NUM_ATOMS*(long long)GLOBAL_ID)/GLOBAL_SIZE;
+    int end = (NUM_ATOMS*(long long)(GLOBAL_ID+1))/GLOBAL_SIZE;
     for (int i = start; i < end; ++i) {
         real posz = posq[pmeAtomGridIndex[i].x].z;
         posz -= floor(posz*recipBoxVecZ.z)*periodicBoxSize.z;

--- a/platforms/cpu/src/CpuGBSAOBCForce.cpp
+++ b/platforms/cpu/src/CpuGBSAOBCForce.cpp
@@ -129,8 +129,8 @@ void CpuGBSAOBCForce::threadComputeForce(ThreadPool& threads, int threadIndex) {
     const float gammaObc = 4.85f;
     fvec4 boxSize(periodicBoxSize[0], periodicBoxSize[1], periodicBoxSize[2], 0);
     fvec4 invBoxSize((1/periodicBoxSize[0]), (1/periodicBoxSize[1]), (1/periodicBoxSize[2]), 0);
-    int start = (threadIndex*numParticles)/numThreads;
-    int end = ((threadIndex+1)*numParticles)/numThreads;
+    int start = (threadIndex*(long long)numParticles)/numThreads;
+    int end = ((threadIndex+1)*(long long)numParticles)/numThreads;
 
     // Calculate Born radii
 

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -182,8 +182,8 @@ void CpuCalcForcesAndEnergyKernel::beginComputation(ContextImpl& context, bool i
         bool triclinic = (boxVectors[0][1] != 0 || boxVectors[0][2] != 0 || boxVectors[1][0] != 0 || boxVectors[1][2] != 0 || boxVectors[2][0] != 0 || boxVectors[2][1] != 0);
         int numParticles = context.getSystem().getNumParticles();
         int numThreads = threads.getNumThreads();
-        int start = threadIndex*numParticles/numThreads;
-        int end = (threadIndex+1)*numParticles/numThreads;
+        int start = threadIndex*(long long)numParticles/numThreads;
+        int end = (threadIndex+1)*(long long)numParticles/numThreads;
         if (data.isPeriodic) {
             if (triclinic) {
                 for (int i = start; i < end; i++) {
@@ -286,8 +286,8 @@ double CpuCalcForcesAndEnergyKernel::finishComputation(ContextImpl& context, boo
         
         int numParticles = context.getSystem().getNumParticles();
         int numThreads = threads.getNumThreads();
-        int start = threadIndex*numParticles/numThreads;
-        int end = (threadIndex+1)*numParticles/numThreads;
+        int start = threadIndex*(long long)numParticles/numThreads;
+        int end = (threadIndex+1)*(long long)numParticles/numThreads;
         vector<Vec3>& forceData = extractForces(context);
         for (int i = start; i < end; i++) {
             fvec4 f(0.0f);

--- a/platforms/cuda/include/CudaArray.h
+++ b/platforms/cuda/include/CudaArray.h
@@ -164,7 +164,7 @@ public:
      * @param blocking if true, this call will block until the transfer is complete.  If false,
      *                 the source array  must be in page-locked memory.
      */
-    void uploadSubArray(const void* data, int offset, int elements, bool blocking=true);
+    void uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking=true);
     /**
      * Copy the values in the device memory to an array.
      * 

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -541,6 +541,11 @@ public:
      * expense of reduced simulation performance.
      */
     void flushQueue();
+    /**
+     * Wait until all work has been completed.
+     * This is useful for debugging.
+     */
+    void synchronize();
 private:
     /**
      * Compute a sorted list of device indices in decreasing order of desirability

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -311,7 +311,7 @@ public:
      * @param memory     the memory to clear
      * @param size       the size of the buffer in bytes
      */
-    void clearBuffer(CUdeviceptr memory, int size);
+    void clearBuffer(CUdeviceptr memory, size_t size);
     /**
      * Register a buffer that should be automatically cleared (all elements set to 0) at the start of each force or energy computation.
      */
@@ -322,7 +322,7 @@ public:
      * @param memory     the memory to clear
      * @param size       the size of the buffer in bytes
      */
-    void addAutoclearBuffer(CUdeviceptr memory, int size);
+    void addAutoclearBuffer(CUdeviceptr memory, size_t size);
     /**
      * Clear all buffers that have been registered with addAutoclearBuffer().
      */
@@ -590,7 +590,7 @@ private:
     std::vector<std::string> energyParamDerivNames;
     std::map<std::string, double> energyParamDerivWorkspace;
     std::vector<CUdeviceptr> autoclearBuffers;
-    std::vector<int> autoclearBufferSizes;
+    std::vector<size_t> autoclearBufferSizes;
     CudaIntegrationUtilities* integration;
     CudaExpressionUtilities* expression;
     CudaBondedUtilities* bonded;

--- a/platforms/cuda/include/CudaNonbondedUtilities.h
+++ b/platforms/cuda/include/CudaNonbondedUtilities.h
@@ -268,13 +268,13 @@ public:
     /**
      * Get the index of the first tile this context is responsible for processing.
      */
-    int getStartTileIndex() const {
+    long long getStartTileIndex() const {
         return startTileIndex;
     }
     /**
      * Get the total number of tiles this context is responsible for processing.
      */
-    int getNumTiles() const {
+    long long getNumTiles() const {
         return numTiles;
     }
     /**
@@ -338,7 +338,7 @@ private:
     CudaArray rebuildNeighborList;
     CudaSort* blockSorter;
     CUevent downloadCountEvent;
-    unsigned int* pinnedCountBuffer;
+    long long* pinnedCountBuffer;
     std::vector<void*> forceArgs, findBlockBoundsArgs, sortBoxDataArgs, findInteractingBlocksArgs;
     std::vector<std::vector<int> > atomExclusions;
     std::vector<ParameterInfo> parameters;
@@ -348,9 +348,8 @@ private:
     std::map<int, std::string> groupKernelSource;
     double lastCutoff;
     bool useCutoff, usePeriodic, anyExclusions, usePadding, forceRebuildNeighborList, canUsePairList;
-    int startTileIndex, startBlockIndex, numBlocks, maxExclusions, numForceThreadBlocks, forceThreadBlockSize, numAtoms, groupFlags;
-    unsigned int maxTiles, maxSinglePairs;
-    long long numTiles;
+    int startBlockIndex, numBlocks, maxExclusions, numForceThreadBlocks, forceThreadBlockSize, numAtoms, groupFlags;
+    long long numTiles, maxTiles, maxSinglePairs, startTileIndex;
     std::string kernelSource;
 };
 

--- a/platforms/cuda/include/CudaParallelKernels.h
+++ b/platforms/cuda/include/CudaParallelKernels.h
@@ -84,7 +84,7 @@ private:
     std::vector<Kernel> kernels;
     std::vector<long long> completionTimes;
     std::vector<double> contextNonbondedFractions;
-    int2* interactionCounts;
+    long2* interactionCounts;
     CudaArray contextForces;
     void* pinnedPositionBuffer;
     long long* pinnedForceBuffer;

--- a/platforms/cuda/src/CudaArray.cpp
+++ b/platforms/cuda/src/CudaArray.cpp
@@ -89,7 +89,7 @@ ComputeContext& CudaArray::getContext() {
     return *context;
 }
 
-void CudaArray::uploadSubArray(const void* data, int offset, int elements, bool blocking) {
+void CudaArray::uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking) {
     if (pointer == 0)
         throw OpenMMException("CudaArray has not been initialized");
     if (offset < 0 || offset+elements > getSize())

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -857,8 +857,11 @@ void CudaContext::flushQueue() {
     cuStreamSynchronize(getCurrentStream());
 }
 void CudaContext::synchronize() {
+    CUcontext popped;
     string errorMessage = "Error on synchronization";
+    CHECK_RESULT(cuCtxPushCurrent(context));
     CHECK_RESULT(cuCtxSynchronize());
+    CHECK_RESULT(cuCtxPopCurrent(&popped));
 }
 
 vector<int> CudaContext::getDevicePrecedence() {

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -756,8 +756,8 @@ void CudaContext::clearBuffer(ArrayInterface& array) {
     clearBuffer(unwrap(array).getDevicePointer(), array.getSize()*array.getElementSize());
 }
 
-void CudaContext::clearBuffer(CUdeviceptr memory, int size) {
-    int words = size/4;
+void CudaContext::clearBuffer(CUdeviceptr memory, size_t size) {
+    size_t words = size/4;
     void* args[] = {&memory, &words};
     executeKernel(clearBufferKernel, args, words, 128);
 }
@@ -766,7 +766,7 @@ void CudaContext::addAutoclearBuffer(ArrayInterface& array) {
     addAutoclearBuffer(unwrap(array).getDevicePointer(), array.getSize()*array.getElementSize());
 }
 
-void CudaContext::addAutoclearBuffer(CUdeviceptr memory, int size) {
+void CudaContext::addAutoclearBuffer(CUdeviceptr memory, size_t size) {
     autoclearBuffers.push_back(memory);
     autoclearBufferSizes.push_back(size/4);
 }

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -856,6 +856,10 @@ void CudaContext::addEnergyParameterDerivative(const string& param) {
 void CudaContext::flushQueue() {
     cuStreamSynchronize(getCurrentStream());
 }
+void CudaContext::synchronize() {
+    string errorMessage = "Error on synchronization";
+    CHECK_RESULT(cuCtxSynchronize());
+}
 
 vector<int> CudaContext::getDevicePrecedence() {
     int numDevices;

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -139,8 +139,8 @@ void CudaUpdateStateDataKernel::getPositions(ContextImpl& context, vector<Vec3>&
         Vec3 boxVectors[3];
         cu.getPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2]);
         int numThreads = threads.getNumThreads();
-        int start = threadIndex*numParticles/numThreads;
-        int end = (threadIndex+1)*numParticles/numThreads;
+        int start = threadIndex*(long long)numParticles/numThreads;
+        int end = (threadIndex+1)*(long long)numParticles/numThreads;
         if (cu.getUseDoublePrecision()) {
             double4* posq = (double4*) cu.getPinnedBuffer();
             for (int i = start; i < end; ++i) {

--- a/platforms/cuda/src/CudaNonbondedUtilities.cpp
+++ b/platforms/cuda/src/CudaNonbondedUtilities.cpp
@@ -282,7 +282,8 @@ void CudaNonbondedUtilities::initialize(const System& system) {
         blockSorter = new CudaSort(context, new BlockSortTrait(context.getUseDoublePrecision()), numAtomBlocks, false);
         vector<long long> count(2, 0);
         interactionCount.upload(count);
-        rebuildNeighborList.upload(&count[0]);
+        vector<int> zero(1, 0);
+        rebuildNeighborList.upload(zero);
     }
 
     // Record arguments for kernels.

--- a/platforms/cuda/src/CudaParallelKernels.cpp
+++ b/platforms/cuda/src/CudaParallelKernels.cpp
@@ -64,7 +64,7 @@ if (result != CUDA_SUCCESS) { \
 class CudaParallelCalcForcesAndEnergyKernel::BeginComputationTask : public CudaContext::WorkTask {
 public:
     BeginComputationTask(ContextImpl& context, CudaContext& cu, CudaCalcForcesAndEnergyKernel& kernel,
-            bool includeForce, bool includeEnergy, int groups, void* pinnedMemory, CUevent event, int2& interactionCount) : context(context), cu(cu), kernel(kernel),
+            bool includeForce, bool includeEnergy, int groups, void* pinnedMemory, CUevent event, long2& interactionCount) : context(context), cu(cu), kernel(kernel),
             includeForce(includeForce), includeEnergy(includeEnergy), groups(groups), pinnedMemory(pinnedMemory), event(event), interactionCount(interactionCount) {
     }
     void execute() {
@@ -88,14 +88,14 @@ private:
     int groups;
     void* pinnedMemory;
     CUevent event;
-    int2& interactionCount;
+    long2& interactionCount;
 };
 
 class CudaParallelCalcForcesAndEnergyKernel::FinishComputationTask : public CudaContext::WorkTask {
 public:
     FinishComputationTask(ContextImpl& context, CudaContext& cu, CudaCalcForcesAndEnergyKernel& kernel,
             bool includeForce, bool includeEnergy, int groups, double& energy, long long& completionTime, long long* pinnedMemory, CudaArray& contextForces,
-            bool& valid, int2& interactionCount, CUstream stream, CUevent event, CUevent localEvent) :
+            bool& valid, long2& interactionCount, CUstream stream, CUevent event, CUevent localEvent) :
             context(context), cu(cu), kernel(kernel), includeForce(includeForce), includeEnergy(includeEnergy), groups(groups), energy(energy),
             completionTime(completionTime), pinnedMemory(pinnedMemory), contextForces(contextForces), valid(valid), interactionCount(interactionCount),
             stream(stream), event(event), localEvent(localEvent) {
@@ -144,7 +144,7 @@ private:
     long long* pinnedMemory;
     CudaArray& contextForces;
     bool& valid;
-    int2& interactionCount;
+    long2& interactionCount;
     CUstream stream;
     CUevent event;
     CUevent localEvent;
@@ -197,7 +197,7 @@ void CudaParallelCalcForcesAndEnergyKernel::initialize(const System& system) {
         ContextSelector selectorLocal(cuLocal);
         CHECK_RESULT(cuEventCreate(&peerCopyEventLocal[i], 0), "Error creating event");
     }
-    CHECK_RESULT(cuMemHostAlloc((void**) &interactionCounts, numContexts*sizeof(int2), 0), "Error creating interaction counts buffer");
+    CHECK_RESULT(cuMemHostAlloc((void**) &interactionCounts, numContexts*sizeof(long2), 0), "Error creating interaction counts buffer");
 }
 
 void CudaParallelCalcForcesAndEnergyKernel::beginComputation(ContextImpl& context, bool includeForce, bool includeEnergy, int groups) {

--- a/platforms/cuda/src/kernels/findInteractingBlocks.cu
+++ b/platforms/cuda/src/kernels/findInteractingBlocks.cu
@@ -384,9 +384,6 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
     }
     
     // Record the positions the neighbor list is based on.
-    //if(indexInWarp == 0)
-    //    printf("Finished warp %i/%i\n", warpIndex, totalWarps);
-
     for (int i = threadIdx.x+blockIdx.x*blockDim.x; i < NUM_ATOMS; i += blockDim.x*gridDim.x)
         oldPositions[i] = posq[i];
 }

--- a/platforms/cuda/src/kernels/findInteractingBlocks.cu
+++ b/platforms/cuda/src/kernels/findInteractingBlocks.cu
@@ -384,7 +384,9 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
     }
     
     // Record the positions the neighbor list is based on.
-    
+    //if(indexInWarp == 0)
+    //    printf("Finished warp %i/%i\n", warpIndex, totalWarps);
+
     for (int i = threadIdx.x+blockIdx.x*blockDim.x; i < NUM_ATOMS; i += blockDim.x*gridDim.x)
         oldPositions[i] = posq[i];
 }

--- a/platforms/cuda/src/kernels/findInteractingBlocks.cu
+++ b/platforms/cuda/src/kernels/findInteractingBlocks.cu
@@ -54,7 +54,7 @@ extern "C" __global__ void findBlockBounds(int numAtoms, real4 periodicBoxSize, 
 extern "C" __global__ void sortBoxData(const real2* __restrict__ sortedBlock, const real4* __restrict__ blockCenter,
         const real4* __restrict__ blockBoundingBox, real4* __restrict__ sortedBlockCenter,
         real4* __restrict__ sortedBlockBoundingBox, const real4* __restrict__ posq, const real4* __restrict__ oldPositions,
-        unsigned int* __restrict__ interactionCount, int* __restrict__ rebuildNeighborList, bool forceRebuild) {
+        long long* __restrict__ interactionCount, int* __restrict__ rebuildNeighborList, bool forceRebuild) {
     for (int i = threadIdx.x+blockIdx.x*blockDim.x; i < NUM_BLOCKS; i += blockDim.x*gridDim.x) {
         int index = (int) sortedBlock[i].y;
         sortedBlockCenter[i] = blockCenter[index];
@@ -76,26 +76,26 @@ extern "C" __global__ void sortBoxData(const real2* __restrict__ sortedBlock, co
     }
 }
 
-__device__ int saveSinglePairs(int x, int* atoms, int* flags, int length, unsigned int maxSinglePairs, unsigned int* singlePairCount, int2* singlePairs, int* sumBuffer, volatile unsigned int& pairStartIndex) {
+__device__ int saveSinglePairs(int x, int* atoms, int* flags, int length, long long maxSinglePairs, unsigned long long* singlePairCount, int2* singlePairs, int* sumBuffer, volatile long long& pairStartIndex) {
     // Record interactions that should be computed as single pairs rather than in blocks.
     
     const int indexInWarp = threadIdx.x%32;
-    int sum = 0;
+    long long sum = 0;
     #pragma unroll 8 // (GROUP_SIZE / TILE_SIZE)
     for (int i = indexInWarp; i < length; i += 32) {
         int count = __popc(flags[i]);
         sum += (count <= MAX_BITS_FOR_PAIRS ? count : 0);
     }
     for (int i = 1; i < 32; i *= 2) {
-        int n = __shfl_up_sync(0xffffffff, sum, i);
+        long long n = __shfl_up_sync(0xffffffff, sum, i);
         if (indexInWarp >= i)
             sum += n;
     }
     if (indexInWarp == 31)
-        pairStartIndex = atomicAdd(singlePairCount,(unsigned int) sum);
+        pairStartIndex = atomicAdd(singlePairCount, (unsigned long long) sum);
     __syncwarp();
-    int prevSum = __shfl_up_sync(0xffffffff, sum, 1);
-    unsigned int pairIndex = pairStartIndex + (indexInWarp > 0 ? prevSum : 0);
+    long long prevSum = __shfl_up_sync(0xffffffff, sum, 1);
+    long long pairIndex = pairStartIndex + (indexInWarp > 0 ? prevSum : 0);
     for (int i = indexInWarp; i < length; i += 32) {
         int count = __popc(flags[i]);
         if (count <= MAX_BITS_FOR_PAIRS && pairIndex+count <= maxSinglePairs) {
@@ -178,8 +178,8 @@ __device__ int saveSinglePairs(int x, int* atoms, int* flags, int length, unsign
  *
  */
 extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
-        unsigned int* __restrict__ interactionCount, int* __restrict__ interactingTiles, unsigned int* __restrict__ interactingAtoms,
-        int2* __restrict__ singlePairs, const real4* __restrict__ posq, unsigned int maxTiles, unsigned int maxSinglePairs,
+        unsigned long long* __restrict__ interactionCount, int* __restrict__ interactingTiles, unsigned int* __restrict__ interactingAtoms,
+        int2* __restrict__ singlePairs, const real4* __restrict__ posq, long long maxTiles, long long maxSinglePairs,
         unsigned int startBlockIndex, unsigned int numBlocks, real2* __restrict__ sortedBlocks, const real4* __restrict__ sortedBlockCenter,
         const real4* __restrict__ sortedBlockBoundingBox, const unsigned int* __restrict__ exclusionIndices, const unsigned int* __restrict__ exclusionRowIndices,
         real4* __restrict__ oldPositions, const int* __restrict__ rebuildNeighborList) {
@@ -196,14 +196,14 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
     __shared__ int workgroupFlagsBuffer[BUFFER_SIZE*(GROUP_SIZE/32)];
     __shared__ int warpExclusions[MAX_EXCLUSIONS*(GROUP_SIZE/32)];
     __shared__ real4 posBuffer[GROUP_SIZE];
-    __shared__ volatile unsigned int workgroupTileIndex[GROUP_SIZE/32];
-    __shared__ unsigned int workgroupPairStartIndex[GROUP_SIZE/32];
+    __shared__ volatile long long workgroupTileIndex[GROUP_SIZE/32];
+    __shared__ long long workgroupPairStartIndex[GROUP_SIZE/32];
     int* sumBuffer = (int*) posBuffer; // Reuse the same buffer to save memory
     int* buffer = workgroupBuffer+BUFFER_SIZE*(warpStart/32);
     int* flagsBuffer = workgroupFlagsBuffer+BUFFER_SIZE*(warpStart/32);
     int* exclusionsForX = warpExclusions+MAX_EXCLUSIONS*(warpStart/32);
-    volatile unsigned int& tileStartIndex = workgroupTileIndex[warpStart/32];
-    volatile unsigned int& pairStartIndex = workgroupPairStartIndex[warpStart/32];
+    volatile long long& tileStartIndex = workgroupTileIndex[warpStart/32];
+    volatile long long& pairStartIndex = workgroupPairStartIndex[warpStart/32];
 
     // Loop over blocks.
     
@@ -342,11 +342,11 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
 #if MAX_BITS_FOR_PAIRS > 0
                     neighborsInBuffer = saveSinglePairs(x, buffer, flagsBuffer, neighborsInBuffer, maxSinglePairs, &interactionCount[1], singlePairs, sumBuffer+warpStart, pairStartIndex);
 #endif
-                    unsigned int tilesToStore = neighborsInBuffer/TILE_SIZE;
+                    long long tilesToStore = neighborsInBuffer/TILE_SIZE;
                     if (tilesToStore > 0) {
                         if (indexInWarp == 0)
                             tileStartIndex = atomicAdd(&interactionCount[0], tilesToStore);
-                        unsigned int newTileStartIndex = tileStartIndex;
+                        long long newTileStartIndex = tileStartIndex;
                         if (newTileStartIndex+tilesToStore <= maxTiles) {
                             if (indexInWarp < tilesToStore)
                                 interactingTiles[newTileStartIndex+indexInWarp] = x;
@@ -369,10 +369,10 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
             neighborsInBuffer = saveSinglePairs(x, buffer, flagsBuffer, neighborsInBuffer, maxSinglePairs, &interactionCount[1], singlePairs, sumBuffer+warpStart, pairStartIndex);
 #endif
         if (neighborsInBuffer > 0) {
-            unsigned int tilesToStore = (neighborsInBuffer+TILE_SIZE-1)/TILE_SIZE;
+            long long tilesToStore = (neighborsInBuffer+TILE_SIZE-1)/TILE_SIZE;
             if (indexInWarp == 0)
                 tileStartIndex = atomicAdd(&interactionCount[0], tilesToStore);
-            unsigned int newTileStartIndex = tileStartIndex;
+            long long newTileStartIndex = tileStartIndex;
             if (newTileStartIndex+tilesToStore <= maxTiles) {
                 if (indexInWarp < tilesToStore)
                     interactingTiles[newTileStartIndex+indexInWarp] = x;

--- a/platforms/cuda/src/kernels/nonbonded.cu
+++ b/platforms/cuda/src/kernels/nonbonded.cu
@@ -365,7 +365,7 @@ extern "C" __global__ void computeNonbonded(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= MAX_CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= MAX_CUTOFF);
 #else
-        y = floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(long long)y*NUM_BLOCKS+y*((long long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/cuda/src/kernels/nonbonded.cu
+++ b/platforms/cuda/src/kernels/nonbonded.cu
@@ -138,8 +138,8 @@ extern "C" __global__ void computeNonbonded(
 
     // First loop: process tiles that contain exclusions.
 
-    const long long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const long long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const long long firstExclusionTile = FIRST_EXCLUSION_TILE+(long long)warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const long long lastExclusionTile = FIRST_EXCLUSION_TILE+((long long)warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     for (long long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
@@ -608,7 +608,7 @@ extern "C" __global__ void computeNonbonded(
     // Third loop: single pairs that aren't part of a tile.
     
 #if USE_CUTOFF
-    const unsigned int numPairs = interactionCount[1];
+    const long long numPairs = interactionCount[1];
     if (numPairs > maxSinglePairs)
         return; // There wasn't enough memory for the neighbor list.
     for (int i = blockIdx.x*blockDim.x+threadIdx.x; i < numPairs; i += blockDim.x*gridDim.x) {

--- a/platforms/cuda/src/kernels/utilities.cu
+++ b/platforms/cuda/src/kernels/utilities.cu
@@ -3,30 +3,30 @@ extern "C" {
 /**
  * This is called by the various functions below to clear a buffer.
  */
-__device__ void clearSingleBuffer(int* __restrict__ buffer, int size) {
-    int index = blockDim.x*blockIdx.x+threadIdx.x;
+__device__ void clearSingleBuffer(int* __restrict__ buffer, unsigned long long size) {
+    unsigned long long index = blockDim.x*blockIdx.x+threadIdx.x;
     int4* buffer4 = (int4*) buffer;
-    int sizeDiv4 = size/4;
+    unsigned long long sizeDiv4 = size/4;
     while (index < sizeDiv4) {
         buffer4[index] = make_int4(0);
         index += blockDim.x*gridDim.x;
     }
     if (blockDim.x*blockIdx.x+threadIdx.x == 0)
-        for (int i = sizeDiv4*4; i < size; i++)
+        for (unsigned long long i = sizeDiv4*4; i < size; i++)
             buffer[i] = 0;
 }
 
 /**
  * Fill a buffer with 0.
  */
-__global__ void clearBuffer(int* __restrict__ buffer, int size) {
+__global__ void clearBuffer(int* __restrict__ buffer, unsigned long long size) {
     clearSingleBuffer(buffer, size);
 }
 
 /**
  * Fill two buffers with 0.
  */
-__global__ void clearTwoBuffers(int* __restrict__ buffer1, int size1, int* __restrict__ buffer2, int size2) {
+__global__ void clearTwoBuffers(int* __restrict__ buffer1, unsigned long long size1, int* __restrict__ buffer2, unsigned long long size2) {
     clearSingleBuffer(buffer1, size1);
     clearSingleBuffer(buffer2, size2);
 }
@@ -34,7 +34,7 @@ __global__ void clearTwoBuffers(int* __restrict__ buffer1, int size1, int* __res
 /**
  * Fill three buffers with 0.
  */
-__global__ void clearThreeBuffers(int* __restrict__ buffer1, int size1, int* __restrict__ buffer2, int size2, int* __restrict__ buffer3, int size3) {
+__global__ void clearThreeBuffers(int* __restrict__ buffer1, unsigned long long size1, int* __restrict__ buffer2, unsigned long long size2, int* __restrict__ buffer3, unsigned long long size3) {
     clearSingleBuffer(buffer1, size1);
     clearSingleBuffer(buffer2, size2);
     clearSingleBuffer(buffer3, size3);
@@ -43,7 +43,7 @@ __global__ void clearThreeBuffers(int* __restrict__ buffer1, int size1, int* __r
 /**
  * Fill four buffers with 0.
  */
-__global__ void clearFourBuffers(int* __restrict__ buffer1, int size1, int* __restrict__ buffer2, int size2, int* __restrict__ buffer3, int size3, int* __restrict__ buffer4, int size4) {
+__global__ void clearFourBuffers(int* __restrict__ buffer1, unsigned long long size1, int* __restrict__ buffer2, unsigned long long size2, int* __restrict__ buffer3, unsigned long long size3, int* __restrict__ buffer4, unsigned long long size4) {
     clearSingleBuffer(buffer1, size1);
     clearSingleBuffer(buffer2, size2);
     clearSingleBuffer(buffer3, size3);
@@ -53,7 +53,7 @@ __global__ void clearFourBuffers(int* __restrict__ buffer1, int size1, int* __re
 /**
  * Fill five buffers with 0.
  */
-__global__ void clearFiveBuffers(int* __restrict__ buffer1, int size1, int* __restrict__ buffer2, int size2, int* __restrict__ buffer3, int size3, int* __restrict__ buffer4, int size4, int* __restrict__ buffer5, int size5) {
+__global__ void clearFiveBuffers(int* __restrict__ buffer1, unsigned long long size1, int* __restrict__ buffer2, unsigned long long size2, int* __restrict__ buffer3, unsigned long long size3, int* __restrict__ buffer4, unsigned long long size4, int* __restrict__ buffer5, unsigned long long size5) {
     clearSingleBuffer(buffer1, size1);
     clearSingleBuffer(buffer2, size2);
     clearSingleBuffer(buffer3, size3);
@@ -64,7 +64,7 @@ __global__ void clearFiveBuffers(int* __restrict__ buffer1, int size1, int* __re
 /**
  * Fill six buffers with 0.
  */
-__global__ void clearSixBuffers(int* __restrict__ buffer1, int size1, int* __restrict__ buffer2, int size2, int* __restrict__ buffer3, int size3, int* __restrict__ buffer4, int size4, int* __restrict__ buffer5, int size5, int* __restrict__ buffer6, int size6) {
+__global__ void clearSixBuffers(int* __restrict__ buffer1, unsigned long long size1, int* __restrict__ buffer2, unsigned long long size2, int* __restrict__ buffer3, unsigned long long size3, int* __restrict__ buffer4, unsigned long long size4, int* __restrict__ buffer5, unsigned long long size5, int* __restrict__ buffer6, unsigned long long size6) {
     clearSingleBuffer(buffer1, size1);
     clearSingleBuffer(buffer2, size2);
     clearSingleBuffer(buffer3, size3);

--- a/platforms/opencl/include/OpenCLArray.h
+++ b/platforms/opencl/include/OpenCLArray.h
@@ -224,7 +224,7 @@ public:
      * @param elements the number of elements to copy
      * @param blocking if true, this call will block until the transfer is complete.
      */
-    void uploadSubArray(const void* data, int offset, int elements, bool blocking=true);
+    void uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking=true);
     /**
      * Copy the values in the Buffer to an array.
      * 

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -345,7 +345,7 @@ public:
      * @param memory     the Memory to clear
      * @param size       the size of the buffer in bytes
      */
-    void clearBuffer(cl::Memory& memory, int size);
+    void clearBuffer(cl::Memory& memory, size_t size);
     /**
      * Register a buffer that should be automatically cleared (all elements set to 0) at the start of each force or energy computation.
      */
@@ -356,7 +356,7 @@ public:
      * @param memory     the Memory to clear
      * @param size       the size of the buffer in bytes
      */
-    void addAutoclearBuffer(cl::Memory& memory, int size);
+    void addAutoclearBuffer(cl::Memory& memory, size_t size);
     /**
      * Clear all buffers that have been registered with addAutoclearBuffer().
      */
@@ -712,7 +712,7 @@ private:
     std::vector<std::string> energyParamDerivNames;
     std::map<std::string, double> energyParamDerivWorkspace;
     std::vector<cl::Memory*> autoclearBuffers;
-    std::vector<int> autoclearBufferSizes;
+    std::vector<size_t> autoclearBufferSizes;
     OpenCLIntegrationUtilities* integration;
     OpenCLExpressionUtilities* expression;
     OpenCLBondedUtilities* bonded;

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -664,6 +664,11 @@ public:
      * expense of reduced simulation performance.
      */
     void flushQueue();
+    /**
+     * Wait until all work has been completed.
+     * This is useful for debugging.
+     */
+    void synchronize();
 private:
     OpenCLPlatform::PlatformData& platformData;
     int deviceIndex;

--- a/platforms/opencl/include/OpenCLNonbondedUtilities.h
+++ b/platforms/opencl/include/OpenCLNonbondedUtilities.h
@@ -254,13 +254,13 @@ public:
     /**
      * Get the index of the first tile this context is responsible for processing.
      */
-    int getStartTileIndex() const {
+    long long getStartTileIndex() const {
         return startTileIndex;
     }
     /**
      * Get the total number of tiles this context is responsible for processing.
      */
-    int getNumTiles() const {
+    long long getNumTiles() const {
         return numTiles;
     }
     /**
@@ -331,9 +331,9 @@ private:
     std::map<int, std::string> groupKernelSource;
     double lastCutoff;
     bool useCutoff, usePeriodic, deviceIsCpu, anyExclusions, usePadding, forceRebuildNeighborList;
-    int numForceBuffers, startTileIndex, startBlockIndex, numBlocks, maxExclusions, numForceThreadBlocks;
+    int numForceBuffers, startBlockIndex, numBlocks, maxExclusions, numForceThreadBlocks;
     int forceThreadBlockSize, interactingBlocksThreadBlockSize, groupFlags;
-    long long numTiles;
+    long long numTiles, startTileIndex;
     std::string kernelSource;
 };
 

--- a/platforms/opencl/include/OpenCLParallelKernels.h
+++ b/platforms/opencl/include/OpenCLParallelKernels.h
@@ -84,7 +84,7 @@ private:
     std::vector<Kernel> kernels;
     std::vector<long long> completionTimes;
     std::vector<double> contextNonbondedFractions;
-    std::vector<int> tileCounts;
+    std::vector<long long> tileCounts;
     OpenCLArray contextForces;
     cl::Buffer* pinnedPositionBuffer;
     cl::Buffer* pinnedForceBuffer;

--- a/platforms/opencl/src/OpenCLArray.cpp
+++ b/platforms/opencl/src/OpenCLArray.cpp
@@ -96,7 +96,7 @@ ComputeContext& OpenCLArray::getContext() {
     return *context;
 }
 
-void OpenCLArray::uploadSubArray(const void* data, int offset, int elements, bool blocking) {
+void OpenCLArray::uploadSubArray(const void* data, size_t offset, size_t elements, bool blocking) {
     if (buffer == NULL)
         throw OpenMMException("OpenCLArray has not been initialized");
     if (offset < 0 || offset+elements > getSize())

--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -698,10 +698,10 @@ void OpenCLContext::clearBuffer(ArrayInterface& array) {
     clearBuffer(unwrap(array).getDeviceBuffer(), array.getSize()*array.getElementSize());
 }
 
-void OpenCLContext::clearBuffer(cl::Memory& memory, int size) {
-    int words = size/4;
+void OpenCLContext::clearBuffer(cl::Memory& memory, size_t size) {
+    size_t words = size/4;
     clearBufferKernel.setArg<cl::Memory>(0, memory);
-    clearBufferKernel.setArg<cl_int>(1, words);
+    clearBufferKernel.setArg<cl_ulong>(1, words);
     executeKernel(clearBufferKernel, words, 128);
 }
 
@@ -709,7 +709,7 @@ void OpenCLContext::addAutoclearBuffer(ArrayInterface& array) {
     addAutoclearBuffer(unwrap(array).getDeviceBuffer(), array.getSize()*array.getElementSize());
 }
 
-void OpenCLContext::addAutoclearBuffer(cl::Memory& memory, int size) {
+void OpenCLContext::addAutoclearBuffer(cl::Memory& memory, size_t size) {
     autoclearBuffers.push_back(&memory);
     autoclearBufferSizes.push_back(size/4);
 }
@@ -719,58 +719,58 @@ void OpenCLContext::clearAutoclearBuffers() {
     int total = autoclearBufferSizes.size();
     while (total-base >= 6) {
         clearSixBuffersKernel.setArg<cl::Memory>(0, *autoclearBuffers[base]);
-        clearSixBuffersKernel.setArg<cl_int>(1, autoclearBufferSizes[base]);
+        clearSixBuffersKernel.setArg<cl_ulong>(1, autoclearBufferSizes[base]);
         clearSixBuffersKernel.setArg<cl::Memory>(2, *autoclearBuffers[base+1]);
-        clearSixBuffersKernel.setArg<cl_int>(3, autoclearBufferSizes[base+1]);
+        clearSixBuffersKernel.setArg<cl_ulong>(3, autoclearBufferSizes[base+1]);
         clearSixBuffersKernel.setArg<cl::Memory>(4, *autoclearBuffers[base+2]);
-        clearSixBuffersKernel.setArg<cl_int>(5, autoclearBufferSizes[base+2]);
+        clearSixBuffersKernel.setArg<cl_ulong>(5, autoclearBufferSizes[base+2]);
         clearSixBuffersKernel.setArg<cl::Memory>(6, *autoclearBuffers[base+3]);
-        clearSixBuffersKernel.setArg<cl_int>(7, autoclearBufferSizes[base+3]);
+        clearSixBuffersKernel.setArg<cl_ulong>(7, autoclearBufferSizes[base+3]);
         clearSixBuffersKernel.setArg<cl::Memory>(8, *autoclearBuffers[base+4]);
-        clearSixBuffersKernel.setArg<cl_int>(9, autoclearBufferSizes[base+4]);
+        clearSixBuffersKernel.setArg<cl_ulong>(9, autoclearBufferSizes[base+4]);
         clearSixBuffersKernel.setArg<cl::Memory>(10, *autoclearBuffers[base+5]);
-        clearSixBuffersKernel.setArg<cl_int>(11, autoclearBufferSizes[base+5]);
+        clearSixBuffersKernel.setArg<cl_ulong>(11, autoclearBufferSizes[base+5]);
         executeKernel(clearSixBuffersKernel, max(max(max(max(max(autoclearBufferSizes[base], autoclearBufferSizes[base+1]), autoclearBufferSizes[base+2]), autoclearBufferSizes[base+3]), autoclearBufferSizes[base+4]), autoclearBufferSizes[base+5]), 128);
         base += 6;
     }
     if (total-base == 5) {
         clearFiveBuffersKernel.setArg<cl::Memory>(0, *autoclearBuffers[base]);
-        clearFiveBuffersKernel.setArg<cl_int>(1, autoclearBufferSizes[base]);
+        clearFiveBuffersKernel.setArg<cl_ulong>(1, autoclearBufferSizes[base]);
         clearFiveBuffersKernel.setArg<cl::Memory>(2, *autoclearBuffers[base+1]);
-        clearFiveBuffersKernel.setArg<cl_int>(3, autoclearBufferSizes[base+1]);
+        clearFiveBuffersKernel.setArg<cl_ulong>(3, autoclearBufferSizes[base+1]);
         clearFiveBuffersKernel.setArg<cl::Memory>(4, *autoclearBuffers[base+2]);
-        clearFiveBuffersKernel.setArg<cl_int>(5, autoclearBufferSizes[base+2]);
+        clearFiveBuffersKernel.setArg<cl_ulong>(5, autoclearBufferSizes[base+2]);
         clearFiveBuffersKernel.setArg<cl::Memory>(6, *autoclearBuffers[base+3]);
-        clearFiveBuffersKernel.setArg<cl_int>(7, autoclearBufferSizes[base+3]);
+        clearFiveBuffersKernel.setArg<cl_ulong>(7, autoclearBufferSizes[base+3]);
         clearFiveBuffersKernel.setArg<cl::Memory>(8, *autoclearBuffers[base+4]);
-        clearFiveBuffersKernel.setArg<cl_int>(9, autoclearBufferSizes[base+4]);
+        clearFiveBuffersKernel.setArg<cl_ulong>(9, autoclearBufferSizes[base+4]);
         executeKernel(clearFiveBuffersKernel, max(max(max(max(autoclearBufferSizes[base], autoclearBufferSizes[base+1]), autoclearBufferSizes[base+2]), autoclearBufferSizes[base+3]), autoclearBufferSizes[base+4]), 128);
     }
     else if (total-base == 4) {
         clearFourBuffersKernel.setArg<cl::Memory>(0, *autoclearBuffers[base]);
-        clearFourBuffersKernel.setArg<cl_int>(1, autoclearBufferSizes[base]);
+        clearFourBuffersKernel.setArg<cl_ulong>(1, autoclearBufferSizes[base]);
         clearFourBuffersKernel.setArg<cl::Memory>(2, *autoclearBuffers[base+1]);
-        clearFourBuffersKernel.setArg<cl_int>(3, autoclearBufferSizes[base+1]);
+        clearFourBuffersKernel.setArg<cl_ulong>(3, autoclearBufferSizes[base+1]);
         clearFourBuffersKernel.setArg<cl::Memory>(4, *autoclearBuffers[base+2]);
-        clearFourBuffersKernel.setArg<cl_int>(5, autoclearBufferSizes[base+2]);
+        clearFourBuffersKernel.setArg<cl_ulong>(5, autoclearBufferSizes[base+2]);
         clearFourBuffersKernel.setArg<cl::Memory>(6, *autoclearBuffers[base+3]);
-        clearFourBuffersKernel.setArg<cl_int>(7, autoclearBufferSizes[base+3]);
+        clearFourBuffersKernel.setArg<cl_ulong>(7, autoclearBufferSizes[base+3]);
         executeKernel(clearFourBuffersKernel, max(max(max(autoclearBufferSizes[base], autoclearBufferSizes[base+1]), autoclearBufferSizes[base+2]), autoclearBufferSizes[base+3]), 128);
     }
     else if (total-base == 3) {
         clearThreeBuffersKernel.setArg<cl::Memory>(0, *autoclearBuffers[base]);
-        clearThreeBuffersKernel.setArg<cl_int>(1, autoclearBufferSizes[base]);
+        clearThreeBuffersKernel.setArg<cl_ulong>(1, autoclearBufferSizes[base]);
         clearThreeBuffersKernel.setArg<cl::Memory>(2, *autoclearBuffers[base+1]);
-        clearThreeBuffersKernel.setArg<cl_int>(3, autoclearBufferSizes[base+1]);
+        clearThreeBuffersKernel.setArg<cl_ulong>(3, autoclearBufferSizes[base+1]);
         clearThreeBuffersKernel.setArg<cl::Memory>(4, *autoclearBuffers[base+2]);
-        clearThreeBuffersKernel.setArg<cl_int>(5, autoclearBufferSizes[base+2]);
+        clearThreeBuffersKernel.setArg<cl_ulong>(5, autoclearBufferSizes[base+2]);
         executeKernel(clearThreeBuffersKernel, max(max(autoclearBufferSizes[base], autoclearBufferSizes[base+1]), autoclearBufferSizes[base+2]), 128);
     }
     else if (total-base == 2) {
         clearTwoBuffersKernel.setArg<cl::Memory>(0, *autoclearBuffers[base]);
-        clearTwoBuffersKernel.setArg<cl_int>(1, autoclearBufferSizes[base]);
+        clearTwoBuffersKernel.setArg<cl_ulong>(1, autoclearBufferSizes[base]);
         clearTwoBuffersKernel.setArg<cl::Memory>(2, *autoclearBuffers[base+1]);
-        clearTwoBuffersKernel.setArg<cl_int>(3, autoclearBufferSizes[base+1]);
+        clearTwoBuffersKernel.setArg<cl_ulong>(3, autoclearBufferSizes[base+1]);
         executeKernel(clearTwoBuffersKernel, max(autoclearBufferSizes[base], autoclearBufferSizes[base+1]), 128);
     }
     else if (total-base == 1) {

--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -845,3 +845,7 @@ void OpenCLContext::addEnergyParameterDerivative(const string& param) {
 void OpenCLContext::flushQueue() {
     getQueue().flush();
 }
+
+void OpenCLContext::synchronize() {
+    getQueue().finish();
+}

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -153,8 +153,8 @@ void OpenCLUpdateStateDataKernel::getPositions(ContextImpl& context, vector<Vec3
         Vec3 boxVectors[3];
         cl.getPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2]);
         int numThreads = threads.getNumThreads();
-        int start = threadIndex*numParticles/numThreads;
-        int end = (threadIndex+1)*numParticles/numThreads;
+        int start = threadIndex*(long long)numParticles/numThreads;
+        int end = (threadIndex+1)*(long long)numParticles/numThreads;
         if (cl.getUseDoublePrecision()) {
             mm_double4* posq = (mm_double4*) cl.getPinnedBuffer();
             for (int i = start; i < end; ++i) {

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -308,7 +308,8 @@ void OpenCLNonbondedUtilities::initialize(const System& system) {
         blockSorter = new OpenCLSort(context, new BlockSortTrait(context.getUseDoublePrecision()), numAtomBlocks, false);
         vector<cl_long> count(1, 0);
         interactionCount.upload(count);
-        rebuildNeighborList.upload(count);
+        vector<cl_int> zero(1, 0);
+        rebuildNeighborList.upload(zero);
     }
 }
 
@@ -451,19 +452,19 @@ void OpenCLNonbondedUtilities::setAtomBlockRange(double startFraction, double en
         for (map<int, KernelSet>::iterator iter = groupKernels.begin(); iter != groupKernels.end(); ++iter) {
             KernelSet& kernels = iter->second;
             if (*reinterpret_cast<cl_kernel*>(&kernels.forceKernel) != NULL) {
-                kernels.forceKernel.setArg<cl_uint>(5, startTileIndex);
-                kernels.forceKernel.setArg<cl_ulong>(6, numTiles);
+                kernels.forceKernel.setArg<cl_long>(5, startTileIndex);
+                kernels.forceKernel.setArg<cl_long>(6, numTiles);
             }
             if (*reinterpret_cast<cl_kernel*>(&kernels.energyKernel) != NULL) {
-                kernels.energyKernel.setArg<cl_uint>(5, startTileIndex);
-                kernels.energyKernel.setArg<cl_ulong>(6, numTiles);
+                kernels.energyKernel.setArg<cl_long>(5, startTileIndex);
+                kernels.energyKernel.setArg<cl_long>(6, numTiles);
             }
             if (*reinterpret_cast<cl_kernel*>(&kernels.forceEnergyKernel) != NULL) {
-                kernels.forceEnergyKernel.setArg<cl_uint>(5, startTileIndex);
-                kernels.forceEnergyKernel.setArg<cl_ulong>(6, numTiles);
+                kernels.forceEnergyKernel.setArg<cl_long>(5, startTileIndex);
+                kernels.forceEnergyKernel.setArg<cl_long>(6, numTiles);
             }
-            kernels.findInteractingBlocksKernel.setArg<cl_uint>(10, startBlockIndex);
-            kernels.findInteractingBlocksKernel.setArg<cl_uint>(11, numBlocks);
+            kernels.findInteractingBlocksKernel.setArg<cl_long>(10, startBlockIndex);
+            kernels.findInteractingBlocksKernel.setArg<cl_long>(11, numBlocks);
         }
         forceRebuildNeighborList = true;
     }

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -444,7 +444,7 @@ void OpenCLNonbondedUtilities::setAtomBlockRange(double startFraction, double en
     startBlockIndex = (int) (startFraction*numAtomBlocks);
     numBlocks = (int) (endFraction*numAtomBlocks)-startBlockIndex;
     long long totalTiles = context.getNumAtomBlocks()*((long long)context.getNumAtomBlocks()+1)/2;
-    startTileIndex = (int) (startFraction*totalTiles);;
+    startTileIndex = (startFraction*totalTiles);
     numTiles = (long long) (endFraction*totalTiles)-startTileIndex;
     if (useCutoff) {
         // We are using a cutoff, and the kernels have already been created.

--- a/platforms/opencl/src/OpenCLParallelKernels.cpp
+++ b/platforms/opencl/src/OpenCLParallelKernels.cpp
@@ -54,7 +54,7 @@ using namespace std;
 class OpenCLParallelCalcForcesAndEnergyKernel::BeginComputationTask : public OpenCLContext::WorkTask {
 public:
     BeginComputationTask(ContextImpl& context, OpenCLContext& cl, OpenCLCalcForcesAndEnergyKernel& kernel,
-            bool includeForce, bool includeEnergy, int groups, void* pinnedMemory, int& numTiles) : context(context), cl(cl), kernel(kernel),
+            bool includeForce, bool includeEnergy, int groups, void* pinnedMemory, long long& numTiles) : context(context), cl(cl), kernel(kernel),
             includeForce(includeForce), includeEnergy(includeEnergy), groups(groups), pinnedMemory(pinnedMemory), numTiles(numTiles) {
     }
     void execute() {
@@ -73,13 +73,13 @@ private:
     bool includeForce, includeEnergy;
     int groups;
     void* pinnedMemory;
-    int& numTiles;
+    long long& numTiles;
 };
 
 class OpenCLParallelCalcForcesAndEnergyKernel::FinishComputationTask : public OpenCLContext::WorkTask {
 public:
     FinishComputationTask(ContextImpl& context, OpenCLContext& cl, OpenCLCalcForcesAndEnergyKernel& kernel,
-            bool includeForce, bool includeEnergy, int groups, double& energy, long long& completionTime, void* pinnedMemory, bool& valid, int& numTiles) :
+            bool includeForce, bool includeEnergy, int groups, double& energy, long long& completionTime, void* pinnedMemory, bool& valid, long long& numTiles) :
             context(context), cl(cl), kernel(kernel), includeForce(includeForce), includeEnergy(includeEnergy), groups(groups), energy(energy),
             completionTime(completionTime), pinnedMemory(pinnedMemory), valid(valid), numTiles(numTiles) {
     }
@@ -113,7 +113,7 @@ private:
     long long& completionTime;
     void* pinnedMemory;
     bool& valid;
-    int& numTiles;
+    long long& numTiles;
 };
 
 OpenCLParallelCalcForcesAndEnergyKernel::OpenCLParallelCalcForcesAndEnergyKernel(string name, const Platform& platform, OpenCLPlatform::PlatformData& data) :

--- a/platforms/opencl/src/kernels/findInteractingBlocks.cl
+++ b/platforms/opencl/src/kernels/findInteractingBlocks.cl
@@ -451,8 +451,8 @@ void storeInteractionData(int x, __local int* buffer, __local int* sum, __local 
  * mark them as non-interacting.
  */
 __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
-        __global unsigned int* restrict interactionCount, __global int* restrict interactingTiles, __global unsigned int* restrict interactingAtoms,
-        __global const real4* restrict posq, unsigned int maxTiles, unsigned int startBlockIndex, unsigned int numBlocks, __global real2* restrict sortedBlocks,
+        __global long* restrict interactionCount, __global int* restrict interactingTiles, __global unsigned int* restrict interactingAtoms,
+        __global const real4* restrict posq, long maxTiles, unsigned int startBlockIndex, unsigned int numBlocks, __global real2* restrict sortedBlocks,
         __global const real4* restrict sortedBlockCenter, __global const real4* restrict sortedBlockBoundingBox,
         __global const unsigned int* restrict exclusionIndices, __global const unsigned int* restrict exclusionRowIndices, __global real4* restrict oldPositions,
         __global const int* restrict rebuildNeighborList) {

--- a/platforms/opencl/src/kernels/findInteractingBlocks.cl
+++ b/platforms/opencl/src/kernels/findInteractingBlocks.cl
@@ -54,7 +54,7 @@ __kernel void findBlockBounds(int numAtoms, real4 periodicBoxSize, real4 invPeri
 __kernel void sortBoxData(__global const real2* restrict sortedBlock, __global const real4* restrict blockCenter,
         __global const real4* restrict blockBoundingBox, __global real4* restrict sortedBlockCenter,
         __global real4* restrict sortedBlockBoundingBox, __global const real4* restrict posq, __global const real4* restrict oldPositions,
-        __global unsigned int* restrict interactionCount, __global int* restrict rebuildNeighborList, int forceRebuild) {
+        __global long* restrict interactionCount, __global int* restrict rebuildNeighborList, int forceRebuild) {
     for (int i = get_global_id(0); i < NUM_BLOCKS; i += get_global_size(0)) {
         int index = (int) sortedBlock[i].y;
         sortedBlockCenter[i] = blockCenter[index];
@@ -80,8 +80,8 @@ __kernel void sortBoxData(__global const real2* restrict sortedBlock, __global c
 #define BUFFER_SIZE 256
 
 __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
-        __global unsigned int* restrict interactionCount, __global int* restrict interactingTiles, __global unsigned int* restrict interactingAtoms,
-        __global const real4* restrict posq, unsigned int maxTiles, unsigned int startBlockIndex, unsigned int numBlocks, __global real2* restrict sortedBlocks,
+        __global long* restrict interactionCount, __global int* restrict interactingTiles, __global unsigned int* restrict interactingAtoms,
+        __global const real4* restrict posq, long maxTiles, long startBlockIndex, long numBlocks, __global real2* restrict sortedBlocks,
         __global const real4* restrict sortedBlockCenter, __global const real4* restrict sortedBlockBoundingBox,
         __global const unsigned int* restrict exclusionIndices, __global const unsigned int* restrict exclusionRowIndices, __global real4* restrict oldPositions,
         __global const int* restrict rebuildNeighborList) {
@@ -97,12 +97,12 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
     __local int workgroupBuffer[BUFFER_SIZE*(GROUP_SIZE/32)];
     __local int warpExclusions[MAX_EXCLUSIONS*(GROUP_SIZE/32)];
     __local real3 posBuffer[GROUP_SIZE];
-    __local volatile unsigned int workgroupTileIndex[GROUP_SIZE/32];
+    __local volatile long workgroupTileIndex[GROUP_SIZE/32];
     __local bool includeBlockFlags[GROUP_SIZE];
     __local volatile short2 atomCountBuffer[GROUP_SIZE];
     __local int* buffer = workgroupBuffer+BUFFER_SIZE*(warpStart/32);
     __local int* exclusionsForX = warpExclusions+MAX_EXCLUSIONS*(warpStart/32);
-    __local volatile unsigned int* tileStartIndex = workgroupTileIndex+(warpStart/32);
+    __local volatile long* tileStartIndex = workgroupTileIndex+(warpStart/32);
 
     // Loop over blocks.
 
@@ -113,7 +113,7 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
         int x = (int) sortedKey.y;
         real4 blockCenterX = sortedBlockCenter[block1];
         real4 blockSizeX = sortedBlockBoundingBox[block1];
-        int neighborsInBuffer = 0;
+        long neighborsInBuffer = 0;
         real3 pos1 = posq[x*TILE_SIZE+indexInWarp].xyz;
 #ifdef USE_PERIODIC
         const bool singlePeriodicCopy = (0.5f*periodicBoxSize.x-blockSizeX.x >= PADDED_CUTOFF &&
@@ -233,11 +233,11 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
                     if (neighborsInBuffer > BUFFER_SIZE-TILE_SIZE) {
                         // Store the new tiles to memory.
 
-                        unsigned int tilesToStore = neighborsInBuffer/TILE_SIZE;
+                        long tilesToStore = neighborsInBuffer/TILE_SIZE;
                         if (indexInWarp == 0)
                             *tileStartIndex = atom_add(interactionCount, tilesToStore);
                         SYNC_WARPS;
-                        unsigned int newTileStartIndex = *tileStartIndex;
+                        long newTileStartIndex = *tileStartIndex;
                         if (newTileStartIndex+tilesToStore <= maxTiles) {
                             if (indexInWarp < tilesToStore)
                                 interactingTiles[newTileStartIndex+indexInWarp] = x;
@@ -255,11 +255,11 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
         // If we have a partially filled buffer,  store it to memory.
         
         if (neighborsInBuffer > 0) {
-            unsigned int tilesToStore = (neighborsInBuffer+TILE_SIZE-1)/TILE_SIZE;
+            long tilesToStore = (neighborsInBuffer+TILE_SIZE-1)/TILE_SIZE;
             if (indexInWarp == 0)
                 *tileStartIndex = atom_add(interactionCount, tilesToStore);
             SYNC_WARPS;
-            unsigned int newTileStartIndex = *tileStartIndex;
+            long newTileStartIndex = *tileStartIndex;
             if (newTileStartIndex+tilesToStore <= maxTiles) {
                 if (indexInWarp < tilesToStore)
                     interactingTiles[newTileStartIndex+indexInWarp] = x;
@@ -315,9 +315,9 @@ void prefixSum(__local int* sum, __local int2* temp) {
  * in them, and writes the result to global memory.
  */
 void storeInteractionData(int x, __local int* buffer, __local int* sum, __local int2* temp, __local int* atoms, __local int* numAtoms,
-            __local int* baseIndex, __global unsigned int* interactionCount, __global int* interactingTiles, __global unsigned int* interactingAtoms, real4 periodicBoxSize,
+            __local long* baseIndex, __global long* interactionCount, __global int* interactingTiles, __global unsigned int* interactingAtoms, real4 periodicBoxSize,
             real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, __global const real4* posq, __local real4* posBuffer,
-            real4 blockCenterX, real4 blockSizeX, unsigned int maxTiles, bool finish) {
+            real4 blockCenterX, real4 blockSizeX, long maxTiles, bool finish) {
     const bool singlePeriodicCopy = (0.5f*periodicBoxSize.x-blockSizeX.x >= PADDED_CUTOFF &&
                                      0.5f*periodicBoxSize.y-blockSizeX.y >= PADDED_CUTOFF &&
                                      0.5f*periodicBoxSize.z-blockSizeX.z >= PADDED_CUTOFF);
@@ -400,7 +400,7 @@ void storeInteractionData(int x, __local int* buffer, __local int* sum, __local 
 
         int atomsToStore = *numAtoms+sum[BUFFER_SIZE-1];
         bool storePartialTile = (finish && base >= numValid-BUFFER_SIZE/WARP_SIZE);
-        int tilesToStore = (storePartialTile ? (atomsToStore+TILE_SIZE-1)/TILE_SIZE : atomsToStore/TILE_SIZE);
+        long tilesToStore = (storePartialTile ? (atomsToStore+TILE_SIZE-1)/TILE_SIZE : atomsToStore/TILE_SIZE);
         if (tilesToStore > 0) {
             if (get_local_id(0) == 0)
                 *baseIndex = atom_add(interactionCount, tilesToStore);
@@ -463,7 +463,7 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
     __local real4 posBuffer[TILE_SIZE];
     __local int exclusionsForX[MAX_EXCLUSIONS];
     __local int bufferFull;
-    __local int globalIndex;
+    __local long globalIndex;
     __local int numAtoms;
 #ifdef AMD_ATOMIC_WORK_AROUND
     // Do a byte write to force all memory accesses to interactionCount to use the complete path.

--- a/platforms/opencl/src/kernels/findInteractingBlocks_cpu.cl
+++ b/platforms/opencl/src/kernels/findInteractingBlocks_cpu.cl
@@ -44,7 +44,7 @@ __kernel void findBlockBounds(int numAtoms, real4 periodicBoxSize, real4 invPeri
 __kernel void sortBoxData(__global const real2* restrict sortedBlock, __global const real4* restrict blockCenter,
         __global const real4* restrict blockBoundingBox, __global real4* restrict sortedBlockCenter,
         __global real4* restrict sortedBlockBoundingBox, __global const real4* restrict posq, __global const real4* restrict oldPositions,
-        __global unsigned int* restrict interactionCount, __global int* restrict rebuildNeighborList, int forceRebuild) {
+        __global long* restrict interactionCount, __global int* restrict rebuildNeighborList, int forceRebuild) {
     for (int i = get_global_id(0); i < NUM_BLOCKS; i += get_global_size(0)) {
         int index = (int) sortedBlock[i].y;
         sortedBlockCenter[i] = blockCenter[index];
@@ -69,9 +69,9 @@ __kernel void sortBoxData(__global const real2* restrict sortedBlock, __global c
  * This is called by findBlocksWithInteractions().  It compacts the list of blocks and writes them
  * to global memory.
  */
-void storeInteractionData(int x, int* buffer, int* atoms, int* numAtoms, int numValid, __global unsigned int* interactionCount,
-            __global int* interactingTiles, __global unsigned int* interactingAtoms, real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX,
-            real4 periodicBoxVecY, real4 periodicBoxVecZ, __global const real4* posq, real4 blockCenterX, real4 blockSizeX, unsigned int maxTiles, bool finish) {
+void storeInteractionData(int x, int* buffer, int* atoms, int* numAtoms, int numValid, __global long* interactionCount,
+            __global long* interactingTiles, __global unsigned int* interactingAtoms, real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX,
+            real4 periodicBoxVecY, real4 periodicBoxVecZ, __global const real4* posq, real4 blockCenterX, real4 blockSizeX, long maxTiles, bool finish) {
     real4 posBuffer[TILE_SIZE];
     const bool singlePeriodicCopy = (0.5f*periodicBoxSize.x-blockSizeX.x >= PADDED_CUTOFF &&
                                      0.5f*periodicBoxSize.y-blockSizeX.y >= PADDED_CUTOFF &&
@@ -124,8 +124,8 @@ void storeInteractionData(int x, int* buffer, int* atoms, int* numAtoms, int num
             if (*numAtoms == BUFFER_SIZE) {
                 // The atoms buffer is full, so store it to global memory.
                 
-                int tilesToStore = BUFFER_SIZE/TILE_SIZE;
-                int baseIndex = atom_add(interactionCount, tilesToStore);
+                long tilesToStore = BUFFER_SIZE/TILE_SIZE;
+                long baseIndex = atom_add(interactionCount, tilesToStore);
                 if (baseIndex+tilesToStore <= maxTiles) {
                     for (int i = 0; i < tilesToStore; i++) {
                         interactingTiles[baseIndex+i] = x;
@@ -141,8 +141,8 @@ void storeInteractionData(int x, int* buffer, int* atoms, int* numAtoms, int num
     if (*numAtoms > 0 && finish) {
         // There are some leftover atoms, so save them now.
         
-        int tilesToStore = (*numAtoms+TILE_SIZE-1)/TILE_SIZE;
-        int baseIndex = atom_add(interactionCount, tilesToStore);
+        long tilesToStore = (*numAtoms+TILE_SIZE-1)/TILE_SIZE;
+        long baseIndex = atom_add(interactionCount, tilesToStore);
         if (baseIndex+tilesToStore <= maxTiles) {
             for (int i = 0; i < tilesToStore; i++) {
                 interactingTiles[baseIndex+i] = x;
@@ -160,8 +160,8 @@ void storeInteractionData(int x, int* buffer, int* atoms, int* numAtoms, int num
  * mark them as non-interacting.
  */
 __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
-        __global unsigned int* restrict interactionCount, __global int* restrict interactingTiles, __global unsigned int* restrict interactingAtoms,
-        __global const real4* restrict posq, unsigned int maxTiles, unsigned int startBlockIndex, unsigned int numBlocks, __global real2* restrict sortedBlocks,
+        __global long* restrict interactionCount, __global int* restrict interactingTiles, __global unsigned int* restrict interactingAtoms,
+        __global const real4* restrict posq, long maxTiles, unsigned int startBlockIndex, unsigned int numBlocks, __global real2* restrict sortedBlocks,
         __global const real4* restrict sortedBlockCenter, __global const real4* restrict sortedBlockBoundingBox,
         __global const unsigned int* restrict exclusionIndices, __global const unsigned int* restrict exclusionRowIndices, __global real4* restrict oldPositions,
         __global const int* restrict rebuildNeighborList) {

--- a/platforms/opencl/src/kernels/nonbonded.cl
+++ b/platforms/opencl/src/kernels/nonbonded.cl
@@ -232,7 +232,7 @@ __kernel void computeNonbonded(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= MAX_CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= MAX_CUTOFF);
 #else
-        y = floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(long)y*NUM_BLOCKS+y*((long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/opencl/src/kernels/nonbonded.cl
+++ b/platforms/opencl/src/kernels/nonbonded.cl
@@ -23,10 +23,10 @@ __kernel void computeNonbonded(
         __global real4* restrict forceBuffers,
 #endif
         __global mixed* restrict energyBuffer, __global const real4* restrict posq, __global const unsigned int* restrict exclusions,
-        __global const int2* restrict exclusionTiles, unsigned int startTileIndex, unsigned long numTileIndices
+        __global const int2* restrict exclusionTiles, long startTileIndex, long numTileIndices
 #ifdef USE_CUTOFF
-        , __global const int* restrict tiles, __global const unsigned int* restrict interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, __global const real4* restrict blockCenter,
+        , __global const int* restrict tiles, __global const long* restrict interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, long maxTiles, __global const real4* restrict blockCenter,
         __global const real4* restrict blockSize, __global const int* restrict interactingAtoms
 #endif
         PARAMETER_ARGUMENTS) {
@@ -41,9 +41,9 @@ __kernel void computeNonbonded(
 
     // First loop: process tiles that contain exclusions.
 
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*((long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*((long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -201,14 +201,14 @@ __kernel void computeNonbonded(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    unsigned int numTiles = interactionCount[0];
+    long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (warp*(long)numTiles/totalWarps);
-    int end = (int) ((warp+1)*(long)numTiles/totalWarps);
+    long pos = (warp*(long)numTiles/totalWarps);
+    long end = ((warp+1)*(long)numTiles/totalWarps);
 #else
-    int pos = (int) (startTileIndex+warp*numTileIndices/totalWarps);
-    int end = (int) (startTileIndex+(warp+1)*numTileIndices/totalWarps);
+    long pos = (startTileIndex+warp*numTileIndices/totalWarps);
+    long end = (startTileIndex+(warp+1)*numTileIndices/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -232,11 +232,11 @@ __kernel void computeNonbonded(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= MAX_CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= MAX_CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        y = floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        x = (pos-(long)y*NUM_BLOCKS+y*((long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(long)y*NUM_BLOCKS+y*((long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -246,7 +246,7 @@ __kernel void computeNonbonded(
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[get_local_id(0)] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[get_local_id(0)] = tile.x + (long)tile.y*NUM_BLOCKS - tile.y*((long)tile.y+1)/2;
             }
             else
                 skipTiles[get_local_id(0)] = end;

--- a/platforms/opencl/src/kernels/nonbonded_cpu.cl
+++ b/platforms/opencl/src/kernels/nonbonded_cpu.cl
@@ -246,7 +246,7 @@ __kernel void computeNonbonded(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= MAX_CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= MAX_CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (int) (pos-(long)y*NUM_BLOCKS+y*((long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/platforms/opencl/src/kernels/utilities.cl
+++ b/platforms/opencl/src/kernels/utilities.cl
@@ -2,23 +2,23 @@
  * Fill a buffer with 0.
  */
 
-__kernel void clearBuffer(__global int* restrict buffer, mm_ulong size) {
-    mm_ulong index = get_global_id(0);
+__kernel void clearBuffer(__global int* restrict buffer, unsigned long size) {
+    unsigned long index = get_global_id(0);
     __global int4* buffer4 = (__global int4*) buffer;
-    mm_ulong sizeDiv4 = size/4;
+    unsigned long sizeDiv4 = size/4;
     while (index < sizeDiv4) {
         buffer4[index] = (int4) 0;
         index += get_global_size(0);
     }
     if (get_global_id(0) == 0)
-        for (mm_ulong i = sizeDiv4*4; i < size; i++)
+        for (unsigned long i = sizeDiv4*4; i < size; i++)
             buffer[i] = 0;
 }
 
 /**
  * Fill two buffers with 0.
  */
-__kernel void clearTwoBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2) {
+__kernel void clearTwoBuffers(__global int* restrict buffer1, unsigned long size1, __global int* restrict buffer2, unsigned long size2) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
 }
@@ -26,7 +26,7 @@ __kernel void clearTwoBuffers(__global int* restrict buffer1, mm_ulong size1, __
 /**
  * Fill three buffers with 0.
  */
-__kernel void clearThreeBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3) {
+__kernel void clearThreeBuffers(__global int* restrict buffer1, unsigned long size1, __global int* restrict buffer2, unsigned long size2, __global int* restrict buffer3, unsigned long size3) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);
@@ -35,7 +35,7 @@ __kernel void clearThreeBuffers(__global int* restrict buffer1, mm_ulong size1, 
 /**
  * Fill four buffers with 0.
  */
-__kernel void clearFourBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3, __global int* restrict buffer4, mm_ulong size4) {
+__kernel void clearFourBuffers(__global int* restrict buffer1, unsigned long size1, __global int* restrict buffer2, unsigned long size2, __global int* restrict buffer3, unsigned long size3, __global int* restrict buffer4, unsigned long size4) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);
@@ -45,7 +45,7 @@ __kernel void clearFourBuffers(__global int* restrict buffer1, mm_ulong size1, _
 /**
  * Fill five buffers with 0.
  */
-__kernel void clearFiveBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3, __global int* restrict buffer4, mm_ulong size4, __global int* restrict buffer5, mm_ulong size5) {
+__kernel void clearFiveBuffers(__global int* restrict buffer1, unsigned long size1, __global int* restrict buffer2, unsigned long size2, __global int* restrict buffer3, unsigned long size3, __global int* restrict buffer4, unsigned long size4, __global int* restrict buffer5, unsigned long size5) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);
@@ -56,7 +56,7 @@ __kernel void clearFiveBuffers(__global int* restrict buffer1, mm_ulong size1, _
 /**
  * Fill six buffers with 0.
  */
-__kernel void clearSixBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3, __global int* restrict buffer4, mm_ulong size4, __global int* restrict buffer5, mm_ulong size5, __global int* restrict buffer6, mm_ulong size6) {
+__kernel void clearSixBuffers(__global int* restrict buffer1, unsigned long size1, __global int* restrict buffer2, unsigned long size2, __global int* restrict buffer3, unsigned long size3, __global int* restrict buffer4, unsigned long size4, __global int* restrict buffer5, unsigned long size5, __global int* restrict buffer6, unsigned long size6) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);

--- a/platforms/opencl/src/kernels/utilities.cl
+++ b/platforms/opencl/src/kernels/utilities.cl
@@ -2,23 +2,23 @@
  * Fill a buffer with 0.
  */
 
-__kernel void clearBuffer(__global int* restrict buffer, int size) {
-    int index = get_global_id(0);
+__kernel void clearBuffer(__global int* restrict buffer, mm_ulong size) {
+    mm_ulong index = get_global_id(0);
     __global int4* buffer4 = (__global int4*) buffer;
-    int sizeDiv4 = size/4;
+    mm_ulong sizeDiv4 = size/4;
     while (index < sizeDiv4) {
         buffer4[index] = (int4) 0;
         index += get_global_size(0);
     }
     if (get_global_id(0) == 0)
-        for (int i = sizeDiv4*4; i < size; i++)
+        for (mm_ulong i = sizeDiv4*4; i < size; i++)
             buffer[i] = 0;
 }
 
 /**
  * Fill two buffers with 0.
  */
-__kernel void clearTwoBuffers(__global int* restrict buffer1, int size1, __global int* restrict buffer2, int size2) {
+__kernel void clearTwoBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
 }
@@ -26,7 +26,7 @@ __kernel void clearTwoBuffers(__global int* restrict buffer1, int size1, __globa
 /**
  * Fill three buffers with 0.
  */
-__kernel void clearThreeBuffers(__global int* restrict buffer1, int size1, __global int* restrict buffer2, int size2, __global int* restrict buffer3, int size3) {
+__kernel void clearThreeBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);
@@ -35,7 +35,7 @@ __kernel void clearThreeBuffers(__global int* restrict buffer1, int size1, __glo
 /**
  * Fill four buffers with 0.
  */
-__kernel void clearFourBuffers(__global int* restrict buffer1, int size1, __global int* restrict buffer2, int size2, __global int* restrict buffer3, int size3, __global int* restrict buffer4, int size4) {
+__kernel void clearFourBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3, __global int* restrict buffer4, mm_ulong size4) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);
@@ -45,7 +45,7 @@ __kernel void clearFourBuffers(__global int* restrict buffer1, int size1, __glob
 /**
  * Fill five buffers with 0.
  */
-__kernel void clearFiveBuffers(__global int* restrict buffer1, int size1, __global int* restrict buffer2, int size2, __global int* restrict buffer3, int size3, __global int* restrict buffer4, int size4, __global int* restrict buffer5, int size5) {
+__kernel void clearFiveBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3, __global int* restrict buffer4, mm_ulong size4, __global int* restrict buffer5, mm_ulong size5) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);
@@ -56,7 +56,7 @@ __kernel void clearFiveBuffers(__global int* restrict buffer1, int size1, __glob
 /**
  * Fill six buffers with 0.
  */
-__kernel void clearSixBuffers(__global int* restrict buffer1, int size1, __global int* restrict buffer2, int size2, __global int* restrict buffer3, int size3, __global int* restrict buffer4, int size4, __global int* restrict buffer5, int size5, __global int* restrict buffer6, int size6) {
+__kernel void clearSixBuffers(__global int* restrict buffer1, mm_ulong size1, __global int* restrict buffer2, mm_ulong size2, __global int* restrict buffer3, mm_ulong size3, __global int* restrict buffer4, mm_ulong size4, __global int* restrict buffer5, mm_ulong size5, __global int* restrict buffer6, mm_ulong size6) {
     clearBuffer(buffer1, size1);
     clearBuffer(buffer2, size2);
     clearBuffer(buffer3, size3);

--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
@@ -1175,7 +1175,7 @@ double CommonCalcAmoebaMultipoleForceKernel::execute(ContextImpl& context, bool 
 
         // Reciprocal space calculation.
         
-        unsigned int maxTiles = nb.getInteractingTiles().getSize();
+        long long maxTiles = nb.getInteractingTiles().getSize();
         pmeTransformMultipolesKernel->execute(cc.getNumAtoms());
         pmeSpreadFixedMultipolesKernel->execute(cc.getNumAtoms());
         if (useFixedPointChargeSpreading())
@@ -1255,7 +1255,7 @@ void CommonCalcAmoebaMultipoleForceKernel::computeInducedField() {
     computeInducedFieldKernel->setArg(7, numTileIndices);
     if (usePME) {
         setPeriodicBoxArgs(cc, computeInducedFieldKernel, 10);
-        computeInducedFieldKernel->setArg(15, (int) nb.getInteractingTiles().getSize());
+        computeInducedFieldKernel->setArg(15, nb.getInteractingTiles().getSize());
     }
     cc.clearBuffer(inducedField);
     cc.clearBuffer(inducedFieldPolar);

--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
@@ -1083,8 +1083,8 @@ double CommonCalcAmoebaMultipoleForceKernel::execute(ContextImpl& context, bool 
     // Compute the lab frame moments.
 
     computeMomentsKernel->execute(cc.getNumAtoms());
-    int startTileIndex = nb.getStartTileIndex();
-    int numTileIndices = nb.getNumTiles();
+    long long startTileIndex = nb.getStartTileIndex();
+    long long numTileIndices = nb.getNumTiles();
     int numForceThreadBlocks = nb.getNumForceThreadBlocks();
     electrostaticsKernel->setArg(7, startTileIndex);
     electrostaticsKernel->setArg(8, numTileIndices);
@@ -1248,8 +1248,8 @@ double CommonCalcAmoebaMultipoleForceKernel::execute(ContextImpl& context, bool 
 
 void CommonCalcAmoebaMultipoleForceKernel::computeInducedField() {
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
-    int startTileIndex = nb.getStartTileIndex();
-    int numTileIndices = nb.getNumTiles();
+    long long startTileIndex = nb.getStartTileIndex();
+    long long numTileIndices = nb.getNumTiles();
     int numForceThreadBlocks = nb.getNumForceThreadBlocks();
     computeInducedFieldKernel->setArg(6, startTileIndex);
     computeInducedFieldKernel->setArg(7, numTileIndices);
@@ -1954,8 +1954,8 @@ void CommonCalcAmoebaGeneralizedKirkwoodForceKernel::computeBornRadii(ComputeArr
 
 void CommonCalcAmoebaGeneralizedKirkwoodForceKernel::finishComputation() {
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
-    int startTileIndex = nb.getStartTileIndex();
-    int numTileIndices = nb.getNumTiles();
+    long long startTileIndex = nb.getStartTileIndex();
+    long long numTileIndices = nb.getNumTiles();
     int numForceThreadBlocks = nb.getNumForceThreadBlocks();
     
     // Compute the GK force.
@@ -2282,8 +2282,8 @@ void CommonCalcAmoebaWcaDispersionForceKernel::initialize(const System& system, 
 double CommonCalcAmoebaWcaDispersionForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
     ContextSelector selector(cc);
     NonbondedUtilities& nb = cc.getNonbondedUtilities();
-    int startTileIndex = nb.getStartTileIndex();
-    int numTileIndices = nb.getNumTiles();
+    long long startTileIndex = nb.getStartTileIndex();
+    long long numTileIndices = nb.getNumTiles();
     int numForceThreadBlocks = nb.getNumForceThreadBlocks();
     forceKernel->setArg(3, startTileIndex);
     forceKernel->setArg(4, numTileIndices);
@@ -3187,7 +3187,7 @@ double CommonCalcHippoNonbondedForceKernel::execute(ContextImpl& context, bool i
         // These kernels can't be compiled in initialize(), because the nonbonded utilities object
         // has not yet been initialized then.
 
-        maxTiles = (nb.getUseCutoff() ? nb.getInteractingTiles().getSize() : cc.getNumAtomBlocks()*(cc.getNumAtomBlocks()+1)/2);
+        maxTiles = (nb.getUseCutoff() ? nb.getInteractingTiles().getSize() : cc.getNumAtomBlocks()*((long long)cc.getNumAtomBlocks()+1)/2);
         createFieldKernel(CommonAmoebaKernelSources::hippoFixedField, {&coreCharge, &valenceCharge, &alpha, &labDipoles, &labQuadrupoles[0],
                 &labQuadrupoles[1], &labQuadrupoles[2], &labQuadrupoles[3], &labQuadrupoles[4]}, field, fixedFieldKernel,
                 fixedFieldExceptionKernel, exceptionScales[1]);

--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.h
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.h
@@ -503,7 +503,8 @@ protected:
     void addTorquesToForces();
     void createFieldKernel(const std::string& interactionSrc, std::vector<ComputeArray*> params, ComputeArray& fieldBuffer,
         ComputeKernel& kernel, ComputeKernel& exceptionKernel, ComputeArray& exceptionScale);
-    int numParticles, maxExtrapolationOrder, maxTiles, fieldThreadBlockSize;
+    int numParticles, maxExtrapolationOrder, fieldThreadBlockSize;
+    long long maxTiles;
     int gridSizeX, gridSizeY, gridSizeZ;
     int dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ;
     double pmeAlpha, dpmeAlpha, cutoff;

--- a/plugins/amoeba/platforms/common/src/kernels/amoebaGk.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/amoebaGk.cc
@@ -105,7 +105,7 @@ KERNEL void computeBornSum(GLOBAL mm_ulong* RESTRICT bornSum, GLOBAL const real4
         AtomData1 data;
         data.bornSum = 0;
         if (pos < end) {
-            y = (int) floor(NUM_BLOCKS+0.5f-sqrt((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+            y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
             x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
@@ -239,7 +239,7 @@ KERNEL void computeGKForces(
         const unsigned int tbx = LOCAL_ID - tgx;
         int x, y;
         if (pos < end) {
-            y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+            y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
             x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
@@ -509,7 +509,7 @@ KERNEL void computeChainRuleForce(
         const unsigned int tbx = LOCAL_ID - tgx;
         int x, y;
         if (pos < end) {
-            y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+            y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
             x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
@@ -808,7 +808,7 @@ KERNEL void computeEDiffForce(
         // Extract the coordinates of this tile.
 
         int x, y;
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/amoebaGk.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/amoebaGk.cc
@@ -90,11 +90,11 @@ DEVICE real computeBornSumOneInteraction(AtomData1 atom1, AtomData1 atom2) {
  * Compute the Born sum.
  */
 KERNEL void computeBornSum(GLOBAL mm_ulong* RESTRICT bornSum, GLOBAL const real4* RESTRICT posq,
-        GLOBAL const float2* RESTRICT params, unsigned int numTiles) {
+        GLOBAL const float2* RESTRICT params, mm_long numTiles) {
     unsigned int totalWarps = (GLOBAL_SIZE)/TILE_SIZE;
     unsigned int warp = (GLOBAL_ID)/TILE_SIZE;
-    unsigned int pos = (unsigned int) (warp*(mm_long)numTiles/totalWarps);
-    unsigned int end = (unsigned int) ((warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long pos = (warp*(mm_long)numTiles/totalWarps);
+    mm_long end = ((warp+1)*(mm_long)numTiles/totalWarps);
     unsigned int lasty = 0xFFFFFFFF;
     LOCAL AtomData1 localData[BORN_SUM_THREAD_BLOCK_SIZE];
     do {
@@ -106,10 +106,10 @@ KERNEL void computeBornSum(GLOBAL mm_ulong* RESTRICT bornSum, GLOBAL const real4
         data.bornSum = 0;
         if (pos < end) {
             y = (int) floor(NUM_BLOCKS+0.5f-sqrt((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
-                x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+                x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             }
             unsigned int atom1 = x*TILE_SIZE + tgx;
             data.pos = trimTo3(posq[atom1]);
@@ -222,14 +222,14 @@ inline DEVICE AtomData2 loadAtomData2(int atom, GLOBAL const real4* RESTRICT pos
  */
 KERNEL void computeGKForces(
         GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mm_ulong* RESTRICT torqueBuffers, GLOBAL mixed* RESTRICT energyBuffer,
-        GLOBAL const real4* RESTRICT posq, unsigned int startTileIndex, unsigned int numTileIndices, GLOBAL const real* RESTRICT labFrameDipole,
+        GLOBAL const real4* RESTRICT posq, mm_long startTileIndex, mm_long numTileIndices, GLOBAL const real* RESTRICT labFrameDipole,
         GLOBAL const real* RESTRICT labFrameQuadrupole, GLOBAL const real* RESTRICT inducedDipole, GLOBAL const real* RESTRICT inducedDipolePolar,
         GLOBAL const real* RESTRICT bornRadii, GLOBAL mm_ulong* RESTRICT bornForce) {
     unsigned int totalWarps = (GLOBAL_SIZE)/TILE_SIZE;
     unsigned int warp = (GLOBAL_ID)/TILE_SIZE;
-    const unsigned int numTiles = numTileIndices;
-    unsigned int pos = (unsigned int) (startTileIndex+warp*(mm_long)numTiles/totalWarps);
-    unsigned int end = (unsigned int) (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = (startTileIndex+warp*(mm_long)numTiles/totalWarps);
+    mm_long end = (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
     mixed energy = 0;
     LOCAL AtomData2 localData[GK_FORCE_THREAD_BLOCK_SIZE];
     
@@ -240,10 +240,10 @@ KERNEL void computeGKForces(
         int x, y;
         if (pos < end) {
             y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
-                x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+                x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             }
             unsigned int atom1 = x*TILE_SIZE + tgx;
             AtomData2 data = loadAtomData2(atom1, posq, labFrameDipole, labFrameQuadrupole, inducedDipole, inducedDipolePolar, bornRadii);
@@ -494,13 +494,13 @@ DEVICE void computeBornChainRuleInteraction(AtomData3 atom1, AtomData3 atom2, re
  * Compute chain rule terms.
  */
 KERNEL void computeChainRuleForce(
-        GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL const real4* RESTRICT posq, unsigned int startTileIndex, unsigned int numTileIndices,
+        GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL const real4* RESTRICT posq, mm_long startTileIndex, mm_long numTileIndices,
         GLOBAL const float2* RESTRICT params, GLOBAL const real* RESTRICT bornRadii, GLOBAL const mm_long* RESTRICT bornForce) {
     unsigned int totalWarps = (GLOBAL_SIZE)/TILE_SIZE;
     unsigned int warp = (GLOBAL_ID)/TILE_SIZE;
-    const unsigned int numTiles = numTileIndices;
-    unsigned int pos = startTileIndex+warp*numTiles/totalWarps;
-    unsigned int end = startTileIndex+(warp+1)*numTiles/totalWarps;
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = startTileIndex+warp*numTiles/totalWarps;
+    mm_long end = startTileIndex+(warp+1)*numTiles/totalWarps;
     LOCAL AtomData3 localData[CHAIN_RULE_THREAD_BLOCK_SIZE];
     
     do {
@@ -510,10 +510,10 @@ KERNEL void computeChainRuleForce(
         int x, y;
         if (pos < end) {
             y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
-                x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+                x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             }
             unsigned int atom1 = x*TILE_SIZE + tgx;
             AtomData3 data = loadAtomData3(atom1, posq, params, bornRadii, bornForce);
@@ -640,7 +640,7 @@ DEVICE float computePScaleFactor(uint2 covalent, unsigned int polarizationGroup,
 KERNEL void computeEDiffForce(
         GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mm_ulong* RESTRICT torqueBuffers, GLOBAL mixed* RESTRICT energyBuffer,
         GLOBAL const real4* RESTRICT posq, GLOBAL const uint2* RESTRICT covalentFlags, GLOBAL const unsigned int* RESTRICT polarizationGroupFlags,
-        GLOBAL const int2* RESTRICT exclusionTiles, unsigned int startTileIndex, unsigned int numTileIndices,
+        GLOBAL const int2* RESTRICT exclusionTiles, mm_long startTileIndex, mm_long numTileIndices,
         GLOBAL const real* RESTRICT labFrameDipole, GLOBAL const real* RESTRICT labFrameQuadrupole, GLOBAL const real* RESTRICT inducedDipole,
         GLOBAL const real* RESTRICT inducedDipolePolar, GLOBAL const real* RESTRICT inducedDipoleS, GLOBAL const real* RESTRICT inducedDipolePolarS,
         GLOBAL const float2* RESTRICT dampingAndThole) {
@@ -653,9 +653,9 @@ KERNEL void computeEDiffForce(
 
     // First loop: process tiles that contain exclusions.
     
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -796,9 +796,9 @@ KERNEL void computeEDiffForce(
 
     // Second loop: tiles without exclusions (by enumerating all of them, since there's no cutoff).
 
-    const unsigned int numTiles = numTileIndices;
-    int pos = startTileIndex+warp*numTiles/totalWarps;
-    int end = startTileIndex+(warp+1)*numTiles/totalWarps;
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = startTileIndex+warp*numTiles/totalWarps;
+    mm_long end = startTileIndex+(warp+1)*numTiles/totalWarps;
     int skipBase = 0;
     int currentSkipIndex = tbx;
     LOCAL volatile int skipTiles[EDIFF_THREAD_BLOCK_SIZE];
@@ -809,10 +809,10 @@ KERNEL void computeEDiffForce(
 
         int x, y;
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -822,7 +822,7 @@ KERNEL void computeEDiffForce(
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/plugins/amoeba/platforms/common/src/kernels/amoebaWcaForce.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/amoebaWcaForce.cc
@@ -194,12 +194,12 @@ DEVICE void computeOneInteraction(AtomData atom1, AtomData atom2, real rmixo, re
  * Compute WCA interaction.
  */
 KERNEL void computeWCAForce(GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mixed* RESTRICT energyBuffer,
-        GLOBAL const real4* RESTRICT posq, unsigned int startTileIndex, unsigned int numTileIndices, GLOBAL const float2* RESTRICT radiusEpsilon) {
+        GLOBAL const real4* RESTRICT posq, mm_long startTileIndex, mm_long numTileIndices, GLOBAL const float2* RESTRICT radiusEpsilon) {
     unsigned int totalWarps = GLOBAL_SIZE/TILE_SIZE;
     unsigned int warp = GLOBAL_ID/TILE_SIZE;
-    const unsigned int numTiles = numTileIndices;
-    unsigned int pos = (unsigned int) (startTileIndex+warp*(mm_long)numTiles/totalWarps);
-    unsigned int end = (unsigned int) (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = (startTileIndex+warp*(mm_long)numTiles/totalWarps);
+    mm_long end = (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
     mixed energy = 0;
     LOCAL AtomData localData[THREAD_BLOCK_SIZE];
     
@@ -213,10 +213,10 @@ KERNEL void computeWCAForce(GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mixed
         AtomData data;
         if (pos < end) {
             y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);
-                x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+                x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             }
             unsigned int atom1 = x*TILE_SIZE + tgx;
             data = loadAtomData(atom1, posq, radiusEpsilon);

--- a/plugins/amoeba/platforms/common/src/kernels/amoebaWcaForce.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/amoebaWcaForce.cc
@@ -212,7 +212,7 @@ KERNEL void computeWCAForce(GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mixed
         int x, y;
         AtomData data;
         if (pos < end) {
-            y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+            y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
             x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
             if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
                 y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/hippoComputeField.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/hippoComputeField.cc
@@ -72,8 +72,8 @@ KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigne
 
     // First loop: process tiles that contain exclusions.
     
-    const mm_long firstExclusionTile = warp*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
-    const mm_long lastExclusionTile = (warp+1)*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
+    const mm_long firstExclusionTile = (mm_long)warp*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
+    const mm_long lastExclusionTile = ((mm_long)warp+1)*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
     for (mm_long tile = firstExclusionTile; tile < lastExclusionTile; tile++) {
         const int2 tileIndices = exclusionTiles[tile];
         const unsigned int x = tileIndices.x;

--- a/plugins/amoeba/platforms/common/src/kernels/hippoComputeField.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/hippoComputeField.cc
@@ -219,7 +219,7 @@ KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigne
                               0.5f*periodicBoxSize.y-blockSizeX.y >= CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*tile));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*tile));
         x = (y-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/hippoComputeField.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/hippoComputeField.cc
@@ -57,11 +57,11 @@ typedef struct {
 KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigned int* RESTRICT exclusions,
         GLOBAL const int2* RESTRICT exclusionTiles, GLOBAL mm_ulong* RESTRICT fieldBuffers,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const unsigned int* RESTRICT interactingAtoms
 #else
-        unsigned int numTiles
+        mm_long numTiles
 #endif
         PARAMETER_ARGUMENTS) {
     const unsigned int totalWarps = (GLOBAL_SIZE)/TILE_SIZE;
@@ -72,9 +72,9 @@ KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigne
 
     // First loop: process tiles that contain exclusions.
     
-    const unsigned int firstExclusionTile = warp*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
-    const unsigned int lastExclusionTile = (warp+1)*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
-    for (int tile = firstExclusionTile; tile < lastExclusionTile; tile++) {
+    const mm_long firstExclusionTile = warp*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
+    const mm_long lastExclusionTile = (warp+1)*NUM_TILES_WITH_EXCLUSIONS/totalWarps;
+    for (mm_long tile = firstExclusionTile; tile < lastExclusionTile; tile++) {
         const int2 tileIndices = exclusionTiles[tile];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -189,14 +189,14 @@ KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigne
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    unsigned int numTiles = interactionCount[0];
+    mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int tile = (int) (warp*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : (long)numTiles)/totalWarps);
-    int end = (int) ((warp+1)*(numTiles > maxTiles ? NUM_BLOCKS*((mm_long)NUM_BLOCKS+1)/2 : (long)numTiles)/totalWarps);
+    mm_long tile = (warp*numTiles/totalWarps);
+    mm_long end = (warp+1)*numTiles/totalWarps;
 #else
-    int tile = (int) (warp*(mm_long)numTiles/totalWarps);
-    int end = (int) ((warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long tile = (warp*numTiles/totalWarps);
+    mm_long end = ((warp+1)*numTiles/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -220,10 +220,10 @@ KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigne
                               0.5f*periodicBoxSize.z-blockSizeX.z >= CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*tile));
-        x = (tile-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (y-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (tile-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (y-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -233,7 +233,7 @@ KERNEL void computeField(GLOBAL const real4* RESTRICT posq, GLOBAL const unsigne
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/plugins/amoeba/platforms/common/src/kernels/hippoNonbonded.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/hippoNonbonded.cc
@@ -45,13 +45,13 @@ static __inline__ __device__ mm_long real_shfl(mm_long var, int srcLane) {
 
 KERNEL void computeNonbonded(
         GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mixed* RESTRICT energyBuffer, GLOBAL const real4* RESTRICT posq, GLOBAL const unsigned int* RESTRICT exclusions,
-        GLOBAL const int2* RESTRICT exclusionTiles, unsigned int startTileIndex, mm_ulong numTileIndices
+        GLOBAL const int2* RESTRICT exclusionTiles, mm_long startTileIndex, mm_long numTileIndices
 #ifdef USE_CUTOFF
-        , GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        , GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const real4* RESTRICT blockSize, GLOBAL const unsigned int* RESTRICT interactingAtoms
 #ifdef __CUDA_ARCH__
-        , unsigned int maxSinglePairs, GLOBAL const int2* RESTRICT singlePairs
+        , mm_long maxSinglePairs, GLOBAL const int2* RESTRICT singlePairs
 #endif
 #endif
         PARAMETER_ARGUMENTS) {
@@ -68,9 +68,9 @@ KERNEL void computeNonbonded(
 
     // First loop: process tiles that contain exclusions.
 
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -231,15 +231,15 @@ KERNEL void computeNonbonded(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    const unsigned int numTiles = interactionCount[0];
+    const mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (numTiles > maxTiles ? startTileIndex+warp*(mm_long)numTileIndices/totalWarps : warp*(mm_long)numTiles/totalWarps);
-    int end = (int) (numTiles > maxTiles ? startTileIndex+(warp+1)*(mm_long)numTileIndices/totalWarps : (warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long pos = warp*(mm_long)numTiles/totalWarps;
+    mm_long end = (warp+1)*(mm_long)numTiles/totalWarps;
 #else
-    const unsigned int numTiles = numTileIndices;
-    int pos = (int) (startTileIndex+warp*(mm_long)numTiles/totalWarps);
-    int end = (int) (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = (startTileIndex+warp*(mm_long)numTiles/totalWarps);
+    mm_long end = (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -266,10 +266,10 @@ KERNEL void computeNonbonded(
                               0.5f*periodicBoxSize.z-blockSizeX.z >= MAX_CUTOFF);
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -279,7 +279,7 @@ KERNEL void computeNonbonded(
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/plugins/amoeba/platforms/common/src/kernels/hippoNonbonded.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/hippoNonbonded.cc
@@ -265,7 +265,7 @@ KERNEL void computeNonbonded(
                               0.5f*periodicBoxSize.y-blockSizeX.y >= MAX_CUTOFF &&
                               0.5f*periodicBoxSize.z-blockSizeX.z >= MAX_CUTOFF);
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/multipoleElectrostatics.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/multipoleElectrostatics.cc
@@ -514,7 +514,7 @@ KERNEL void computeElectrostatics(
 #ifdef USE_CUTOFF
         x = tiles[pos];
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/multipoleElectrostatics.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/multipoleElectrostatics.cc
@@ -375,10 +375,10 @@ DEVICE void computeOneInteraction(AtomData* atom1, LOCAL_ARG AtomData* atom2, bo
 KERNEL void computeElectrostatics(
         GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL mm_ulong* RESTRICT torqueBuffers, GLOBAL mixed* RESTRICT energyBuffer,
         GLOBAL const real4* RESTRICT posq, GLOBAL const uint2* RESTRICT covalentFlags, GLOBAL const unsigned int* RESTRICT polarizationGroupFlags,
-        GLOBAL const int2* RESTRICT exclusionTiles, unsigned int startTileIndex, unsigned int numTileIndices,
+        GLOBAL const int2* RESTRICT exclusionTiles, mm_long startTileIndex, mm_long numTileIndices,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const unsigned int* RESTRICT interactingAtoms,
 #endif
         GLOBAL const real* RESTRICT sphericalDipole, GLOBAL const real* RESTRICT sphericalQuadrupole, GLOBAL const real* RESTRICT inducedDipole,
@@ -392,9 +392,9 @@ KERNEL void computeElectrostatics(
 
     // First loop: process tiles that contain exclusions.
     
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -489,15 +489,15 @@ KERNEL void computeElectrostatics(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    const unsigned int numTiles = interactionCount[0];
+    const mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (numTiles > maxTiles ? startTileIndex+warp*(mm_long)numTileIndices/totalWarps : warp*(mm_long)numTiles/totalWarps);
-    int end = (int) (numTiles > maxTiles ? startTileIndex+(warp+1)*(mm_long)numTileIndices/totalWarps : (warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long pos = warp*(mm_long)numTiles/totalWarps;
+    mm_long end = (warp+1)*(mm_long)numTiles/totalWarps;
 #else
-    const unsigned int numTiles = numTileIndices;
-    int pos = (int) (startTileIndex+warp*(mm_long)numTiles/totalWarps);
-    int end = (int) (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = (startTileIndex+warp*(mm_long)numTiles/totalWarps);
+    mm_long end = (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -515,10 +515,10 @@ KERNEL void computeElectrostatics(
         x = tiles[pos];
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -528,7 +528,7 @@ KERNEL void computeElectrostatics(
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/plugins/amoeba/platforms/common/src/kernels/multipoleFixedField.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/multipoleFixedField.cc
@@ -439,10 +439,10 @@ DEVICE float computePScaleFactor(uint2 covalent, unsigned int polarizationGroup,
 KERNEL void computeFixedField(
         GLOBAL mm_ulong* RESTRICT fieldBuffers, GLOBAL mm_ulong* RESTRICT fieldPolarBuffers, GLOBAL const real4* RESTRICT posq,
         GLOBAL const uint2* RESTRICT covalentFlags, GLOBAL const unsigned int* RESTRICT polarizationGroupFlags, GLOBAL const int2* RESTRICT exclusionTiles,
-        unsigned int startTileIndex, unsigned int numTileIndices,
+        mm_long startTileIndex, mm_long numTileIndices,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
-        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, GLOBAL const real4* RESTRICT blockCenter,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
         GLOBAL const unsigned int* RESTRICT interactingAtoms,
 #elif defined USE_GK
         GLOBAL const real* RESTRICT bornRadii, GLOBAL mm_ulong* RESTRICT gkFieldBuffers,
@@ -456,9 +456,9 @@ KERNEL void computeFixedField(
 
     // First loop: process tiles that contain exclusions.
     
-    const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*((mm_long)LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
         const unsigned int y = tileIndices.y;
@@ -595,15 +595,15 @@ KERNEL void computeFixedField(
     // of them (no cutoff).
 
 #ifdef USE_CUTOFF
-    const unsigned int numTiles = interactionCount[0];
+    const mm_long numTiles = interactionCount[0];
     if (numTiles > maxTiles)
         return; // There wasn't enough memory for the neighbor list.
-    int pos = (int) (numTiles > maxTiles ? startTileIndex+warp*(mm_long)numTileIndices/totalWarps : warp*(mm_long)numTiles/totalWarps);
-    int end = (int) (numTiles > maxTiles ? startTileIndex+(warp+1)*(mm_long)numTileIndices/totalWarps : (warp+1)*(mm_long)numTiles/totalWarps);
+    mm_long pos = warp*(mm_long)numTiles/totalWarps;
+    mm_long end = (warp+1)*(mm_long)numTiles/totalWarps;
 #else
-    const unsigned int numTiles = numTileIndices;
-    int pos = (int) (startTileIndex+warp*(mm_long)numTiles/totalWarps);
-    int end = (int) (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
+    const mm_long numTiles = numTileIndices;
+    mm_long pos = (startTileIndex+warp*(mm_long)numTiles/totalWarps);
+    mm_long end = (startTileIndex+(warp+1)*(mm_long)numTiles/totalWarps);
 #endif
     int skipBase = 0;
     int currentSkipIndex = tbx;
@@ -621,10 +621,10 @@ KERNEL void computeFixedField(
         x = tiles[pos];
 #else
         y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
-        x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+        x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);
-            x = (pos-y*NUM_BLOCKS+y*(y+1)/2);
+            x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         }
 
         // Skip over tiles that have exclusions, since they were already processed.
@@ -634,7 +634,7 @@ KERNEL void computeFixedField(
             SYNC_WARPS;
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[LOCAL_ID] = tile.x + tile.y*NUM_BLOCKS - tile.y*(tile.y+1)/2;
+                skipTiles[LOCAL_ID] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
             }
             else
                 skipTiles[LOCAL_ID] = end;

--- a/plugins/amoeba/platforms/common/src/kernels/multipoleFixedField.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/multipoleFixedField.cc
@@ -620,7 +620,7 @@ KERNEL void computeFixedField(
 #ifdef USE_CUTOFF
         x = tiles[pos];
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/multipoleInducedField.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/multipoleInducedField.cc
@@ -498,7 +498,7 @@ KERNEL void computeInducedField(
 #ifdef USE_CUTOFF
         x = tiles[pos];
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/pmeMultipoleElectrostatics.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/pmeMultipoleElectrostatics.cc
@@ -581,7 +581,7 @@ KERNEL void computeElectrostatics(
 #ifdef USE_CUTOFF
         x = tiles[pos];
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(mm_long)y*NUM_BLOCKS+y*((mm_long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/amoeba/platforms/common/src/kernels/pmeMultipoleElectrostatics.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/pmeMultipoleElectrostatics.cc
@@ -456,8 +456,8 @@ KERNEL void computeElectrostatics(
 
     // First loop: process tiles that contain exclusions.
     
-    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long firstExclusionTile = FIRST_EXCLUSION_TILE+(mm_long)warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const mm_long lastExclusionTile = FIRST_EXCLUSION_TILE+((mm_long)warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     for (mm_long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;

--- a/plugins/amoeba/platforms/common/src/kernels/pmeMultipoleElectrostatics.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/pmeMultipoleElectrostatics.cc
@@ -441,9 +441,9 @@ KERNEL void computeElectrostatics(
         GLOBAL const real4* RESTRICT posq, GLOBAL const uint2* RESTRICT covalentFlags, GLOBAL const unsigned int* RESTRICT polarizationGroupFlags,
         GLOBAL const int2* RESTRICT exclusionTiles, mm_long startTileIndex, mm_long numTileIndices,
 #ifdef USE_CUTOFF
-        GLOBAL const int* RESTRICT tiles, GLOBAL const unsigned int* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
+        GLOBAL const int* RESTRICT tiles, GLOBAL const mm_long* RESTRICT interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
         real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, mm_long maxTiles, GLOBAL const real4* RESTRICT blockCenter,
-        GLOBAL const mm_long* RESTRICT interactingAtoms,
+        GLOBAL const unsigned int* RESTRICT interactingAtoms,
 #endif
         GLOBAL const real* RESTRICT sphericalDipole, GLOBAL const real* RESTRICT sphericalQuadrupole, GLOBAL const real* RESTRICT inducedDipole,
         GLOBAL const real* RESTRICT inducedDipolePolar, GLOBAL const float2* RESTRICT dampingAndThole) {

--- a/plugins/amoeba/platforms/cuda/src/kernels/multipoleInducedField.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/multipoleInducedField.cu
@@ -373,8 +373,8 @@ extern "C" __global__ void computeInducedField(
 
     // First loop: process tiles that contain exclusions.
     
-    const long long firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
-    const long long lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const long long firstExclusionTile = FIRST_EXCLUSION_TILE+(long long)warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
+    const long long lastExclusionTile = FIRST_EXCLUSION_TILE+((long long)warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     for (long long pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
         const int2 tileIndices = exclusionTiles[pos];
         const unsigned int x = tileIndices.x;
@@ -483,7 +483,7 @@ extern "C" __global__ void computeInducedField(
         while (skipTiles[tbx+TILE_SIZE-1] < pos) {
             if (skipBase+tgx < NUM_TILES_WITH_EXCLUSIONS) {
                 int2 tile = exclusionTiles[skipBase+tgx];
-                skipTiles[threadIdx.x] = tile.x + (mm_long)tile.y*NUM_BLOCKS - tile.y*((mm_long)tile.y+1)/2;
+                skipTiles[threadIdx.x] = tile.x + (long long)tile.y*NUM_BLOCKS - tile.y*((long long)tile.y+1)/2;
             }
             else
                 skipTiles[threadIdx.x] = end;

--- a/plugins/amoeba/platforms/cuda/src/kernels/multipoleInducedField.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/multipoleInducedField.cu
@@ -471,7 +471,7 @@ extern "C" __global__ void computeInducedField(
 #ifdef USE_CUTOFF
         x = tiles[pos];
 #else
-        y = (int) floor(NUM_BLOCKS+0.5f-SQRT((NUM_BLOCKS+0.5f)*(NUM_BLOCKS+0.5f)-2*pos));
+        y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*pos));
         x = (pos-(long long)y*NUM_BLOCKS+y*((long long)y+1)/2);
         if (x < y || x >= NUM_BLOCKS) { // Occasionally happens due to roundoff error.
             y += (x < y ? -1 : 1);

--- a/plugins/drude/openmmapi/src/DrudeLangevinIntegrator.cpp
+++ b/plugins/drude/openmmapi/src/DrudeLangevinIntegrator.cpp
@@ -98,6 +98,7 @@ void DrudeLangevinIntegrator::setDrudeFriction(double coeff) {
 }
 
 void DrudeLangevinIntegrator::cleanup() {
+    context = nullptr;
     kernel = Kernel();
 }
 

--- a/plugins/drude/openmmapi/src/DrudeSCFIntegrator.cpp
+++ b/plugins/drude/openmmapi/src/DrudeSCFIntegrator.cpp
@@ -80,6 +80,7 @@ void DrudeSCFIntegrator::setMinimizationErrorTolerance(double tol) {
 }
 
 void DrudeSCFIntegrator::cleanup() {
+    context = nullptr;
     kernel = Kernel();
 }
 

--- a/plugins/rpmd/openmmapi/src/RPMDIntegrator.cpp
+++ b/plugins/rpmd/openmmapi/src/RPMDIntegrator.cpp
@@ -72,6 +72,7 @@ void RPMDIntegrator::initialize(ContextImpl& contextRef) {
 }
 
 void RPMDIntegrator::cleanup() {
+    context = nullptr;
     kernel = Kernel();
 }
 


### PR DESCRIPTION
This is meant to address #3511 , where the number of interacting tiles exceeds `INT_MAX`. This also makes it possible to run regular simulations (which do have cutoff) with >67M atoms. I tried to do my best to be as thorough as possible and not miss any counters project-wise, but my main focus was the `NonbondedForce`. I still have a few tests to run to verify that it works correctly for _very_ large systems, but for the most part (i think) the job is done.

Here's what i did:

1. Any counter representing the number of tiles needed to be changed to 64-bit. Most notably, the `interactionCount`.
2. Sometimes, array sizes exceed `INT_MAX`. So, functions like `uploadSubArray` and `clearBuffer` need to take 64-bit arguments.
3. I added a `ComputeContext::synchronize()` method which proved useful when debugging, so i decided to leave that in.
4. float32's mantissa is only 22 bits, so the formula for computing tile coords based on its index when there's no cutoff might break as the amount of atoms approaches 2^22. So changed it to use double precision.

Some observations that i made:

1. OpenCL kernels have argument type-checking, which helped a lot in catching subtle type mismatches. A shame CUDA doesn't have anything like that (or at least i couldn't find a way to do it)
2. There seems to be a lot of code duplication. For example, the exact line `y = (int) floor(NUM_BLOCKS+0.5-sqrt((NUM_BLOCKS+0.5)*(NUM_BLOCKS+0.5)-2*tile))` appears in the code base 22 times, and one more time with `tile` instead of `pos`. Is there any infrastructure that could help unify all those forces? Because it would be far more convenient to make changes in just one place, not 23 :)
3. Im not very well versed in OpenCL, but i noted that there is a flag `SUPPORTS_64_BIT_ATOMICS` and i do `ATOMIC_ADD` on `interactionCount` without checking that macro. Should i not have done it? Do i need to come up with a workaround?
4. It takes far too much time to track down an integer overflow in GPU code. Are there any tools that could help me do that in future?
