### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - name: Linux CUDA 10.0
             os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
             cuda-version: "10.0"
             OPENCL: false
             CMAKE_FLAGS: |
@@ -51,7 +51,7 @@ jobs:
 
           - name: Linux CUDA 11.2
             os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
             OPENCL: false
             cuda-version: "11.2"
             CMAKE_FLAGS: |
@@ -72,7 +72,7 @@ jobs:
 
           - name: Linux AMD OpenCL
             os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
             OPENCL: true
             cuda-version: ""
             CMAKE_FLAGS: |
@@ -90,9 +90,9 @@ jobs:
               -DOPENCL_INCLUDE_DIR=${GITHUB_WORKSPACE}/AMDAPPSDK/include \
               -DOPENCL_LIBRARY=${GITHUB_WORKSPACE}/AMDAPPSDK/lib/x86_64/libOpenCL.so \
 
-          - name: Linux CPU Python 3.6 with static lib
+          - name: Linux CPU Python 3.7 with static lib
             os: ubuntu-latest
-            python-version: "3.6"
+            python-version: "3.7"
             OPENCL: false
             cuda-version: ""
             CC: $CCACHE/clang
@@ -102,8 +102,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.6 with condaforge compilers
-            python-version: "3.6"
+          - name: Linux CPU Python 3.7 with condaforge compilers
+            python-version: "3.7"
             os: ubuntu-latest
             OPENCL: false
             cuda-version: ""
@@ -112,8 +112,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.6
-            python-version: "3.6"
+          - name: Linux CPU Python 3.7
+            python-version: "3.7"
             os: ubuntu-latest
             OPENCL: false
             cuda-version: ""
@@ -121,8 +121,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.9
-            python-version: "3.9"
+          - name: Linux CPU Python 3.10
+            python-version: "3.10"
             os: ubuntu-latest
             OPENCL: false
             cuda-version: ""
@@ -130,8 +130,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Pypy 3.6
-            python-version: "3.6.*=*pypy*"
+          - name: Linux CPU Pypy 3.7
+            python-version: "3.7.*=*pypy*"
             os: ubuntu-latest
             OPENCL: false
             cuda-version: ""
@@ -139,8 +139,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: MacOS Intel CPU/OpenCL Python 3.9
-            python-version: "3.9"
+          - name: MacOS Intel CPU/OpenCL Python 3.10
+            python-version: "3.10"
             os: macos-latest
             OPENCL: false
             cuda-version: ""
@@ -322,8 +322,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Windows CUDA 11.2 Python 3.9
-            python-version: "3.9"
+          - name: Windows CUDA 11.2 Python 3.10
+            python-version: "3.10"
             cuda-version: "11.2"
             CMAKE_FLAGS: |
               -DCUDA_TOOLKIT_ROOT_DIR="%CUDA_TOOLKIT_ROOT_DIR%" ^
@@ -458,19 +458,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: PowerPC CPU/CUDA 10.2 Python 3.9 with condaforge compilers
+          - name: PowerPC CPU/CUDA 10.2 Python 3.10 with condaforge compilers
             docker-image: quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
-            python-version: "3.9"
+            python-version: "3.10"
             compilers: compilers
 
-          - name: PowerPC CPU Python 3.9 devtoolset-7 compilers
+          - name: PowerPC CPU Python 3.10 devtoolset-7 compilers
             docker-image: quay.io/condaforge/linux-anvil-ppc64le
-            python-version: "3.9"
+            python-version: "3.10"
             compilers: devtoolset-7
 
-          - name: ARM CPU Python 3.6 with condaforge compilers
+          - name: ARM CPU Python 3.10 with condaforge compilers
             docker-image: quay.io/condaforge/linux-anvil-aarch64
-            python-version: "3.9"
+            python-version: "3.10"
             compilers: compilers
 
 
@@ -555,7 +555,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         name: "Prepare base dependencies"
         with:
-          python-version: "3.6"
+          python-version: "3.7"
           activate-environment: build
           environment-file: devtools/ci/gh-actions/conda-envs/docs.yml
           auto-activate-base: false


### PR DESCRIPTION
All our Python 3.6 builds have recently begun failing.  It looks to me like `importlib_metadata` no longer supports it.  I believe Python 3.6 is now past its end of support date, and 3.10 has been out for a while now.  This PR updates our CI builds to run on Python 3.7 and 3.10 instead of 3.6 and 3.9.