### PR TITLE
fix divergence in barriers

### DIFF
--- a/platforms/opencl/src/kernels/findInteractingBlocks.cl
+++ b/platforms/opencl/src/kernels/findInteractingBlocks.cl
@@ -249,6 +249,9 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
                         neighborsInBuffer -= TILE_SIZE*tilesToStore;
                    }
                 }
+                else {
+                    SYNC_WARPS;
+                }
             }
         }
         


### PR DESCRIPTION
Without this fix, we see cases in which not all work-items in a thread group end up hitting the same number of barriers, which leads to a hang in OpenCL GPU execution.