### PR TITLE
UseBlockingSync defaults to false

### DIFF
--- a/platforms/cuda/src/CudaPlatform.cpp
+++ b/platforms/cuda/src/CudaPlatform.cpp
@@ -118,7 +118,7 @@ CudaPlatform::CudaPlatform() {
     platformProperties.push_back(CudaDeterministicForces());
     setPropertyDefaultValue(CudaDeviceIndex(), "");
     setPropertyDefaultValue(CudaDeviceName(), "");
-    setPropertyDefaultValue(CudaUseBlockingSync(), "true");
+    setPropertyDefaultValue(CudaUseBlockingSync(), "false");
     setPropertyDefaultValue(CudaPrecision(), "single");
     setPropertyDefaultValue(CudaUseCpuPme(), "false");
     setPropertyDefaultValue(CudaDisablePmeStream(), "false");


### PR DESCRIPTION
On recent CUDA versions, this seems to give better performance.  See https://github.com/choderalab/perses/issues/613#issuecomment-1180894126.  Also, given the changes in #3561, this is actually closer to the default behavior in previous releases.