### PR TITLE
Fixed compilation error with multiple CustomNonbondedForces

### DIFF
--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -1910,7 +1910,8 @@ void CommonCalcCustomNonbondedForceKernel::initialize(const System& system, cons
         vector<float> f = cc.getExpressionUtilities().computeFunctionCoefficients(force.getTabulatedFunction(i), width);
         tabulatedFunctionArrays[i].initialize<float>(cc, f.size(), "TabulatedFunction");
         tabulatedFunctionArrays[i].upload(f);
-        cc.getNonbondedUtilities().addArgument(ComputeParameterInfo(tabulatedFunctionArrays[i], arrayName, "float", width));
+        if (force.getNumInteractionGroups() == 0)
+            cc.getNonbondedUtilities().addArgument(ComputeParameterInfo(tabulatedFunctionArrays[i], arrayName, "float", width));
         if (width == 1)
             tableTypes.push_back("float");
         else


### PR DESCRIPTION
Fixes #3726.  When you had two CustomNonbondedForces, both having interaction groups, and both having tabulated functions, it would lead to a kernel compilation error on CUDA and OpenCL.