### PR TITLE
Added temperature adjustment to MC barostat for simulated tempering

### DIFF
--- a/wrappers/python/openmm/app/simulatedtempering.py
+++ b/wrappers/python/openmm/app/simulatedtempering.py
@@ -160,6 +160,9 @@ class SimulatedTempering(object):
         
         self.currentTemperature = 0
         self.simulation.integrator.setTemperature(self.temperatures[self.currentTemperature])
+        for param in self.simulation.context.getParameters():
+            if 'MonteCarloTemperature' in param:
+                self.simulation.context.setParameter(param, self.temperatures[self.currentTemperature])
         
         # Add a reporter to the simulation which will handle the updates and reports.
         
@@ -230,6 +233,9 @@ class SimulatedTempering(object):
                     self._hasMadeTransition = True
                     self.currentTemperature = j
                     self.simulation.integrator.setTemperature(self.temperatures[j])
+                    for param in self.simulation.context.getParameters():
+                        if 'MonteCarloTemperature' in param:
+                            self.simulation.context.setParameter(param, self.temperatures[self.currentTemperature])
                 if self._updateWeights:
                     # Update the weight factors.
                     

--- a/wrappers/python/tests/TestSimulatedTempering.py
+++ b/wrappers/python/tests/TestSimulatedTempering.py
@@ -54,31 +54,37 @@ class TestSimulatedTempering(unittest.TestCase):
             expectedEnergy = (0.5*MOLAR_GAS_CONSTANT_R*t).value_in_unit(kilojoules_per_mole)
             self.assertAlmostEqual(expectedEnergy, meanEnergy, delta=expectedEnergy*0.3)
 
-    def testHarmonicOscillatorNPT(self):
-        system = System()
-        system.addParticle(1.0)
-        system.addParticle(1.0)
-        force = HarmonicBondForce()
-        force.addBond(0, 1, 1.0, 1000.0)
-        system.addForce(force)
-        mcBarostat = MonteCarloBarostat(1*bar, 300*kelvin, 2)
+
+    def testAlanineDipeptideExplicit(self):
+        prmtop = AmberPrmtopFile('systems/alanine-dipeptide-explicit.prmtop')
+        inpcrd = AmberInpcrdFile('systems/alanine-dipeptide-explicit.inpcrd')
+        system = prmtop.createSystem(nonbondedMethod=PME, nonbondedCutoff=1*nanometer, constraints=HBonds)
+        mcbarostat = MonteCarloBarostat(1*bar, 100*kelvin, 2)
         system.addForce(mcBarostat)
-        integrator = LangevinIntegrator(300*kelvin, 10/picosecond, 0.001*picosecond)
-        topology = Topology()
-        chain = topology.addChain()
-        residue = topology.addResidue('H2', chain)
-        topology.addAtom('H1', element.hydrogen, residue)
-        topology.addAtom('H2', element.hydrogen, residue)
+        integrator = LangevinIntegrator(100*kelvin, 1/picosecond, 0.001*picosecond)
         simulation = Simulation(topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation.context.setPositions(inpcrd.positions)
+        simulation.context.setPeriodicBoxVectors(*inpcrd.boxVectors)
+        
+        # Check the temperature is correct before creating the simulated tempering simulation
+        
+        self.assertEqual(100*kelvin, integrator.getTemperature())
+        self.assertEqual(100*kelvin, simulation.context.getParameter('MonteCarloTemperature')*kelvin)
+
         st = SimulatedTempering(simulation, numTemperatures=10, minTemperature=200*kelvin, maxTemperature=400*kelvin, tempChangeInterval=4, reportInterval=10000)
+
+        # Check the temperatures of the integrator and barostat are set to the value of minTemperature
+
         self.assertEqual(10, len(st.temperatures))
         self.assertEqual(200*kelvin, st.temperatures[0])
         self.assertEqual(400*kelvin, st.temperatures[-1])
-        simulation.context.setPositions([Vec3(0, 0, 0), Vec3(1, 0, 0)])
+        self.assertEqual(200*kelvin, integrator.getTemperature())
+        self.assertEqual(200*kelvin, simulation.context.getParameter('MonteCarloTemperature')*kelvin)
 
-        # We let the simulation run and assert at every step T(mcBarostat) == T(integrator) == T(tempering)
-        for i in range(20000):
+        # Let the simulation run and assert at every step T(mcbarostat) == T(integrator) == T(tempering)
+
+        for i in range(50):
             st.step(2)
             self.assertEqual(st.temperatures[st.currentTemperature], integrator.getTemperature())
-            self.assertEqual(st.temperatures[st.currentTemperature], simulation.context.getParameter('MonteCarloTemperature'))
+            self.assertEqual(st.temperatures[st.currentTemperature], simulation.context.getParameter('MonteCarloTemperature')*kelvin)
 

--- a/wrappers/python/tests/TestSimulatedTempering.py
+++ b/wrappers/python/tests/TestSimulatedTempering.py
@@ -60,7 +60,7 @@ class TestSimulatedTempering(unittest.TestCase):
         inpcrd = AmberInpcrdFile('systems/alanine-dipeptide-explicit.inpcrd')
         system = prmtop.createSystem(nonbondedMethod=PME, nonbondedCutoff=1*nanometer, constraints=HBonds)
         mcbarostat = MonteCarloBarostat(1*bar, 100*kelvin, 2)
-        system.addForce(mcBarostat)
+        system.addForce(mcbarostat)
         integrator = LangevinIntegrator(100*kelvin, 1/picosecond, 0.001*picosecond)
         simulation = Simulation(topology, system, integrator, Platform.getPlatformByName('Reference'))
         simulation.context.setPositions(inpcrd.positions)

--- a/wrappers/python/tests/TestSimulatedTempering.py
+++ b/wrappers/python/tests/TestSimulatedTempering.py
@@ -61,7 +61,7 @@ class TestSimulatedTempering(unittest.TestCase):
         force = HarmonicBondForce()
         force.addBond(0, 1, 1.0, 1000.0)
         system.addForce(force)
-        mcBarostat = MonteCarloBarostat(1*bar, 300*kelvin* 2)
+        mcBarostat = MonteCarloBarostat(1*bar, 300*kelvin, 2)
         system.addForce(mcBarostat)
         integrator = LangevinIntegrator(300*kelvin, 10/picosecond, 0.001*picosecond)
         topology = Topology()


### PR DESCRIPTION
The title more or less explains it all:
This pull request allows simulated tempering to be run in isobaric ensembles using Monte Carlo barostats by adjusting the temperature of the barostat.

fixes #3612