### PR TITLE
Fixed freeze when using multiple GPUs

### DIFF
--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019 Stanford University and the Authors.           *
+ * Portions copyright (c) 2019-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -555,6 +555,10 @@ public:
      * Get whether the worker thread has exited.
      */
     bool isFinished();
+    /**
+     * Get whether the thread invoking this method is the worker thread.
+     */
+    bool isCurrentThread();
     /**
      * Block until all tasks have finished executing and the worker thread is idle.
      */

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -1812,7 +1812,8 @@ public:
     double computeForceAndEnergy(bool includeForces, bool includeEnergy, int groups) {
         if ((groups&(1<<force->getForceGroup())) == 0)
             return 0;
-        cc.getWorkThread().flush();
+        if (!cc.getWorkThread().isCurrentThread())
+            cc.getWorkThread().flush();
         Vec3 a, b, c;
         cc.getPeriodicBoxVectors(a, b, c);
         double volume = a[0]*b[1]*c[2];

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019-2021 Stanford University and the Authors.      *
+ * Portions copyright (c) 2019-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -714,6 +714,10 @@ bool ComputeContext::WorkThread::isWaiting() {
 
 bool ComputeContext::WorkThread::isFinished() {
     return finished;
+}
+
+bool ComputeContext::WorkThread::isCurrentThread() {
+    return (pthread_self() == thread);
 }
 
 void ComputeContext::WorkThread::flush() {


### PR DESCRIPTION
Fixes #3661.

The freeze happened if you used multiple GPUs, and the system included a CustomNonbondedForce that used a long range correction.  The problem was introduced by #3236.