### PR TITLE
CustomCVForce avoids breaking up molecules

### DIFF
--- a/openmmapi/include/openmm/internal/CustomCVForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomCVForceImpl.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2017 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -62,6 +62,7 @@ public:
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups);
     std::map<std::string, double> getDefaultParameters();
     std::vector<std::string> getKernelNames();
+    std::vector<std::pair<int, int> > getBondedParticles() const;
     void getCollectiveVariableValues(ContextImpl& context, std::vector<double>& values);
     Context& getInnerContext();
     void updateParametersInContext(ContextImpl& context);

--- a/openmmapi/src/CustomCVForceImpl.cpp
+++ b/openmmapi/src/CustomCVForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2017 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2022 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -89,6 +89,16 @@ vector<string> CustomCVForceImpl::getKernelNames() {
     vector<string> names;
     names.push_back(CalcCustomCVForceKernel::Name());
     return names;
+}
+
+vector<pair<int, int> > CustomCVForceImpl::getBondedParticles() const {
+    vector<pair<int, int> > bonds;
+    const ContextImpl& innerContextImpl = getContextImpl(*innerContext);
+    for (auto& impl : innerContextImpl.getForceImpls()) {
+        for (auto& bond : impl->getBondedParticles())
+            bonds.push_back(bond);
+    }
+    return bonds;
 }
 
 map<string, double> CustomCVForceImpl::getDefaultParameters() {


### PR DESCRIPTION
This might or might not be the fix for https://github.com/openmm/openmm-ml/issues/36.  Each Force object reports what atoms it creates bonds between, so all the atoms in a molecule are translated together when applying periodic boundary conditions.  CustomCVForce did not propagate the bond specifications from the Forces it contained.

This only applied to output when calling `getState()` with `enforcePeriodicBox=true`.  There's a different mechanism used to identify molecules when internally translating positions to preserve accuracy.  That mechanism was handled correctly, so it never broke up molecules during normal integration.  It only happened when returning output from `getState()`.

cc @dominicrufa