### PR TITLE
Skip more URLs that linkinator reports as broken

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -650,7 +650,7 @@ jobs:
         shell: bash -l {0}
         env:
           # Pipe-seperated list of domains to skip
-          SKIP_DOMAIN: support.amd.com|www.pnas.org
+          SKIP_DOMAIN: support.amd.com|www.pnas.org|doi.org
         run: |
           set +e
           # Linkinator accepts regex for its --skip argument, so we


### PR DESCRIPTION
The docs build recently started failing again.  For some reason linkinator now reports more URLs as broken, even though it didn't before and they still work.