### PR TITLE
Kernel source headers included in installation

### DIFF
--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -16,5 +16,5 @@ ADD_CUSTOM_TARGET(CommonKernels DEPENDS ${KERNELS_CPP} ${KERNELS_H})
 
 # Install headers
 
-FILE(GLOB CORE_HEADERS include/openmm/common/*.h)
+FILE(GLOB CORE_HEADERS include/openmm/common/*.h ${KERNELS_H})
 INSTALL_FILES(/include/openmm/common FILES ${CORE_HEADERS})

--- a/platforms/cuda/CMakeLists.txt
+++ b/platforms/cuda/CMakeLists.txt
@@ -87,7 +87,7 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/../common/src)
 
 # Install headers
 
-FILE(GLOB CORE_HEADERS include/*.h)
+FILE(GLOB CORE_HEADERS include/*.h ${KERNELS_H})
 INSTALL_FILES(/include/openmm/cuda FILES ${CORE_HEADERS})
 
 SUBDIRS (sharedTarget)

--- a/platforms/opencl/CMakeLists.txt
+++ b/platforms/opencl/CMakeLists.txt
@@ -87,7 +87,7 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/../common/src)
 
 # Install headers
 
-FILE(GLOB CORE_HEADERS include/*.h src/opencl.hpp)
+FILE(GLOB CORE_HEADERS include/*.h src/opencl.hpp ${KERNELS_H})
 INSTALL_FILES(/include/openmm/opencl FILES ${CORE_HEADERS})
 
 SUBDIRS (sharedTarget)


### PR DESCRIPTION
Installs header files `[Common|Cuda|OpenCL]KernelSources.h`, generated during compilation, in the corresponding include directories.