### PR TITLE
Add all Amber ion params

### DIFF
--- a/devtools/forcefield-scripts/diffIons.py
+++ b/devtools/forcefield-scripts/diffIons.py
@@ -1,0 +1,26 @@
+import sys
+import re
+import subprocess
+
+file1, file2 = sys.argv[1], sys.argv[2]
+
+with open(file1) as fh:
+    text1 = fh.read()
+
+with open(file2) as fh:
+    text2 = fh.read()
+
+m = re.search(r'Type class="([^\-]*)', text1)
+if m:
+    prefix1 = m.group(1)
+m = re.search(r'Type class="([^\-]*)', text2)
+if m:
+    prefix2 = m.group(1)
+
+text2a = text2.replace(prefix2, prefix1)
+text2b = re.sub(r'<!--.*?-->', '', text2a)
+
+with open('new.xml', 'w') as fh:
+    fh.write(text2b)
+
+subprocess.call(['diff', '-uw', file1, 'new.xml'])

--- a/devtools/forcefield-scripts/processAmberIons.py
+++ b/devtools/forcefield-scripts/processAmberIons.py
@@ -39,7 +39,9 @@ def amber_frcmod_ions_to_openmm_xml(
             
     ionname_to_residuename['Na+'] = 'NA' # this is a duplicate in atomic_ions.lib
     ionname_to_residuename['Cl-'] = 'CL' # this is a duplicate in atomic_ions.lib
-    
+    ionname_to_residuename['Cu2+'] = 'CU' # consistent with previous residue names
+    ionname_to_residuename['Cu+'] = 'CU1'
+
     with open(frcmod_file) as fh:
         lines = fh.readlines()
         lines = [x.strip() for x in lines]
@@ -109,7 +111,9 @@ def amber_frcmod_ions_to_openmm_xml(
     output_lines.append('  </AtomTypes>')
 
     output_lines.append('  <Residues>')
-    for ionname, mass, extra in mass_data:
+    # NOTE this is a hack to sort residues in a similar way to the older converted xml files, for easier diff
+    # NOTE it would be better to keep them in the order in which ions are listed
+    for ionname in sorted([x[0] for x in mass_data], key=str.casefold):
         if not ionname in ionname_to_residuename:
             print(f'Warning: ion name {ionname} not found in list of atomic ions')
             continue
@@ -153,7 +157,8 @@ os.makedirs(output_path, exist_ok=True)
 
 for frcmod_file in frcmod_files:
     if '1264' in frcmod_file:
-        print(f'Skipped {frcmod_file} because it has 12-6-4 parameters')
+        print(f'Skipped {frcmod_file} because it has 12-6-4 parameters, only 12-6 are supported')
+        continue
     setname = os.path.basename(frcmod_file)
     setname = setname.replace('frcmod.', '')
     xml_file = f'{output_path}/{setname}.xml'

--- a/devtools/forcefield-scripts/processAmberIons.py
+++ b/devtools/forcefield-scripts/processAmberIons.py
@@ -1,0 +1,164 @@
+import re
+import os
+import sys
+import glob
+import datetime
+import subprocess
+
+# from openmm import unit
+
+kilocalorie_to_kilojoule =  4.184 # 1.0*unit.kilocalorie/unit.kilojoule
+angstrom_to_nanometer = 0.1 # 1.0*unit.angstrom/unit.nanometer
+
+
+def md5sum(file):
+    result = subprocess.check_output(['md5sum', file]).decode('utf-8').split()[0]
+    return result
+
+
+def amber_frcmod_ions_to_openmm_xml(
+    frcmod_file, 
+    atomic_ions_file, 
+    xml_file, 
+    setname=None, 
+    include_extra_comments=True,
+):
+    with open(atomic_ions_file) as fh:
+        lines = fh.readlines()
+
+    ionname_to_residuename = {}
+    ionname_to_charge = {}
+    for i, line in enumerate(lines):
+        if 'unit.atoms table' in line:
+            name, type_, typex, resx, flags, seq, elmnt, chg = lines[i+1].split()
+            name = name.replace('"', '')
+            type_ = type_.replace('"', '')
+            # print(name, type_, typex, resx, flags, seq, elmnt, chg)
+            ionname_to_residuename[type_] = name
+            ionname_to_charge[type_] = float(chg)
+            
+    ionname_to_residuename['Na+'] = 'NA' # this is a duplicate in atomic_ions.lib
+    ionname_to_residuename['Cl-'] = 'CL' # this is a duplicate in atomic_ions.lib
+    
+    with open(frcmod_file) as fh:
+        lines = fh.readlines()
+        lines = [x.strip() for x in lines]
+        
+    mass_data = []
+    nonbon_data = []
+    comments_data = []
+    do_mass = False
+    do_nonbon = False
+
+    for i, line in enumerate(lines):
+        if line == 'MASS':
+            do_mass = True
+            do_nonbon = False
+        elif line == 'NONBON':
+            do_nonbon = True
+            do_mass = False
+        elif line == '':
+            do_mass = False
+            do_nonbon = False
+        else:
+            if do_mass:
+                m = re.match(r'^(\S+)\s+(\S+)(.*)', line)
+                if m:
+                    ionname, mass, extra = m.groups()
+                    mass_data.append((ionname, mass, extra))
+                else:
+                    raise ValueError(f'Could not parse line {i}: {line}')
+            elif do_nonbon:
+                m = re.match(r'^(\S+)\s+(\S+)\s+(\S+)(.*)', line)
+                if m:
+                    ionname, sigma, epsilon, extra = m.groups()
+                    nonbon_data.append((ionname, float(sigma), float(epsilon), extra))
+                else:
+                    raise ValueError(f'Could not parse line {i}: {line}')
+            else:
+                comments_data.append(line)
+
+    if not setname:
+        setname = os.path.basename(frcmod_file)
+        setname = setname.replace('frcmod.', '')
+
+    date_generated = datetime.datetime.utcnow().isoformat()
+    ambertools_version = re.sub(r'.*/ambertools-([^/]*)/.*', r'\1', frcmod_file)
+    frcmod_file_short = re.sub(r'.*/dat/leap/', '', frcmod_file)
+    atomic_ions_file_short = re.sub(r'.*/dat/leap/', '', atomic_ions_file)
+
+    output_lines = []
+
+    output_lines.append('<ForceField>')
+
+    output_lines.append('  <Info>')
+    for comment in comments_data:
+        output_lines.append(f'    <!-- {comment} -->')
+    output_lines.append(f'    <DateGenerated>{date_generated}</DateGenerated>')
+    output_lines.append(f'    <Source Source="{frcmod_file_short}" md5hash="{md5sum(frcmod_file)}" sourcePackage="AmberTools" sourcePackageVersion="{ambertools_version}">{frcmod_file_short}</Source>')
+    output_lines.append(f'    <Source Source="{atomic_ions_file_short}" md5hash="{md5sum(atomic_ions_file)}" sourcePackage="AmberTools" sourcePackageVersion="{ambertools_version}">{atomic_ions_file_short}</Source>')
+    output_lines.append('  </Info>')
+
+    output_lines.append('  <AtomTypes>')
+    for ionname, mass, extra in mass_data:
+        element = re.sub(r'\d*[\-\+]*', '', ionname)
+        line = f'    <Type class="{setname}-{ionname}" element="{element}" mass="{mass}" name="{setname}-{ionname}"/>'
+        if extra and include_extra_comments:
+            line += f'<!-- {extra} -->'
+        output_lines.append(line)
+    output_lines.append('  </AtomTypes>')
+
+    output_lines.append('  <Residues>')
+    for ionname, mass, extra in mass_data:
+        if not ionname in ionname_to_residuename:
+            print(f'Warning: ion name {ionname} not found in list of atomic ions')
+            continue
+        residuename = ionname_to_residuename[ionname]
+        charge = ionname_to_charge[ionname]
+        output_lines.append(f'    <Residue name="{residuename}">')
+        output_lines.append(f'      <Atom charge="{charge:.1f}" name="{residuename}" type="{setname}-{ionname}"/>')
+        output_lines.append(f'    </Residue>')
+    output_lines.append('  </Residues>')
+
+    output_lines.append('  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">')
+    output_lines.append('    <UseAttributeFromResidue name="charge"/>')
+    for ionname, sigma, epsilon, extra in nonbon_data:
+        epsilon_converted = epsilon*kilocalorie_to_kilojoule
+        sigma_converted = (sigma * 2 / (2**(1/6)))*angstrom_to_nanometer
+        line = f'    <Atom epsilon="{epsilon_converted}" sigma="{sigma_converted}" type="{setname}-{ionname}"/>'
+        if extra and include_extra_comments:
+            line += f'<!-- {extra} -->'
+        output_lines.append(line)
+    output_lines.append('  </NonbondedForce>')
+    output_lines.append('</ForceField>')
+    
+    with open(xml_file, 'w') as fh:
+        for line in output_lines:
+            fh.write(line+'\n')
+            
+    print(f'Converted {len(mass_data)} ions from {frcmod_file} to {xml_file}')
+
+if len(sys.argv) < 2:
+    print('processAmberIons.py script to convert all Amber/AmberTools frcmod.ions* files to equivalent openmm xml files')
+    print('Usage: python ./devtools/forcefield-scripts/processAmberIons.py /path/to/ambertools')
+    sys.exit()
+
+ambertools_path = sys.argv[1]
+ambertools_dat_leap_path = os.path.join(ambertools_path, 'dat/leap/')
+frcmod_files = glob.glob(ambertools_dat_leap_path + 'parm/frcmod.ions*')
+atomic_ions_file = ambertools_dat_leap_path + 'lib/atomic_ions.lib'
+
+output_path = 'wrappers/python/openmm/app/data/ions'
+os.makedirs(output_path, exist_ok=True)
+
+for frcmod_file in frcmod_files:
+    if '1264' in frcmod_file:
+        print(f'Skipped {frcmod_file} because it has 12-6-4 parameters')
+    setname = os.path.basename(frcmod_file)
+    setname = setname.replace('frcmod.', '')
+    xml_file = f'{output_path}/{setname}.xml'
+    amber_frcmod_ions_to_openmm_xml(
+        frcmod_file, 
+        atomic_ions_file, 
+        xml_file,
+        setname=setname)

--- a/wrappers/python/openmm/app/data/ions/ions1lm_126_spce.xml
+++ b/wrappers/python/openmm/app/data/ions/ions1lm_126_spce.xml
@@ -1,0 +1,85 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of monovalent ions for SPC/E water model (12-6 normal usage set) -->
+    <DateGenerated>2022-09-11T06:28:33.589814</DateGenerated>
+    <Source Source="parm/frcmod.ions1lm_126_spce" md5hash="2926fce0babc64832f4dcdb0b6ef4f4b" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions1lm_126_spce</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions1lm_126_spce-Li+" element="Li" mass="6.94" name="ions1lm_126_spce-Li+"/>
+    <Type class="ions1lm_126_spce-Na+" element="Na" mass="22.99" name="ions1lm_126_spce-Na+"/>
+    <Type class="ions1lm_126_spce-K+" element="K" mass="39.10" name="ions1lm_126_spce-K+"/>
+    <Type class="ions1lm_126_spce-Rb+" element="Rb" mass="85.47" name="ions1lm_126_spce-Rb+"/>
+    <Type class="ions1lm_126_spce-Cs+" element="Cs" mass="132.91" name="ions1lm_126_spce-Cs+"/>
+    <Type class="ions1lm_126_spce-Tl+" element="Tl" mass="204.38" name="ions1lm_126_spce-Tl+"/>
+    <Type class="ions1lm_126_spce-Cu+" element="Cu" mass="63.55" name="ions1lm_126_spce-Cu+"/>
+    <Type class="ions1lm_126_spce-Ag+" element="Ag" mass="107.87" name="ions1lm_126_spce-Ag+"/>
+    <Type class="ions1lm_126_spce-NH4+" element="NH" mass="18.04" name="ions1lm_126_spce-NH4+"/>
+    <Type class="ions1lm_126_spce-H3O+" element="HO" mass="19.02" name="ions1lm_126_spce-H3O+"/>
+    <Type class="ions1lm_126_spce-F-" element="F" mass="19.00" name="ions1lm_126_spce-F-"/>
+    <Type class="ions1lm_126_spce-Cl-" element="Cl" mass="35.45" name="ions1lm_126_spce-Cl-"/>
+    <Type class="ions1lm_126_spce-Br-" element="Br" mass="79.90" name="ions1lm_126_spce-Br-"/>
+    <Type class="ions1lm_126_spce-I-" element="I" mass="126.9" name="ions1lm_126_spce-I-"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ions1lm_126_spce-Ag+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ions1lm_126_spce-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ions1lm_126_spce-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ions1lm_126_spce-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ions1lm_126_spce-Cu+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ions1lm_126_spce-F-"/>
+    </Residue>
+    <Residue name="O">
+      <Atom charge="1.0" name="O" type="ions1lm_126_spce-H3O+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ions1lm_126_spce-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ions1lm_126_spce-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ions1lm_126_spce-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ions1lm_126_spce-Na+"/>
+    </Residue>
+    <Residue name="N">
+      <Atom charge="1.0" name="N" type="ions1lm_126_spce-NH4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ions1lm_126_spce-Rb+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ions1lm_126_spce-Tl+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.01146796744" sigma="0.22415011748410937" type="ions1lm_126_spce-Li+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.11041584368" sigma="0.25907334723521064" type="ions1lm_126_spce-Na+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.5310938643199999" sigma="0.2998765085260382" type="ions1lm_126_spce-K+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.8646299178400001" sigma="0.31929810058149766" type="ions1lm_126_spce-Rb+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.45072702272" sigma="0.34798503930561653" type="ions1lm_126_spce-Cs+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.49127201672000004" sigma="0.29720381237161714" type="ions1lm_126_spce-Tl+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.00403312496" sigma="0.2123902544046569" type="ions1lm_126_spce-Cu+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.0299963512" sigma="0.23697905902533029" type="ions1lm_126_spce-Ag+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.7058165328" sigma="0.31056729314372233" type="ions1lm_126_spce-NH4+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.02891428512" sigma="0.23644451979444603" type="ions1lm_126_spce-H3O+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.95724882464" sigma="0.32410895365945547" type="ions1lm_126_spce-F-"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="2.69311574024" sigma="0.41123884829358065" type="ions1lm_126_spce-Cl-"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.11439437408" sigma="0.4401039667613277" type="ions1lm_126_spce-Br-"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.63493397288" sigma="0.49355788984974797" type="ions1lm_126_spce-I-"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2015, 11, 1645 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions1lm_126_tip3p.xml
+++ b/wrappers/python/openmm/app/data/ions/ions1lm_126_tip3p.xml
@@ -1,0 +1,85 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of monovalent ions for TIP3P water model (12-6 normal usage set) -->
+    <DateGenerated>2022-09-11T06:28:33.606634</DateGenerated>
+    <Source Source="parm/frcmod.ions1lm_126_tip3p" md5hash="2620dffe70b36cdf9fa0427eeed2474c" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions1lm_126_tip3p</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions1lm_126_tip3p-Li+" element="Li" mass="6.94" name="ions1lm_126_tip3p-Li+"/>
+    <Type class="ions1lm_126_tip3p-Na+" element="Na" mass="22.99" name="ions1lm_126_tip3p-Na+"/>
+    <Type class="ions1lm_126_tip3p-K+" element="K" mass="39.10" name="ions1lm_126_tip3p-K+"/>
+    <Type class="ions1lm_126_tip3p-Rb+" element="Rb" mass="85.47" name="ions1lm_126_tip3p-Rb+"/>
+    <Type class="ions1lm_126_tip3p-Cs+" element="Cs" mass="132.91" name="ions1lm_126_tip3p-Cs+"/>
+    <Type class="ions1lm_126_tip3p-Tl+" element="Tl" mass="204.38" name="ions1lm_126_tip3p-Tl+"/>
+    <Type class="ions1lm_126_tip3p-Cu+" element="Cu" mass="63.55" name="ions1lm_126_tip3p-Cu+"/>
+    <Type class="ions1lm_126_tip3p-Ag+" element="Ag" mass="107.87" name="ions1lm_126_tip3p-Ag+"/>
+    <Type class="ions1lm_126_tip3p-NH4+" element="NH" mass="18.04" name="ions1lm_126_tip3p-NH4+"/>
+    <Type class="ions1lm_126_tip3p-H3O+" element="HO" mass="19.02" name="ions1lm_126_tip3p-H3O+"/>
+    <Type class="ions1lm_126_tip3p-F-" element="F" mass="19.00" name="ions1lm_126_tip3p-F-"/>
+    <Type class="ions1lm_126_tip3p-Cl-" element="Cl" mass="35.45" name="ions1lm_126_tip3p-Cl-"/>
+    <Type class="ions1lm_126_tip3p-Br-" element="Br" mass="79.90" name="ions1lm_126_tip3p-Br-"/>
+    <Type class="ions1lm_126_tip3p-I-" element="I" mass="126.9" name="ions1lm_126_tip3p-I-"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ions1lm_126_tip3p-Ag+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ions1lm_126_tip3p-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ions1lm_126_tip3p-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ions1lm_126_tip3p-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ions1lm_126_tip3p-Cu+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ions1lm_126_tip3p-F-"/>
+    </Residue>
+    <Residue name="O">
+      <Atom charge="1.0" name="O" type="ions1lm_126_tip3p-H3O+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ions1lm_126_tip3p-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ions1lm_126_tip3p-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ions1lm_126_tip3p-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ions1lm_126_tip3p-Na+"/>
+    </Residue>
+    <Residue name="N">
+      <Atom charge="1.0" name="N" type="ions1lm_126_tip3p-NH4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ions1lm_126_tip3p-Rb+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ions1lm_126_tip3p-Tl+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0130567996" sigma="0.22575373517676198" type="ions1lm_126_tip3p-Li+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.13269530895999998" sigma="0.2628151218514001" type="ions1lm_126_tip3p-Na+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.6330957258400001" sigma="0.30629097929664867" type="ions1lm_126_tip3p-K+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.01002663744" sigma="0.3267816498138765" type="ions1lm_126_tip3p-Rb+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.58378972872" sigma="0.35422133033259895" type="ions1lm_126_tip3p-Cs+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.58667223752" sigma="0.3034401033985996" type="ions1lm_126_tip3p-Tl+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.004698632" sigma="0.2139938720973095" type="ions1lm_126_tip3p-Cu+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.03424315304" sigma="0.238939036205239" type="ions1lm_126_tip3p-Ag+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.82125221416" sigma="0.3169817639143327" type="ions1lm_126_tip3p-NH4+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.03264699888" sigma="0.23822631723072674" type="ions1lm_126_tip3p-H3O+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.8345094692" sigma="0.317694482888845" type="ions1lm_126_tip3p-F-"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="2.5226631784799998" sigma="0.40126078265040876" type="ions1lm_126_tip3p-Cl-"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.0154481295999997" sigma="0.43262041752894875" type="ions1lm_126_tip3p-Br-"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.5738969440800004" sigma="0.4853616216428569" type="ions1lm_126_tip3p-I-"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2015, 11, 1645 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions1lm_126_tip4pew.xml
+++ b/wrappers/python/openmm/app/data/ions/ions1lm_126_tip4pew.xml
@@ -1,0 +1,85 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of monovalent ions for TIP4P/EW water model (12-6 normal usage set) -->
+    <DateGenerated>2022-09-11T06:28:33.616234</DateGenerated>
+    <Source Source="parm/frcmod.ions1lm_126_tip4pew" md5hash="f4e9c94f85653071e02c9c537ad21933" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions1lm_126_tip4pew</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions1lm_126_tip4pew-Li+" element="Li" mass="6.94" name="ions1lm_126_tip4pew-Li+"/>
+    <Type class="ions1lm_126_tip4pew-Na+" element="Na" mass="22.99" name="ions1lm_126_tip4pew-Na+"/>
+    <Type class="ions1lm_126_tip4pew-K+" element="K" mass="39.10" name="ions1lm_126_tip4pew-K+"/>
+    <Type class="ions1lm_126_tip4pew-Rb+" element="Rb" mass="85.47" name="ions1lm_126_tip4pew-Rb+"/>
+    <Type class="ions1lm_126_tip4pew-Cs+" element="Cs" mass="132.91" name="ions1lm_126_tip4pew-Cs+"/>
+    <Type class="ions1lm_126_tip4pew-Tl+" element="Tl" mass="204.38" name="ions1lm_126_tip4pew-Tl+"/>
+    <Type class="ions1lm_126_tip4pew-Cu+" element="Cu" mass="63.55" name="ions1lm_126_tip4pew-Cu+"/>
+    <Type class="ions1lm_126_tip4pew-Ag+" element="Ag" mass="107.87" name="ions1lm_126_tip4pew-Ag+"/>
+    <Type class="ions1lm_126_tip4pew-NH4+" element="NH" mass="18.04" name="ions1lm_126_tip4pew-NH4+"/>
+    <Type class="ions1lm_126_tip4pew-H3O+" element="HO" mass="19.02" name="ions1lm_126_tip4pew-H3O+"/>
+    <Type class="ions1lm_126_tip4pew-F-" element="F" mass="19.00" name="ions1lm_126_tip4pew-F-"/>
+    <Type class="ions1lm_126_tip4pew-Cl-" element="Cl" mass="35.45" name="ions1lm_126_tip4pew-Cl-"/>
+    <Type class="ions1lm_126_tip4pew-Br-" element="Br" mass="79.90" name="ions1lm_126_tip4pew-Br-"/>
+    <Type class="ions1lm_126_tip4pew-I-" element="I" mass="126.9" name="ions1lm_126_tip4pew-I-"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ions1lm_126_tip4pew-Ag+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ions1lm_126_tip4pew-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ions1lm_126_tip4pew-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ions1lm_126_tip4pew-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ions1lm_126_tip4pew-Cu+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ions1lm_126_tip4pew-F-"/>
+    </Residue>
+    <Residue name="O">
+      <Atom charge="1.0" name="O" type="ions1lm_126_tip4pew-H3O+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ions1lm_126_tip4pew-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ions1lm_126_tip4pew-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ions1lm_126_tip4pew-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ions1lm_126_tip4pew-Na+"/>
+    </Residue>
+    <Residue name="N">
+      <Atom charge="1.0" name="N" type="ions1lm_126_tip4pew-NH4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ions1lm_126_tip4pew-Rb+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ions1lm_126_tip4pew-Tl+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.007057822240000001" sigma="0.21844836568801118" type="ions1lm_126_tip4pew-Li+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.090124406" sigma="0.2551533928753932" type="ions1lm_126_tip4pew-Na+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.49387597096" sigma="0.2973819921152453" type="ions1lm_126_tip4pew-K+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.7819792236800001" sigma="0.3148436069907959" type="ions1lm_126_tip4pew-Rb+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.3862789460800002" sigma="0.34495598366393937" type="ions1lm_126_tip4pew-Cs+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.43586389048" sigma="0.2932838580117997" type="ions1lm_126_tip4pew-Tl+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.0021137568000000003" sigma="0.20597578363404645" type="ions1lm_126_tip4pew-Cu+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.01894778792" sigma="0.23056458825471982" type="ions1lm_126_tip4pew-Ag+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.59811815528" sigma="0.30415282237311186" type="ions1lm_126_tip4pew-NH4+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.01844784176" sigma="0.23020822876746372" type="ions1lm_126_tip4pew-H3O+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.0385202632000001" sigma="0.32820708776290103" type="ions1lm_126_tip4pew-F-"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="2.7308865492" sigma="0.4135551849607455" type="ions1lm_126_tip4pew-Cl-"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.2231123087199998" sigma="0.44901295394273105" type="ions1lm_126_tip4pew-Br-"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.69371662064" sigma="0.5022886972875232" type="ions1lm_126_tip4pew-I-"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2015, 11, 1645 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions1lm_iod.xml
+++ b/wrappers/python/openmm/app/data/ions/ions1lm_iod.xml
@@ -1,0 +1,95 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of monovalent ions for TIP3P, SPC/E and TIP4P/EW water models (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.577179</DateGenerated>
+    <Source Source="parm/frcmod.ions1lm_iod" md5hash="1c384cb45aec5c706021dd4d847ce20a" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions1lm_iod</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions1lm_iod-Li+" element="Li" mass="6.94" name="ions1lm_iod-Li+"/>
+    <Type class="ions1lm_iod-Na+" element="Na" mass="22.99" name="ions1lm_iod-Na+"/>
+    <Type class="ions1lm_iod-K+" element="K" mass="39.10" name="ions1lm_iod-K+"/>
+    <Type class="ions1lm_iod-Rb+" element="Rb" mass="85.47" name="ions1lm_iod-Rb+"/>
+    <Type class="ions1lm_iod-Cs+" element="Cs" mass="132.91" name="ions1lm_iod-Cs+"/>
+    <Type class="ions1lm_iod-Tl+" element="Tl" mass="204.38" name="ions1lm_iod-Tl+"/>
+    <Type class="ions1lm_iod-Cu+" element="Cu" mass="63.55" name="ions1lm_iod-Cu+"/>
+    <Type class="ions1lm_iod-Ag+" element="Ag" mass="107.87" name="ions1lm_iod-Ag+"/>
+    <Type class="ions1lm_iod-NH4+" element="NH" mass="18.04" name="ions1lm_iod-NH4+"/>
+    <Type class="ions1lm_iod-HE+" element="HE" mass="1.007" name="ions1lm_iod-HE+"/>
+    <Type class="ions1lm_iod-HZ+" element="HZ" mass="1.007" name="ions1lm_iod-HZ+"/>
+    <Type class="ions1lm_iod-H3O+" element="HO" mass="19.02" name="ions1lm_iod-H3O+"/>
+    <Type class="ions1lm_iod-F-" element="F" mass="19.00" name="ions1lm_iod-F-"/>
+    <Type class="ions1lm_iod-Cl-" element="Cl" mass="35.45" name="ions1lm_iod-Cl-"/>
+    <Type class="ions1lm_iod-Br-" element="Br" mass="79.90" name="ions1lm_iod-Br-"/>
+    <Type class="ions1lm_iod-I-" element="I" mass="126.9" name="ions1lm_iod-I-"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ions1lm_iod-Ag+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ions1lm_iod-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ions1lm_iod-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ions1lm_iod-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ions1lm_iod-Cu+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ions1lm_iod-F-"/>
+    </Residue>
+    <Residue name="O">
+      <Atom charge="1.0" name="O" type="ions1lm_iod-H3O+"/>
+    </Residue>
+    <Residue name="H">
+      <Atom charge="1.0" name="H" type="ions1lm_iod-HE+"/>
+    </Residue>
+    <Residue name="H">
+      <Atom charge="1.0" name="H" type="ions1lm_iod-HZ+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ions1lm_iod-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ions1lm_iod-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ions1lm_iod-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ions1lm_iod-Na+"/>
+    </Residue>
+    <Residue name="N">
+      <Atom charge="1.0" name="N" type="ions1lm_iod-NH4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ions1lm_iod-Rb+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ions1lm_iod-Tl+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.024893754" sigma="0.23430636287090922" type="ions1lm_iod-Li+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.12171954728" sigma="0.26103332441511945" type="ions1lm_iod-Na+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.71203621616" sigma="0.31092365263097843" type="ions1lm_iod-K+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.9607396613600001" sigma="0.3242871334030835" type="ions1lm_iod-Rb+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.6293855800000001" sigma="0.35635948725613575" type="ions1lm_iod-Cs+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="1.13990929424" sigma="0.3331961205844869" type="ions1lm_iod-Tl+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.0058239606400000005" sigma="0.21631020876447438" type="ions1lm_iod-Cu+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.16316922192" sigma="0.2672696154421018" type="ions1lm_iod-Ag+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.8579022132" sigma="0.31894174109424145" type="ions1lm_iod-NH4+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="2.765624e-07" sigma="0.14984916439120508" type="ions1lm_iod-HE+"/><!--   IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="6.15048e-06" sigma="0.1648162628559628" type="ions1lm_iod-HZ+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.6360531444" sigma="0.3064691590402767" type="ions1lm_iod-H3O+"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="0.69344913088" sigma="0.30985457416921003" type="ions1lm_iod-F-"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="2.2239911836" sigma="0.38522460572388273" type="ions1lm_iod-Cl-"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="2.75947218112" sigma="0.41533698239702616" type="ions1lm_iod-Br-"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+    <Atom epsilon="3.35949706888" sigma="0.46148553599669573" type="ions1lm_iod-I-"/><!--     IOD set from Li et al., JCTC, 2015, 11, 1645 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_126_spce.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_126_spce.xml
@@ -1,0 +1,255 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for SPC/E water model (12-6 normal usage set) -->
+    <DateGenerated>2022-09-11T06:28:33.564656</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_126_spce" md5hash="11ef85dfcf07639646dd361590b76166" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_126_spce</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_126_spce-Be2+" element="Be" mass="9.01" name="ions234lm_126_spce-Be2+"/>
+    <Type class="ions234lm_126_spce-Cu2+" element="Cu" mass="63.55" name="ions234lm_126_spce-Cu2+"/>
+    <Type class="ions234lm_126_spce-Ni2+" element="Ni" mass="58.69" name="ions234lm_126_spce-Ni2+"/>
+    <Type class="ions234lm_126_spce-Pt2+" element="Pt" mass="195.08" name="ions234lm_126_spce-Pt2+"/>
+    <Type class="ions234lm_126_spce-Zn2+" element="Zn" mass="65.4" name="ions234lm_126_spce-Zn2+"/>
+    <Type class="ions234lm_126_spce-Co2+" element="Co" mass="58.93" name="ions234lm_126_spce-Co2+"/>
+    <Type class="ions234lm_126_spce-Pd2+" element="Pd" mass="106.42" name="ions234lm_126_spce-Pd2+"/>
+    <Type class="ions234lm_126_spce-Ag2+" element="Ag" mass="107.87" name="ions234lm_126_spce-Ag2+"/>
+    <Type class="ions234lm_126_spce-Cr2+" element="Cr" mass="52.00" name="ions234lm_126_spce-Cr2+"/>
+    <Type class="ions234lm_126_spce-Fe2+" element="Fe" mass="55.85" name="ions234lm_126_spce-Fe2+"/>
+    <Type class="ions234lm_126_spce-Mg2+" element="Mg" mass="24.305" name="ions234lm_126_spce-Mg2+"/>
+    <Type class="ions234lm_126_spce-V2+" element="V" mass="50.94" name="ions234lm_126_spce-V2+"/>
+    <Type class="ions234lm_126_spce-Mn2+" element="Mn" mass="54.94" name="ions234lm_126_spce-Mn2+"/>
+    <Type class="ions234lm_126_spce-Hg2+" element="Hg" mass="200.59" name="ions234lm_126_spce-Hg2+"/>
+    <Type class="ions234lm_126_spce-Cd2+" element="Cd" mass="112.41" name="ions234lm_126_spce-Cd2+"/>
+    <Type class="ions234lm_126_spce-Yb2+" element="Yb" mass="173.05" name="ions234lm_126_spce-Yb2+"/>
+    <Type class="ions234lm_126_spce-Ca2+" element="Ca" mass="40.08" name="ions234lm_126_spce-Ca2+"/>
+    <Type class="ions234lm_126_spce-Sn2+" element="Sn" mass="118.71" name="ions234lm_126_spce-Sn2+"/>
+    <Type class="ions234lm_126_spce-Pb2+" element="Pb" mass="207.2" name="ions234lm_126_spce-Pb2+"/>
+    <Type class="ions234lm_126_spce-Eu2+" element="Eu" mass="151.96" name="ions234lm_126_spce-Eu2+"/>
+    <Type class="ions234lm_126_spce-Sr2+" element="Sr" mass="87.62" name="ions234lm_126_spce-Sr2+"/>
+    <Type class="ions234lm_126_spce-Sm2+" element="Sm" mass="150.36" name="ions234lm_126_spce-Sm2+"/>
+    <Type class="ions234lm_126_spce-Ba2+" element="Ba" mass="137.33" name="ions234lm_126_spce-Ba2+"/>
+    <Type class="ions234lm_126_spce-Ra2+" element="Ra" mass="226.03" name="ions234lm_126_spce-Ra2+"/>
+    <Type class="ions234lm_126_spce-Al3+" element="Al" mass="26.98" name="ions234lm_126_spce-Al3+"/>
+    <Type class="ions234lm_126_spce-Fe3+" element="Fe" mass="55.85" name="ions234lm_126_spce-Fe3+"/>
+    <Type class="ions234lm_126_spce-Cr3+" element="Cr" mass="52.00" name="ions234lm_126_spce-Cr3+"/>
+    <Type class="ions234lm_126_spce-In3+" element="In" mass="114.82" name="ions234lm_126_spce-In3+"/>
+    <Type class="ions234lm_126_spce-Tl3+" element="Tl" mass="204.38" name="ions234lm_126_spce-Tl3+"/>
+    <Type class="ions234lm_126_spce-Y3+" element="Y" mass="88.91" name="ions234lm_126_spce-Y3+"/>
+    <Type class="ions234lm_126_spce-La3+" element="La" mass="138.91" name="ions234lm_126_spce-La3+"/>
+    <Type class="ions234lm_126_spce-Ce3+" element="Ce" mass="140.12" name="ions234lm_126_spce-Ce3+"/>
+    <Type class="ions234lm_126_spce-Pr3+" element="Pr" mass="140.91" name="ions234lm_126_spce-Pr3+"/>
+    <Type class="ions234lm_126_spce-Nd3+" element="Nd" mass="144.24" name="ions234lm_126_spce-Nd3+"/>
+    <Type class="ions234lm_126_spce-Sm3+" element="Sm" mass="150.36" name="ions234lm_126_spce-Sm3+"/>
+    <Type class="ions234lm_126_spce-Eu3+" element="Eu" mass="151.96" name="ions234lm_126_spce-Eu3+"/>
+    <Type class="ions234lm_126_spce-Gd3+" element="Gd" mass="157.25" name="ions234lm_126_spce-Gd3+"/>
+    <Type class="ions234lm_126_spce-Tb3+" element="Tb" mass="158.93" name="ions234lm_126_spce-Tb3+"/>
+    <Type class="ions234lm_126_spce-Dy3+" element="Dy" mass="162.5" name="ions234lm_126_spce-Dy3+"/>
+    <Type class="ions234lm_126_spce-Er3+" element="Er" mass="167.26" name="ions234lm_126_spce-Er3+"/>
+    <Type class="ions234lm_126_spce-Tm3+" element="Tm" mass="168.93" name="ions234lm_126_spce-Tm3+"/>
+    <Type class="ions234lm_126_spce-Lu3+" element="Lu" mass="174.97" name="ions234lm_126_spce-Lu3+"/>
+    <Type class="ions234lm_126_spce-Hf4+" element="Hf" mass="178.49" name="ions234lm_126_spce-Hf4+"/>
+    <Type class="ions234lm_126_spce-Zr4+" element="Zr" mass="91.22" name="ions234lm_126_spce-Zr4+"/>
+    <Type class="ions234lm_126_spce-Ce4+" element="Ce" mass="140.12" name="ions234lm_126_spce-Ce4+"/>
+    <Type class="ions234lm_126_spce-U4+" element="U" mass="238.03" name="ions234lm_126_spce-U4+"/>
+    <Type class="ions234lm_126_spce-Pu4+" element="Pu" mass="244.06" name="ions234lm_126_spce-Pu4+"/>
+    <Type class="ions234lm_126_spce-Th4+" element="Th" mass="232.04" name="ions234lm_126_spce-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ions234lm_126_spce-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_126_spce-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_126_spce-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_126_spce-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_126_spce-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_126_spce-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_126_spce-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_126_spce-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_126_spce-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_126_spce-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_126_spce-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_126_spce-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_126_spce-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_126_spce-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ions234lm_126_spce-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_126_spce-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_126_spce-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_126_spce-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_126_spce-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_126_spce-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_126_spce-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_126_spce-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_126_spce-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_126_spce-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_126_spce-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_126_spce-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_126_spce-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_126_spce-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ions234lm_126_spce-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ions234lm_126_spce-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_126_spce-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ions234lm_126_spce-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_126_spce-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ions234lm_126_spce-Ra2+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ions234lm_126_spce-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_126_spce-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_126_spce-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_126_spce-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_126_spce-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_126_spce-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_126_spce-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_126_spce-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_126_spce-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_126_spce-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_126_spce-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ions234lm_126_spce-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_126_spce-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_126_spce-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="1.92464e-05" sigma="0.1712307336265732" type="ions234lm_126_spce-Be2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0067303824" sigma="0.21791382645712704" type="ions234lm_126_spce-Cu2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01065702456" sigma="0.223259218765969" type="ions234lm_126_spce-Ni2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.014015354" sigma="0.22664463389490233" type="ions234lm_126_spce-Pt2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.014823368080000001" sigma="0.2273573528694146" type="ions234lm_126_spce-Zn2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0218984284" sigma="0.23252456543462854" type="ions234lm_126_spce-Co2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0218984284" sigma="0.23252456543462854" type="ions234lm_126_spce-Pd2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03264699888" sigma="0.23822631723072674" type="ions234lm_126_spce-Ag2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03718454688" sigma="0.2401862944106355" type="ions234lm_126_spce-Cr2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03986113536" sigma="0.2412553728724039" type="ions234lm_126_spce-Fe2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.042686716080000006" sigma="0.2423244513341723" type="ions234lm_126_spce-Mg2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.045158958000000006" sigma="0.24321535005231262" type="ions234lm_126_spce-V2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0698627584" sigma="0.2505207195410634" type="ions234lm_126_spce-Mn2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0698627584" sigma="0.2505207195410634" type="ions234lm_126_spce-Hg2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07419972544" sigma="0.2515897980028318" type="ions234lm_126_spce-Cd2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.40718273784000003" sigma="0.2911457010882629" type="ions234lm_126_spce-Yb2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.40953067312" sigma="0.2913238808318909" type="ions234lm_126_spce-Ca2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.44813803104000005" sigma="0.29417475672994003" type="ions234lm_126_spce-Sn2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ions234lm_126_spce-Pb2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.8445052544000001" sigma="0.31822902211972925" type="ions234lm_126_spce-Eu2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.8713768270400001" sigma="0.31965446006875375" type="ions234lm_126_spce-Sr2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.89173069" sigma="0.32072353853052216" type="ions234lm_126_spce-Sm2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.55336865968" sigma="0.35279589238357434" type="ions234lm_126_spce-Ba2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.55336865968" sigma="0.35279589238357434" type="ions234lm_126_spce-Ra2+"/><!--     CM set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.019458696160000004" sigma="0.23092094774197594" type="ions234lm_126_spce-Al3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05678093848" sigma="0.24695712466850203" type="ions234lm_126_spce-Fe3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.035064095680000004" sigma="0.23929539569249514" type="ions234lm_126_spce-Cr3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11751709584" sigma="0.26032060544060714" type="ions234lm_126_spce-In3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18079185336" sigma="0.26958595210926667" type="ions234lm_126_spce-Tl3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_126_spce-Y3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.63014479248" sigma="0.3061127995530206" type="ions234lm_126_spce-La3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.69962078192" sigma="0.3102109336564662" type="ions234lm_126_spce-Ce3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.6781265697600001" sigma="0.3089636754510697" type="ions234lm_126_spce-Pr3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.52569060488" sigma="0.2995201490387821" type="ions234lm_126_spce-Nd3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.46816830344000004" sigma="0.2956001946789646" type="ions234lm_126_spce-Sm3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_126_spce-Eu3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.38186547936" sigma="0.2891857239083541" type="ions234lm_126_spce-Gd3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.39786810784" sigma="0.29043298211375057" type="ions234lm_126_spce-Tb3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.35100580160000006" sigma="0.28669120749756116" type="ions234lm_126_spce-Dy3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_126_spce-Er3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_126_spce-Tm3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.30760316128000004" sigma="0.28294943288137175" type="ions234lm_126_spce-Lu3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16448090592" sigma="0.26744779518572986" type="ions234lm_126_spce-Hf4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.19225856560000001" sigma="0.2710113900582912" type="ions234lm_126_spce-Zr4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.5474740988000001" sigma="0.3009455869878066" type="ions234lm_126_spce-Ce4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.5474740988000001" sigma="0.3009455869878066" type="ions234lm_126_spce-U4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_126_spce-Pu4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.61548811496" sigma="0.30522190083488027" type="ions234lm_126_spce-Th4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_126_tip3p.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_126_tip3p.xml
@@ -1,0 +1,255 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for TIP3P water model (12-6 normal usage set) -->
+    <DateGenerated>2022-09-11T06:28:33.635444</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_126_tip3p" md5hash="405901b178f491715900e854d2732a81" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_126_tip3p</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_126_tip3p-Be2+" element="Be" mass="9.01" name="ions234lm_126_tip3p-Be2+"/>
+    <Type class="ions234lm_126_tip3p-Cu2+" element="Cu" mass="63.55" name="ions234lm_126_tip3p-Cu2+"/>
+    <Type class="ions234lm_126_tip3p-Ni2+" element="Ni" mass="58.69" name="ions234lm_126_tip3p-Ni2+"/>
+    <Type class="ions234lm_126_tip3p-Pt2+" element="Pt" mass="195.08" name="ions234lm_126_tip3p-Pt2+"/>
+    <Type class="ions234lm_126_tip3p-Zn2+" element="Zn" mass="65.4" name="ions234lm_126_tip3p-Zn2+"/>
+    <Type class="ions234lm_126_tip3p-Co2+" element="Co" mass="58.93" name="ions234lm_126_tip3p-Co2+"/>
+    <Type class="ions234lm_126_tip3p-Pd2+" element="Pd" mass="106.42" name="ions234lm_126_tip3p-Pd2+"/>
+    <Type class="ions234lm_126_tip3p-Ag2+" element="Ag" mass="107.87" name="ions234lm_126_tip3p-Ag2+"/>
+    <Type class="ions234lm_126_tip3p-Cr2+" element="Cr" mass="52.00" name="ions234lm_126_tip3p-Cr2+"/>
+    <Type class="ions234lm_126_tip3p-Fe2+" element="Fe" mass="55.85" name="ions234lm_126_tip3p-Fe2+"/>
+    <Type class="ions234lm_126_tip3p-Mg2+" element="Mg" mass="24.305" name="ions234lm_126_tip3p-Mg2+"/>
+    <Type class="ions234lm_126_tip3p-V2+" element="V" mass="50.94" name="ions234lm_126_tip3p-V2+"/>
+    <Type class="ions234lm_126_tip3p-Mn2+" element="Mn" mass="54.94" name="ions234lm_126_tip3p-Mn2+"/>
+    <Type class="ions234lm_126_tip3p-Hg2+" element="Hg" mass="200.59" name="ions234lm_126_tip3p-Hg2+"/>
+    <Type class="ions234lm_126_tip3p-Cd2+" element="Cd" mass="112.41" name="ions234lm_126_tip3p-Cd2+"/>
+    <Type class="ions234lm_126_tip3p-Yb2+" element="Yb" mass="173.05" name="ions234lm_126_tip3p-Yb2+"/>
+    <Type class="ions234lm_126_tip3p-Ca2+" element="Ca" mass="40.08" name="ions234lm_126_tip3p-Ca2+"/>
+    <Type class="ions234lm_126_tip3p-Sn2+" element="Sn" mass="118.71" name="ions234lm_126_tip3p-Sn2+"/>
+    <Type class="ions234lm_126_tip3p-Pb2+" element="Pb" mass="207.2" name="ions234lm_126_tip3p-Pb2+"/>
+    <Type class="ions234lm_126_tip3p-Eu2+" element="Eu" mass="151.96" name="ions234lm_126_tip3p-Eu2+"/>
+    <Type class="ions234lm_126_tip3p-Sr2+" element="Sr" mass="87.62" name="ions234lm_126_tip3p-Sr2+"/>
+    <Type class="ions234lm_126_tip3p-Sm2+" element="Sm" mass="150.36" name="ions234lm_126_tip3p-Sm2+"/>
+    <Type class="ions234lm_126_tip3p-Ba2+" element="Ba" mass="137.33" name="ions234lm_126_tip3p-Ba2+"/>
+    <Type class="ions234lm_126_tip3p-Ra2+" element="Ra" mass="226.03" name="ions234lm_126_tip3p-Ra2+"/>
+    <Type class="ions234lm_126_tip3p-Al3+" element="Al" mass="26.98" name="ions234lm_126_tip3p-Al3+"/>
+    <Type class="ions234lm_126_tip3p-Fe3+" element="Fe" mass="55.85" name="ions234lm_126_tip3p-Fe3+"/>
+    <Type class="ions234lm_126_tip3p-Cr3+" element="Cr" mass="52.00" name="ions234lm_126_tip3p-Cr3+"/>
+    <Type class="ions234lm_126_tip3p-In3+" element="In" mass="114.82" name="ions234lm_126_tip3p-In3+"/>
+    <Type class="ions234lm_126_tip3p-Tl3+" element="Tl" mass="204.38" name="ions234lm_126_tip3p-Tl3+"/>
+    <Type class="ions234lm_126_tip3p-Y3+" element="Y" mass="88.91" name="ions234lm_126_tip3p-Y3+"/>
+    <Type class="ions234lm_126_tip3p-La3+" element="La" mass="138.91" name="ions234lm_126_tip3p-La3+"/>
+    <Type class="ions234lm_126_tip3p-Ce3+" element="Ce" mass="140.12" name="ions234lm_126_tip3p-Ce3+"/>
+    <Type class="ions234lm_126_tip3p-Pr3+" element="Pr" mass="140.91" name="ions234lm_126_tip3p-Pr3+"/>
+    <Type class="ions234lm_126_tip3p-Nd3+" element="Nd" mass="144.24" name="ions234lm_126_tip3p-Nd3+"/>
+    <Type class="ions234lm_126_tip3p-Sm3+" element="Sm" mass="150.36" name="ions234lm_126_tip3p-Sm3+"/>
+    <Type class="ions234lm_126_tip3p-Eu3+" element="Eu" mass="151.96" name="ions234lm_126_tip3p-Eu3+"/>
+    <Type class="ions234lm_126_tip3p-Gd3+" element="Gd" mass="157.25" name="ions234lm_126_tip3p-Gd3+"/>
+    <Type class="ions234lm_126_tip3p-Tb3+" element="Tb" mass="158.93" name="ions234lm_126_tip3p-Tb3+"/>
+    <Type class="ions234lm_126_tip3p-Dy3+" element="Dy" mass="162.5" name="ions234lm_126_tip3p-Dy3+"/>
+    <Type class="ions234lm_126_tip3p-Er3+" element="Er" mass="167.26" name="ions234lm_126_tip3p-Er3+"/>
+    <Type class="ions234lm_126_tip3p-Tm3+" element="Tm" mass="168.93" name="ions234lm_126_tip3p-Tm3+"/>
+    <Type class="ions234lm_126_tip3p-Lu3+" element="Lu" mass="174.97" name="ions234lm_126_tip3p-Lu3+"/>
+    <Type class="ions234lm_126_tip3p-Hf4+" element="Hf" mass="178.49" name="ions234lm_126_tip3p-Hf4+"/>
+    <Type class="ions234lm_126_tip3p-Zr4+" element="Zr" mass="91.22" name="ions234lm_126_tip3p-Zr4+"/>
+    <Type class="ions234lm_126_tip3p-Ce4+" element="Ce" mass="140.12" name="ions234lm_126_tip3p-Ce4+"/>
+    <Type class="ions234lm_126_tip3p-U4+" element="U" mass="238.03" name="ions234lm_126_tip3p-U4+"/>
+    <Type class="ions234lm_126_tip3p-Pu4+" element="Pu" mass="244.06" name="ions234lm_126_tip3p-Pu4+"/>
+    <Type class="ions234lm_126_tip3p-Th4+" element="Th" mass="232.04" name="ions234lm_126_tip3p-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ions234lm_126_tip3p-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_126_tip3p-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_126_tip3p-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_126_tip3p-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_126_tip3p-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_126_tip3p-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_126_tip3p-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_126_tip3p-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_126_tip3p-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_126_tip3p-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_126_tip3p-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_126_tip3p-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_126_tip3p-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_126_tip3p-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ions234lm_126_tip3p-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_126_tip3p-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_126_tip3p-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_126_tip3p-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_126_tip3p-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_126_tip3p-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_126_tip3p-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_126_tip3p-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_126_tip3p-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_126_tip3p-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_126_tip3p-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_126_tip3p-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_126_tip3p-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_126_tip3p-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ions234lm_126_tip3p-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ions234lm_126_tip3p-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_126_tip3p-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ions234lm_126_tip3p-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_126_tip3p-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ions234lm_126_tip3p-Ra2+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ions234lm_126_tip3p-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_126_tip3p-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_126_tip3p-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_126_tip3p-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_126_tip3p-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_126_tip3p-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_126_tip3p-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_126_tip3p-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_126_tip3p-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_126_tip3p-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_126_tip3p-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ions234lm_126_tip3p-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_126_tip3p-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_126_tip3p-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="1.6526800000000002e-05" sigma="0.17033983490843285" type="ions234lm_126_tip3p-Be2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00621311448" sigma="0.21702292773898668" type="ions234lm_126_tip3p-Cu2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0109754688" sigma="0.22361557825322517" type="ions234lm_126_tip3p-Ni2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01287174128" sigma="0.22557555543313393" type="ions234lm_126_tip3p-Pt2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01381916624" sigma="0.22646645415127425" type="ions234lm_126_tip3p-Zn2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.02024604128" sigma="0.23145548697286014" type="ions234lm_126_tip3p-Co2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.021335931440000004" sigma="0.23216820594737242" type="ions234lm_126_tip3p-Pd2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.032257342960000004" sigma="0.2380481374870987" type="ions234lm_126_tip3p-Ag2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03632456752" sigma="0.23982993492337937" type="ions234lm_126_tip3p-Cr2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03940482832" sigma="0.24107719312877582" type="ions234lm_126_tip3p-Fe2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.042686716080000006" sigma="0.2423244513341723" type="ions234lm_126_tip3p-Mg2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ions234lm_126_tip3p-V2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0705719464" sigma="0.25069889928469147" type="ions234lm_126_tip3p-Mn2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0705719464" sigma="0.25069889928469147" type="ions234lm_126_tip3p-Hg2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07419972544" sigma="0.2515897980028318" type="ions234lm_126_tip3p-Cd2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.426181194" sigma="0.29257113903728743" type="ions234lm_126_tip3p-Yb2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.4432056808" sigma="0.29381839724268394" type="ions234lm_126_tip3p-Ca2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_126_tip3p-Sn2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.71203621616" sigma="0.31092365263097843" type="ions234lm_126_tip3p-Pb2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.8985523254400001" sigma="0.3210798980177783" type="ions234lm_126_tip3p-Eu2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.92601852816" sigma="0.32250533596680286" type="ions234lm_126_tip3p-Sr2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.95724882464" sigma="0.32410895365945547" type="ions234lm_126_tip3p-Sm2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.7014071987200001" sigma="0.35974490238506907" type="ions234lm_126_tip3p-Ba2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.7014071987200001" sigma="0.35974490238506907" type="ions234lm_126_tip3p-Ra2+"/><!--     CM set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01971831336" sigma="0.23109912748560402" type="ions234lm_126_tip3p-Al3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05678093848" sigma="0.24695712466850203" type="ions234lm_126_tip3p-Fe3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.03548032" sigma="0.23947357543612321" type="ions234lm_126_tip3p-Cr3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11751709584" sigma="0.26032060544060714" type="ions234lm_126_tip3p-In3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18079185336" sigma="0.26958595210926667" type="ions234lm_126_tip3p-Tl3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_126_tip3p-Y3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.63014479248" sigma="0.3061127995530206" type="ions234lm_126_tip3p-La3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.69962078192" sigma="0.3102109336564662" type="ions234lm_126_tip3p-Ce3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.67508049224" sigma="0.3087854957074416" type="ions234lm_126_tip3p-Pr3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.52569060488" sigma="0.2995201490387821" type="ions234lm_126_tip3p-Nd3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.46816830344000004" sigma="0.2956001946789646" type="ions234lm_126_tip3p-Sm3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_126_tip3p-Eu3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.38186547936" sigma="0.2891857239083541" type="ions234lm_126_tip3p-Gd3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.39786810784" sigma="0.29043298211375057" type="ions234lm_126_tip3p-Tb3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.35100580160000006" sigma="0.28669120749756116" type="ions234lm_126_tip3p-Dy3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_126_tip3p-Er3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_126_tip3p-Tm3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.30760316128000004" sigma="0.28294943288137175" type="ions234lm_126_tip3p-Lu3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16186477624" sigma="0.26709143569847377" type="ions234lm_126_tip3p-Hf4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18934696184" sigma="0.27065503057103507" type="ions234lm_126_tip3p-Zr4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.53380618416" sigma="0.30005468826966625" type="ions234lm_126_tip3p-Ce4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.53380618416" sigma="0.30005468826966625" type="ions234lm_126_tip3p-U4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.47580293192" sigma="0.29613473390984874" type="ions234lm_126_tip3p-Pu4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.6009964544" sigma="0.3043310021167399" type="ions234lm_126_tip3p-Th4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_126_tip4pew.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_126_tip4pew.xml
@@ -1,0 +1,255 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for TIP4P/EW water model (12-6 normal usage set) -->
+    <DateGenerated>2022-09-11T06:28:33.586352</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_126_tip4pew" md5hash="3902b775a0fe5d42cab716a82c183747" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_126_tip4pew</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_126_tip4pew-Be2+" element="Be" mass="9.01" name="ions234lm_126_tip4pew-Be2+"/>
+    <Type class="ions234lm_126_tip4pew-Cu2+" element="Cu" mass="63.55" name="ions234lm_126_tip4pew-Cu2+"/>
+    <Type class="ions234lm_126_tip4pew-Ni2+" element="Ni" mass="58.69" name="ions234lm_126_tip4pew-Ni2+"/>
+    <Type class="ions234lm_126_tip4pew-Pt2+" element="Pt" mass="195.08" name="ions234lm_126_tip4pew-Pt2+"/>
+    <Type class="ions234lm_126_tip4pew-Zn2+" element="Zn" mass="65.4" name="ions234lm_126_tip4pew-Zn2+"/>
+    <Type class="ions234lm_126_tip4pew-Co2+" element="Co" mass="58.93" name="ions234lm_126_tip4pew-Co2+"/>
+    <Type class="ions234lm_126_tip4pew-Pd2+" element="Pd" mass="106.42" name="ions234lm_126_tip4pew-Pd2+"/>
+    <Type class="ions234lm_126_tip4pew-Ag2+" element="Ag" mass="107.87" name="ions234lm_126_tip4pew-Ag2+"/>
+    <Type class="ions234lm_126_tip4pew-Cr2+" element="Cr" mass="52.00" name="ions234lm_126_tip4pew-Cr2+"/>
+    <Type class="ions234lm_126_tip4pew-Fe2+" element="Fe" mass="55.85" name="ions234lm_126_tip4pew-Fe2+"/>
+    <Type class="ions234lm_126_tip4pew-Mg2+" element="Mg" mass="24.305" name="ions234lm_126_tip4pew-Mg2+"/>
+    <Type class="ions234lm_126_tip4pew-V2+" element="V" mass="50.94" name="ions234lm_126_tip4pew-V2+"/>
+    <Type class="ions234lm_126_tip4pew-Mn2+" element="Mn" mass="54.94" name="ions234lm_126_tip4pew-Mn2+"/>
+    <Type class="ions234lm_126_tip4pew-Hg2+" element="Hg" mass="200.59" name="ions234lm_126_tip4pew-Hg2+"/>
+    <Type class="ions234lm_126_tip4pew-Cd2+" element="Cd" mass="112.41" name="ions234lm_126_tip4pew-Cd2+"/>
+    <Type class="ions234lm_126_tip4pew-Yb2+" element="Yb" mass="173.05" name="ions234lm_126_tip4pew-Yb2+"/>
+    <Type class="ions234lm_126_tip4pew-Ca2+" element="Ca" mass="40.08" name="ions234lm_126_tip4pew-Ca2+"/>
+    <Type class="ions234lm_126_tip4pew-Sn2+" element="Sn" mass="118.71" name="ions234lm_126_tip4pew-Sn2+"/>
+    <Type class="ions234lm_126_tip4pew-Pb2+" element="Pb" mass="207.2" name="ions234lm_126_tip4pew-Pb2+"/>
+    <Type class="ions234lm_126_tip4pew-Eu2+" element="Eu" mass="151.96" name="ions234lm_126_tip4pew-Eu2+"/>
+    <Type class="ions234lm_126_tip4pew-Sr2+" element="Sr" mass="87.62" name="ions234lm_126_tip4pew-Sr2+"/>
+    <Type class="ions234lm_126_tip4pew-Sm2+" element="Sm" mass="150.36" name="ions234lm_126_tip4pew-Sm2+"/>
+    <Type class="ions234lm_126_tip4pew-Ba2+" element="Ba" mass="137.33" name="ions234lm_126_tip4pew-Ba2+"/>
+    <Type class="ions234lm_126_tip4pew-Ra2+" element="Ra" mass="226.03" name="ions234lm_126_tip4pew-Ra2+"/>
+    <Type class="ions234lm_126_tip4pew-Al3+" element="Al" mass="26.98" name="ions234lm_126_tip4pew-Al3+"/>
+    <Type class="ions234lm_126_tip4pew-Fe3+" element="Fe" mass="55.85" name="ions234lm_126_tip4pew-Fe3+"/>
+    <Type class="ions234lm_126_tip4pew-Cr3+" element="Cr" mass="52.00" name="ions234lm_126_tip4pew-Cr3+"/>
+    <Type class="ions234lm_126_tip4pew-In3+" element="In" mass="114.82" name="ions234lm_126_tip4pew-In3+"/>
+    <Type class="ions234lm_126_tip4pew-Tl3+" element="Tl" mass="204.38" name="ions234lm_126_tip4pew-Tl3+"/>
+    <Type class="ions234lm_126_tip4pew-Y3+" element="Y" mass="88.91" name="ions234lm_126_tip4pew-Y3+"/>
+    <Type class="ions234lm_126_tip4pew-La3+" element="La" mass="138.91" name="ions234lm_126_tip4pew-La3+"/>
+    <Type class="ions234lm_126_tip4pew-Ce3+" element="Ce" mass="140.12" name="ions234lm_126_tip4pew-Ce3+"/>
+    <Type class="ions234lm_126_tip4pew-Pr3+" element="Pr" mass="140.91" name="ions234lm_126_tip4pew-Pr3+"/>
+    <Type class="ions234lm_126_tip4pew-Nd3+" element="Nd" mass="144.24" name="ions234lm_126_tip4pew-Nd3+"/>
+    <Type class="ions234lm_126_tip4pew-Sm3+" element="Sm" mass="150.36" name="ions234lm_126_tip4pew-Sm3+"/>
+    <Type class="ions234lm_126_tip4pew-Eu3+" element="Eu" mass="151.96" name="ions234lm_126_tip4pew-Eu3+"/>
+    <Type class="ions234lm_126_tip4pew-Gd3+" element="Gd" mass="157.25" name="ions234lm_126_tip4pew-Gd3+"/>
+    <Type class="ions234lm_126_tip4pew-Tb3+" element="Tb" mass="158.93" name="ions234lm_126_tip4pew-Tb3+"/>
+    <Type class="ions234lm_126_tip4pew-Dy3+" element="Dy" mass="162.5" name="ions234lm_126_tip4pew-Dy3+"/>
+    <Type class="ions234lm_126_tip4pew-Er3+" element="Er" mass="167.26" name="ions234lm_126_tip4pew-Er3+"/>
+    <Type class="ions234lm_126_tip4pew-Tm3+" element="Tm" mass="168.93" name="ions234lm_126_tip4pew-Tm3+"/>
+    <Type class="ions234lm_126_tip4pew-Lu3+" element="Lu" mass="174.97" name="ions234lm_126_tip4pew-Lu3+"/>
+    <Type class="ions234lm_126_tip4pew-Hf4+" element="Hf" mass="178.49" name="ions234lm_126_tip4pew-Hf4+"/>
+    <Type class="ions234lm_126_tip4pew-Zr4+" element="Zr" mass="91.22" name="ions234lm_126_tip4pew-Zr4+"/>
+    <Type class="ions234lm_126_tip4pew-Ce4+" element="Ce" mass="140.12" name="ions234lm_126_tip4pew-Ce4+"/>
+    <Type class="ions234lm_126_tip4pew-U4+" element="U" mass="238.03" name="ions234lm_126_tip4pew-U4+"/>
+    <Type class="ions234lm_126_tip4pew-Pu4+" element="Pu" mass="244.06" name="ions234lm_126_tip4pew-Pu4+"/>
+    <Type class="ions234lm_126_tip4pew-Th4+" element="Th" mass="232.04" name="ions234lm_126_tip4pew-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ions234lm_126_tip4pew-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_126_tip4pew-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_126_tip4pew-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_126_tip4pew-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_126_tip4pew-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_126_tip4pew-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_126_tip4pew-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_126_tip4pew-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_126_tip4pew-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_126_tip4pew-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_126_tip4pew-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_126_tip4pew-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_126_tip4pew-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_126_tip4pew-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ions234lm_126_tip4pew-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_126_tip4pew-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_126_tip4pew-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_126_tip4pew-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_126_tip4pew-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_126_tip4pew-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_126_tip4pew-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_126_tip4pew-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_126_tip4pew-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_126_tip4pew-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_126_tip4pew-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_126_tip4pew-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_126_tip4pew-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_126_tip4pew-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ions234lm_126_tip4pew-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ions234lm_126_tip4pew-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_126_tip4pew-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ions234lm_126_tip4pew-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_126_tip4pew-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ions234lm_126_tip4pew-Ra2+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ions234lm_126_tip4pew-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_126_tip4pew-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_126_tip4pew-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_126_tip4pew-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_126_tip4pew-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_126_tip4pew-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_126_tip4pew-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_126_tip4pew-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_126_tip4pew-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_126_tip4pew-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_126_tip4pew-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ions234lm_126_tip4pew-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_126_tip4pew-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_126_tip4pew-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="4.853439999999999e-06" sigma="0.1635690046505663" type="ions234lm_126_tip4pew-Be2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00424537928" sigma="0.2129247936355411" type="ions234lm_126_tip4pew-Cu2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00651925776" sigma="0.21755746696987088" type="ions234lm_126_tip4pew-Ni2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01034627888" sigma="0.2229028592787129" type="ions234lm_126_tip4pew-Pt2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01050071032" sigma="0.22308103902234097" type="ions234lm_126_tip4pew-Zn2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01748020808" sigma="0.2294955097929514" type="ions234lm_126_tip4pew-Co2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01748020808" sigma="0.2294955097929514" type="ions234lm_126_tip4pew-Pd2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.027520218160000002" sigma="0.23573180081993375" type="ions234lm_126_tip4pew-Ag2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03111050856" sigma="0.23751359825621443" type="ions234lm_126_tip4pew-Cr2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.035064095680000004" sigma="0.23929539569249514" type="ions234lm_126_tip4pew-Fe2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03940482832" sigma="0.24107719312877582" type="ions234lm_126_tip4pew-Mg2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03940482832" sigma="0.24107719312877582" type="ions234lm_126_tip4pew-V2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.06639731856" sigma="0.24962982082292307" type="ions234lm_126_tip4pew-Mn2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.06639731856" sigma="0.24962982082292307" type="ions234lm_126_tip4pew-Hg2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0698627584" sigma="0.2505207195410634" type="ions234lm_126_tip4pew-Cd2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.45559312408" sigma="0.29470929596082424" type="ions234lm_126_tip4pew-Yb2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.46311578872000003" sigma="0.29524383519170844" type="ions234lm_126_tip4pew-Ca2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.49648724720000004" sigma="0.29756017185887335" type="ions234lm_126_tip4pew-Sn2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.7530346464" sigma="0.3132399892981433" type="ions234lm_126_tip4pew-Pb2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.9712365224" sigma="0.3248216726339677" type="ions234lm_126_tip4pew-Eu2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.985288068" sigma="0.32553439160847997" type="ions234lm_126_tip4pew-Sr2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.02424478992" sigma="0.3274943687883887" type="ions234lm_126_tip4pew-Sm2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.8181297948000001" sigma="0.3652684744375391" type="ions234lm_126_tip4pew-Ba2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.8181297948000001" sigma="0.3652684744375391" type="ions234lm_126_tip4pew-Ra2+"/><!--     CM set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01678206584" sigma="0.22896097056206718" type="ions234lm_126_tip4pew-Al3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05043699032" sigma="0.2449971474885933" type="ions234lm_126_tip4pew-Fe3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.03111050856" sigma="0.23751359825621443" type="ions234lm_126_tip4pew-Cr3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.10650049832000001" sigma="0.2583606282606984" type="ions234lm_126_tip4pew-In3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16579982824" sigma="0.2676259749293579" type="ions234lm_126_tip4pew-Tl3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ions234lm_126_tip4pew-Y3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.59811815528" sigma="0.30415282237311186" type="ions234lm_126_tip4pew-La3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.66295839824" sigma="0.3080727767329294" type="ions234lm_126_tip4pew-Ce3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.64198735344" sigma="0.30682551852753287" type="ions234lm_126_tip4pew-Pr3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.49387597096" sigma="0.2973819921152453" type="ions234lm_126_tip4pew-Nd3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.43830358088" sigma="0.29346203775542773" type="ions234lm_126_tip4pew-Sm3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.4580931896" sigma="0.29488747570445234" type="ions234lm_126_tip4pew-Eu3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.35748949536" sigma="0.2872257467284454" type="ions234lm_126_tip4pew-Gd3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.37289213824" sigma="0.28847300493384187" type="ions234lm_126_tip4pew-Tb3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.32577870832" sigma="0.28455305057402436" type="ions234lm_126_tip4pew-Dy3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ions234lm_126_tip4pew-Er3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ions234lm_126_tip4pew-Tm3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.28625681168" sigma="0.280989455701463" type="ions234lm_126_tip4pew-Lu3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.14196839183999999" sigma="0.26424055980042466" type="ions234lm_126_tip4pew-Hf4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16712607256" sigma="0.26780415467298596" type="ions234lm_126_tip4pew-Zr4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ions234lm_126_tip4pew-Ce4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ions234lm_126_tip4pew-U4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.43343181496" sigma="0.29310567826817163" type="ions234lm_126_tip4pew-Pu4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.5502288444000001" sigma="0.3011237667314347" type="ions234lm_126_tip4pew-Th4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_hfe_spce.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_hfe_spce.xml
@@ -1,0 +1,255 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for SPC/E water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.603058</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_hfe_spce" md5hash="ad366f1740e9f3c52e262041f5dcfdc9" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_hfe_spce</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_hfe_spce-Be2+" element="Be" mass="9.01" name="ions234lm_hfe_spce-Be2+"/>
+    <Type class="ions234lm_hfe_spce-Cu2+" element="Cu" mass="63.55" name="ions234lm_hfe_spce-Cu2+"/>
+    <Type class="ions234lm_hfe_spce-Ni2+" element="Ni" mass="58.69" name="ions234lm_hfe_spce-Ni2+"/>
+    <Type class="ions234lm_hfe_spce-Pt2+" element="Pt" mass="195.08" name="ions234lm_hfe_spce-Pt2+"/>
+    <Type class="ions234lm_hfe_spce-Zn2+" element="Zn" mass="65.4" name="ions234lm_hfe_spce-Zn2+"/>
+    <Type class="ions234lm_hfe_spce-Co2+" element="Co" mass="58.93" name="ions234lm_hfe_spce-Co2+"/>
+    <Type class="ions234lm_hfe_spce-Pd2+" element="Pd" mass="106.42" name="ions234lm_hfe_spce-Pd2+"/>
+    <Type class="ions234lm_hfe_spce-Ag2+" element="Ag" mass="107.87" name="ions234lm_hfe_spce-Ag2+"/>
+    <Type class="ions234lm_hfe_spce-Cr2+" element="Cr" mass="52.00" name="ions234lm_hfe_spce-Cr2+"/>
+    <Type class="ions234lm_hfe_spce-Fe2+" element="Fe" mass="55.85" name="ions234lm_hfe_spce-Fe2+"/>
+    <Type class="ions234lm_hfe_spce-Mg2+" element="Mg" mass="24.305" name="ions234lm_hfe_spce-Mg2+"/>
+    <Type class="ions234lm_hfe_spce-V2+" element="V" mass="50.94" name="ions234lm_hfe_spce-V2+"/>
+    <Type class="ions234lm_hfe_spce-Mn2+" element="Mn" mass="54.94" name="ions234lm_hfe_spce-Mn2+"/>
+    <Type class="ions234lm_hfe_spce-Hg2+" element="Hg" mass="200.59" name="ions234lm_hfe_spce-Hg2+"/>
+    <Type class="ions234lm_hfe_spce-Cd2+" element="Cd" mass="112.41" name="ions234lm_hfe_spce-Cd2+"/>
+    <Type class="ions234lm_hfe_spce-Yb2+" element="Yb" mass="173.05" name="ions234lm_hfe_spce-Yb2+"/>
+    <Type class="ions234lm_hfe_spce-Ca2+" element="Ca" mass="40.08" name="ions234lm_hfe_spce-Ca2+"/>
+    <Type class="ions234lm_hfe_spce-Sn2+" element="Sn" mass="118.71" name="ions234lm_hfe_spce-Sn2+"/>
+    <Type class="ions234lm_hfe_spce-Pb2+" element="Pb" mass="207.2" name="ions234lm_hfe_spce-Pb2+"/>
+    <Type class="ions234lm_hfe_spce-Eu2+" element="Eu" mass="151.96" name="ions234lm_hfe_spce-Eu2+"/>
+    <Type class="ions234lm_hfe_spce-Sr2+" element="Sr" mass="87.62" name="ions234lm_hfe_spce-Sr2+"/>
+    <Type class="ions234lm_hfe_spce-Sm2+" element="Sm" mass="150.36" name="ions234lm_hfe_spce-Sm2+"/>
+    <Type class="ions234lm_hfe_spce-Ba2+" element="Ba" mass="137.33" name="ions234lm_hfe_spce-Ba2+"/>
+    <Type class="ions234lm_hfe_spce-Ra2+" element="Ra" mass="226.03" name="ions234lm_hfe_spce-Ra2+"/>
+    <Type class="ions234lm_hfe_spce-Al3+" element="Al" mass="26.98" name="ions234lm_hfe_spce-Al3+"/>
+    <Type class="ions234lm_hfe_spce-Fe3+" element="Fe" mass="55.85" name="ions234lm_hfe_spce-Fe3+"/>
+    <Type class="ions234lm_hfe_spce-Cr3+" element="Cr" mass="52.00" name="ions234lm_hfe_spce-Cr3+"/>
+    <Type class="ions234lm_hfe_spce-In3+" element="In" mass="114.82" name="ions234lm_hfe_spce-In3+"/>
+    <Type class="ions234lm_hfe_spce-Tl3+" element="Tl" mass="204.38" name="ions234lm_hfe_spce-Tl3+"/>
+    <Type class="ions234lm_hfe_spce-Y3+" element="Y" mass="88.91" name="ions234lm_hfe_spce-Y3+"/>
+    <Type class="ions234lm_hfe_spce-La3+" element="La" mass="138.91" name="ions234lm_hfe_spce-La3+"/>
+    <Type class="ions234lm_hfe_spce-Ce3+" element="Ce" mass="140.12" name="ions234lm_hfe_spce-Ce3+"/>
+    <Type class="ions234lm_hfe_spce-Pr3+" element="Pr" mass="140.91" name="ions234lm_hfe_spce-Pr3+"/>
+    <Type class="ions234lm_hfe_spce-Nd3+" element="Nd" mass="144.24" name="ions234lm_hfe_spce-Nd3+"/>
+    <Type class="ions234lm_hfe_spce-Sm3+" element="Sm" mass="150.36" name="ions234lm_hfe_spce-Sm3+"/>
+    <Type class="ions234lm_hfe_spce-Eu3+" element="Eu" mass="151.96" name="ions234lm_hfe_spce-Eu3+"/>
+    <Type class="ions234lm_hfe_spce-Gd3+" element="Gd" mass="157.25" name="ions234lm_hfe_spce-Gd3+"/>
+    <Type class="ions234lm_hfe_spce-Tb3+" element="Tb" mass="158.93" name="ions234lm_hfe_spce-Tb3+"/>
+    <Type class="ions234lm_hfe_spce-Dy3+" element="Dy" mass="162.5" name="ions234lm_hfe_spce-Dy3+"/>
+    <Type class="ions234lm_hfe_spce-Er3+" element="Er" mass="167.26" name="ions234lm_hfe_spce-Er3+"/>
+    <Type class="ions234lm_hfe_spce-Tm3+" element="Tm" mass="168.93" name="ions234lm_hfe_spce-Tm3+"/>
+    <Type class="ions234lm_hfe_spce-Lu3+" element="Lu" mass="174.97" name="ions234lm_hfe_spce-Lu3+"/>
+    <Type class="ions234lm_hfe_spce-Hf4+" element="Hf" mass="178.49" name="ions234lm_hfe_spce-Hf4+"/>
+    <Type class="ions234lm_hfe_spce-Zr4+" element="Zr" mass="91.22" name="ions234lm_hfe_spce-Zr4+"/>
+    <Type class="ions234lm_hfe_spce-Ce4+" element="Ce" mass="140.12" name="ions234lm_hfe_spce-Ce4+"/>
+    <Type class="ions234lm_hfe_spce-U4+" element="U" mass="238.03" name="ions234lm_hfe_spce-U4+"/>
+    <Type class="ions234lm_hfe_spce-Pu4+" element="Pu" mass="244.06" name="ions234lm_hfe_spce-Pu4+"/>
+    <Type class="ions234lm_hfe_spce-Th4+" element="Th" mass="232.04" name="ions234lm_hfe_spce-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ions234lm_hfe_spce-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_hfe_spce-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_hfe_spce-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_hfe_spce-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_hfe_spce-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_hfe_spce-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_hfe_spce-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_hfe_spce-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_hfe_spce-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_hfe_spce-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_hfe_spce-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_hfe_spce-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_hfe_spce-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_hfe_spce-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ions234lm_hfe_spce-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_hfe_spce-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_hfe_spce-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_hfe_spce-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_hfe_spce-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_hfe_spce-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_hfe_spce-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_hfe_spce-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_hfe_spce-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_hfe_spce-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_hfe_spce-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_hfe_spce-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_hfe_spce-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_hfe_spce-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ions234lm_hfe_spce-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ions234lm_hfe_spce-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_hfe_spce-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ions234lm_hfe_spce-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_hfe_spce-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ions234lm_hfe_spce-Ra2+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ions234lm_hfe_spce-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_hfe_spce-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_hfe_spce-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_hfe_spce-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_hfe_spce-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_hfe_spce-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_hfe_spce-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_hfe_spce-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_hfe_spce-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_hfe_spce-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_hfe_spce-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ions234lm_hfe_spce-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_hfe_spce-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_hfe_spce-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="4.3932e-06" sigma="0.1630344654196821" type="ions234lm_hfe_spce-Be2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00185158736" sigma="0.20472852542865" type="ions234lm_hfe_spce-Cu2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0025439975199999998" sigma="0.20775758107032713" type="ions234lm_hfe_spce-Ni2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0030480021600000004" sigma="0.2095393785066078" type="ions234lm_hfe_spce-Pt2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0031585016" sigma="0.20989573799386393" type="ions234lm_hfe_spce-Zn2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00611382816" sigma="0.21684474799535858" type="ions234lm_hfe_spce-Co2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00611382816" sigma="0.21684474799535858" type="ions234lm_hfe_spce-Pd2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.012688858640000002" sigma="0.22539737568950585" type="ions234lm_hfe_spce-Ag2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.014823368080000001" sigma="0.2273573528694146" type="ions234lm_hfe_spce-Cr2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01655449808" sigma="0.22878279081843914" type="ions234lm_hfe_spce-Fe2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01748020808" sigma="0.2294955097929514" type="ions234lm_hfe_spce-Mg2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01869645504" sigma="0.23038640851109174" type="ions234lm_hfe_spce-V2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03304037856" sigma="0.2384044969743548" type="ions234lm_hfe_spce-Mn2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03304037856" sigma="0.2384044969743548" type="ions234lm_hfe_spce-Hg2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.03548032" sigma="0.23947357543612321" type="ions234lm_hfe_spce-Cd2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.18790243584000002" sigma="0.270476850827407" type="ions234lm_hfe_spce-Yb2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.19079901904000002" sigma="0.2708332103146632" type="ions234lm_hfe_spce-Ca2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.2088123524" sigma="0.2729713672382" type="ions234lm_hfe_spce-Sn2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.35100580160000006" sigma="0.28669120749756116" type="ions234lm_hfe_spce-Pb2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.46060074448" sigma="0.29506565544808033" type="ions234lm_hfe_spce-Eu2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.46816830344000004" sigma="0.2956001946789646" type="ions234lm_hfe_spce-Sr2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ions234lm_hfe_spce-Sm2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.97825442928" sigma="0.32517803212122387" type="ions234lm_hfe_spce-Ba2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.97825442928" sigma="0.32517803212122387" type="ions234lm_hfe_spce-Ra2+"/><!--     HFE set for SPC\E water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="4.631688e-05" sigma="0.17657612593541527" type="ions234lm_hfe_spce-Al3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0005632500800000001" sigma="0.19439410029822202" type="ions234lm_hfe_spce-Fe3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.004318222720000001" sigma="0.21310297337916914" type="ions234lm_hfe_spce-Cr3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0053666912800000004" sigma="0.21541931004633408" type="ions234lm_hfe_spce-In3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00572994616" sigma="0.21613202902084636" type="ions234lm_hfe_spce-Tl3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11545547168" sigma="0.25996424595335105" type="ions234lm_hfe_spce-Y3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.39555874904000005" sigma="0.2902548023701225" type="ions234lm_hfe_spce-La3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.32577870832" sigma="0.28455305057402436" type="ions234lm_hfe_spce-Ce3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.27501557520000003" sigma="0.2799203772396946" type="ions234lm_hfe_spce-Pr3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.23958713680000002" sigma="0.27635678236713324" type="ions234lm_hfe_spce-Nd3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.19966935008" sigma="0.2719022887764316" type="ions234lm_hfe_spce-Sm3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.17250406064" sigma="0.26851687364749827" type="ions234lm_hfe_spce-Eu3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16186477624" sigma="0.26709143569847377" type="ions234lm_hfe_spce-Gd3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.14435620064" sigma="0.2645969192876808" type="ions234lm_hfe_spce-Tb3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.12933141480000002" sigma="0.26228058262051585" type="ions234lm_hfe_spce-Dy3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0935912684" sigma="0.25586611184990543" type="ions234lm_hfe_spce-Er3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.08510343864" sigma="0.2540843144136248" type="ions234lm_hfe_spce-Tm3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.08510343864" sigma="0.2540843144136248" type="ions234lm_hfe_spce-Lu3+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0006562604" sigma="0.19564135850361852" type="ions234lm_hfe_spce-Hf4+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00185158736" sigma="0.20472852542865" type="ions234lm_hfe_spce-Zr4+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.042686716080000006" sigma="0.2423244513341723" type="ions234lm_hfe_spce-Ce4+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00621311448" sigma="0.21702292773898668" type="ions234lm_hfe_spce-U4+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0158868572" sigma="0.22824825158755493" type="ions234lm_hfe_spce-Pu4+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.12494139464000001" sigma="0.26156786364600365" type="ions234lm_hfe_spce-Th4+"/><!--     HFE set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_hfe_tip3p.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_hfe_tip3p.xml
@@ -1,0 +1,255 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for TIP3P water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.648533</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_hfe_tip3p" md5hash="06e6525fdf7340d7a50db770bc3f90c5" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_hfe_tip3p</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_hfe_tip3p-Be2+" element="Be" mass="9.01" name="ions234lm_hfe_tip3p-Be2+"/>
+    <Type class="ions234lm_hfe_tip3p-Cu2+" element="Cu" mass="63.55" name="ions234lm_hfe_tip3p-Cu2+"/>
+    <Type class="ions234lm_hfe_tip3p-Ni2+" element="Ni" mass="58.69" name="ions234lm_hfe_tip3p-Ni2+"/>
+    <Type class="ions234lm_hfe_tip3p-Pt2+" element="Pt" mass="195.08" name="ions234lm_hfe_tip3p-Pt2+"/>
+    <Type class="ions234lm_hfe_tip3p-Zn2+" element="Zn" mass="65.4" name="ions234lm_hfe_tip3p-Zn2+"/>
+    <Type class="ions234lm_hfe_tip3p-Co2+" element="Co" mass="58.93" name="ions234lm_hfe_tip3p-Co2+"/>
+    <Type class="ions234lm_hfe_tip3p-Pd2+" element="Pd" mass="106.42" name="ions234lm_hfe_tip3p-Pd2+"/>
+    <Type class="ions234lm_hfe_tip3p-Ag2+" element="Ag" mass="107.87" name="ions234lm_hfe_tip3p-Ag2+"/>
+    <Type class="ions234lm_hfe_tip3p-Cr2+" element="Cr" mass="52.00" name="ions234lm_hfe_tip3p-Cr2+"/>
+    <Type class="ions234lm_hfe_tip3p-Fe2+" element="Fe" mass="55.85" name="ions234lm_hfe_tip3p-Fe2+"/>
+    <Type class="ions234lm_hfe_tip3p-Mg2+" element="Mg" mass="24.305" name="ions234lm_hfe_tip3p-Mg2+"/>
+    <Type class="ions234lm_hfe_tip3p-V2+" element="V" mass="50.94" name="ions234lm_hfe_tip3p-V2+"/>
+    <Type class="ions234lm_hfe_tip3p-Mn2+" element="Mn" mass="54.94" name="ions234lm_hfe_tip3p-Mn2+"/>
+    <Type class="ions234lm_hfe_tip3p-Hg2+" element="Hg" mass="200.59" name="ions234lm_hfe_tip3p-Hg2+"/>
+    <Type class="ions234lm_hfe_tip3p-Cd2+" element="Cd" mass="112.41" name="ions234lm_hfe_tip3p-Cd2+"/>
+    <Type class="ions234lm_hfe_tip3p-Yb2+" element="Yb" mass="173.05" name="ions234lm_hfe_tip3p-Yb2+"/>
+    <Type class="ions234lm_hfe_tip3p-Ca2+" element="Ca" mass="40.08" name="ions234lm_hfe_tip3p-Ca2+"/>
+    <Type class="ions234lm_hfe_tip3p-Sn2+" element="Sn" mass="118.71" name="ions234lm_hfe_tip3p-Sn2+"/>
+    <Type class="ions234lm_hfe_tip3p-Pb2+" element="Pb" mass="207.2" name="ions234lm_hfe_tip3p-Pb2+"/>
+    <Type class="ions234lm_hfe_tip3p-Eu2+" element="Eu" mass="151.96" name="ions234lm_hfe_tip3p-Eu2+"/>
+    <Type class="ions234lm_hfe_tip3p-Sr2+" element="Sr" mass="87.62" name="ions234lm_hfe_tip3p-Sr2+"/>
+    <Type class="ions234lm_hfe_tip3p-Sm2+" element="Sm" mass="150.36" name="ions234lm_hfe_tip3p-Sm2+"/>
+    <Type class="ions234lm_hfe_tip3p-Ba2+" element="Ba" mass="137.33" name="ions234lm_hfe_tip3p-Ba2+"/>
+    <Type class="ions234lm_hfe_tip3p-Ra2+" element="Ra" mass="226.03" name="ions234lm_hfe_tip3p-Ra2+"/>
+    <Type class="ions234lm_hfe_tip3p-Al3+" element="Al" mass="26.98" name="ions234lm_hfe_tip3p-Al3+"/>
+    <Type class="ions234lm_hfe_tip3p-Fe3+" element="Fe" mass="55.85" name="ions234lm_hfe_tip3p-Fe3+"/>
+    <Type class="ions234lm_hfe_tip3p-Cr3+" element="Cr" mass="52.00" name="ions234lm_hfe_tip3p-Cr3+"/>
+    <Type class="ions234lm_hfe_tip3p-In3+" element="In" mass="114.82" name="ions234lm_hfe_tip3p-In3+"/>
+    <Type class="ions234lm_hfe_tip3p-Tl3+" element="Tl" mass="204.38" name="ions234lm_hfe_tip3p-Tl3+"/>
+    <Type class="ions234lm_hfe_tip3p-Y3+" element="Y" mass="88.91" name="ions234lm_hfe_tip3p-Y3+"/>
+    <Type class="ions234lm_hfe_tip3p-La3+" element="La" mass="138.91" name="ions234lm_hfe_tip3p-La3+"/>
+    <Type class="ions234lm_hfe_tip3p-Ce3+" element="Ce" mass="140.12" name="ions234lm_hfe_tip3p-Ce3+"/>
+    <Type class="ions234lm_hfe_tip3p-Pr3+" element="Pr" mass="140.91" name="ions234lm_hfe_tip3p-Pr3+"/>
+    <Type class="ions234lm_hfe_tip3p-Nd3+" element="Nd" mass="144.24" name="ions234lm_hfe_tip3p-Nd3+"/>
+    <Type class="ions234lm_hfe_tip3p-Sm3+" element="Sm" mass="150.36" name="ions234lm_hfe_tip3p-Sm3+"/>
+    <Type class="ions234lm_hfe_tip3p-Eu3+" element="Eu" mass="151.96" name="ions234lm_hfe_tip3p-Eu3+"/>
+    <Type class="ions234lm_hfe_tip3p-Gd3+" element="Gd" mass="157.25" name="ions234lm_hfe_tip3p-Gd3+"/>
+    <Type class="ions234lm_hfe_tip3p-Tb3+" element="Tb" mass="158.93" name="ions234lm_hfe_tip3p-Tb3+"/>
+    <Type class="ions234lm_hfe_tip3p-Dy3+" element="Dy" mass="162.5" name="ions234lm_hfe_tip3p-Dy3+"/>
+    <Type class="ions234lm_hfe_tip3p-Er3+" element="Er" mass="167.26" name="ions234lm_hfe_tip3p-Er3+"/>
+    <Type class="ions234lm_hfe_tip3p-Tm3+" element="Tm" mass="168.93" name="ions234lm_hfe_tip3p-Tm3+"/>
+    <Type class="ions234lm_hfe_tip3p-Lu3+" element="Lu" mass="174.97" name="ions234lm_hfe_tip3p-Lu3+"/>
+    <Type class="ions234lm_hfe_tip3p-Hf4+" element="Hf" mass="178.49" name="ions234lm_hfe_tip3p-Hf4+"/>
+    <Type class="ions234lm_hfe_tip3p-Zr4+" element="Zr" mass="91.22" name="ions234lm_hfe_tip3p-Zr4+"/>
+    <Type class="ions234lm_hfe_tip3p-Ce4+" element="Ce" mass="140.12" name="ions234lm_hfe_tip3p-Ce4+"/>
+    <Type class="ions234lm_hfe_tip3p-U4+" element="U" mass="238.03" name="ions234lm_hfe_tip3p-U4+"/>
+    <Type class="ions234lm_hfe_tip3p-Pu4+" element="Pu" mass="244.06" name="ions234lm_hfe_tip3p-Pu4+"/>
+    <Type class="ions234lm_hfe_tip3p-Th4+" element="Th" mass="232.04" name="ions234lm_hfe_tip3p-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ions234lm_hfe_tip3p-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_hfe_tip3p-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_hfe_tip3p-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_hfe_tip3p-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_hfe_tip3p-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_hfe_tip3p-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_hfe_tip3p-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_hfe_tip3p-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_hfe_tip3p-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_hfe_tip3p-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_hfe_tip3p-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_hfe_tip3p-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_hfe_tip3p-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_hfe_tip3p-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ions234lm_hfe_tip3p-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_hfe_tip3p-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_hfe_tip3p-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_hfe_tip3p-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_hfe_tip3p-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_hfe_tip3p-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_hfe_tip3p-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_hfe_tip3p-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_hfe_tip3p-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_hfe_tip3p-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_hfe_tip3p-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_hfe_tip3p-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_hfe_tip3p-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_hfe_tip3p-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ions234lm_hfe_tip3p-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ions234lm_hfe_tip3p-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_hfe_tip3p-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ions234lm_hfe_tip3p-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_hfe_tip3p-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ions234lm_hfe_tip3p-Ra2+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ions234lm_hfe_tip3p-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_hfe_tip3p-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_hfe_tip3p-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_hfe_tip3p-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_hfe_tip3p-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_hfe_tip3p-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_hfe_tip3p-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_hfe_tip3p-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_hfe_tip3p-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_hfe_tip3p-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_hfe_tip3p-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ions234lm_hfe_tip3p-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_hfe_tip3p-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_hfe_tip3p-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="3.3472e-06" sigma="0.16160902747065756" type="ions234lm_hfe_tip3p-Be2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00168209352" sigma="0.20383762671050965" type="ions234lm_hfe_tip3p-Cu2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00236358344" sigma="0.20704486209581485" type="ions234lm_hfe_tip3p-Ni2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00288846624" sigma="0.2090048392757236" type="ions234lm_hfe_tip3p-Pt2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00299398672" sigma="0.20936119876297973" type="ions234lm_hfe_tip3p-Zn2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00554580832" sigma="0.21577566953359018" type="ions234lm_hfe_tip3p-Co2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00591923032" sigma="0.21648838850810248" type="ions234lm_hfe_tip3p-Pd2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.012329536720000001" sigma="0.2250410162022497" type="ions234lm_hfe_tip3p-Ag2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0142138848" sigma="0.22682281363853038" type="ions234lm_hfe_tip3p-Cr2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.015031229200000001" sigma="0.22753553261304266" type="ions234lm_hfe_tip3p-Fe2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01655449808" sigma="0.22878279081843914" type="ions234lm_hfe_tip3p-Mg2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01795869032" sigma="0.22985186928020754" type="ions234lm_hfe_tip3p-V2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ions234lm_hfe_tip3p-Mn2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ions234lm_hfe_tip3p-Hg2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ions234lm_hfe_tip3p-Cd2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.19966935008" sigma="0.2719022887764316" type="ions234lm_hfe_tip3p-Yb2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.20268659984" sigma="0.2722586482636877" type="ions234lm_hfe_tip3p-Ca2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.22628971536" sigma="0.2749313444181087" type="ions234lm_hfe_tip3p-Sn2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.37512380016" sigma="0.2886511846774699" type="ions234lm_hfe_tip3p-Pb2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_hfe_tip3p-Eu2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.5017316820000001" sigma="0.29791653134612944" type="ions234lm_hfe_tip3p-Sr2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.52299970712" sigma="0.299341969295154" type="ions234lm_hfe_tip3p-Sm2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.0385202632000001" sigma="0.32820708776290103" type="ions234lm_hfe_tip3p-Ba2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.0385202632000001" sigma="0.32820708776290103" type="ions234lm_hfe_tip3p-Ra2+"/><!--     HFE set for TIP3P water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="3.481088e-05" sigma="0.17479432849913457" type="ions234lm_hfe_tip3p-Al3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00046095128" sigma="0.19279048260556944" type="ions234lm_hfe_tip3p-Fe3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00376430296" sigma="0.21167753543014461" type="ions234lm_hfe_tip3p-Cr3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00477804432" sigma="0.21417205184093757" type="ions234lm_hfe_tip3p-In3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00510728328" sigma="0.21488477081544982" type="ions234lm_hfe_tip3p-Tl3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11041584368" sigma="0.25907334723521064" type="ions234lm_hfe_tip3p-Y3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.39325717248000003" sigma="0.2900766226264945" type="ions234lm_hfe_tip3p-La3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.32168445512000005" sigma="0.28419669108676826" type="ions234lm_hfe_tip3p-Ce3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.2695012724" sigma="0.27938583800881045" type="ions234lm_hfe_tip3p-Pr3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.23454240432" sigma="0.2758222431362491" type="ions234lm_hfe_tip3p-Nd3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.19372564336" sigma="0.2711895698019193" type="ions234lm_hfe_tip3p-Sm3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16712607256" sigma="0.26780415467298596" type="ions234lm_hfe_tip3p-Eu3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.15671933488" sigma="0.26637871672396146" type="ions234lm_hfe_tip3p-Gd3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.13960849032" sigma="0.2638842003131685" type="ions234lm_hfe_tip3p-Tb3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.12494139464000001" sigma="0.26156786364600365" type="ions234lm_hfe_tip3p-Dy3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.08927271096" sigma="0.25497521313176513" type="ions234lm_hfe_tip3p-Er3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.08108064815999999" sigma="0.2531934156954844" type="ions234lm_hfe_tip3p-Tm3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.08108064815999999" sigma="0.2531934156954844" type="ions234lm_hfe_tip3p-Lu3+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0005155106400000001" sigma="0.19368138132370977" type="ions234lm_hfe_tip3p-Hf4+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00152628136" sigma="0.20294672799236932" type="ions234lm_hfe_tip3p-Zr4+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.03940482832" sigma="0.24107719312877582" type="ions234lm_hfe_tip3p-Ce4+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0053666912800000004" sigma="0.21541931004633408" type="ions234lm_hfe_tip3p-U4+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0142138848" sigma="0.22682281363853038" type="ions234lm_hfe_tip3p-Pu4+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11960507919999999" sigma="0.2606769649278633" type="ions234lm_hfe_tip3p-Th4+"/><!--     HFE set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_hfe_tip4pew.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_hfe_tip4pew.xml
@@ -1,0 +1,255 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for TIP4P/EW water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.582841</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_hfe_tip4pew" md5hash="8409f4a567b72ca99a35153b02e08d8f" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_hfe_tip4pew</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_hfe_tip4pew-Be2+" element="Be" mass="9.01" name="ions234lm_hfe_tip4pew-Be2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Cu2+" element="Cu" mass="63.55" name="ions234lm_hfe_tip4pew-Cu2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ni2+" element="Ni" mass="58.69" name="ions234lm_hfe_tip4pew-Ni2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Pt2+" element="Pt" mass="195.08" name="ions234lm_hfe_tip4pew-Pt2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Zn2+" element="Zn" mass="65.4" name="ions234lm_hfe_tip4pew-Zn2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Co2+" element="Co" mass="58.93" name="ions234lm_hfe_tip4pew-Co2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Pd2+" element="Pd" mass="106.42" name="ions234lm_hfe_tip4pew-Pd2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ag2+" element="Ag" mass="107.87" name="ions234lm_hfe_tip4pew-Ag2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Cr2+" element="Cr" mass="52.00" name="ions234lm_hfe_tip4pew-Cr2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Fe2+" element="Fe" mass="55.85" name="ions234lm_hfe_tip4pew-Fe2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Mg2+" element="Mg" mass="24.305" name="ions234lm_hfe_tip4pew-Mg2+"/>
+    <Type class="ions234lm_hfe_tip4pew-V2+" element="V" mass="50.94" name="ions234lm_hfe_tip4pew-V2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Mn2+" element="Mn" mass="54.94" name="ions234lm_hfe_tip4pew-Mn2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Hg2+" element="Hg" mass="200.59" name="ions234lm_hfe_tip4pew-Hg2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Cd2+" element="Cd" mass="112.41" name="ions234lm_hfe_tip4pew-Cd2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Yb2+" element="Yb" mass="173.05" name="ions234lm_hfe_tip4pew-Yb2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ca2+" element="Ca" mass="40.08" name="ions234lm_hfe_tip4pew-Ca2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Sn2+" element="Sn" mass="118.71" name="ions234lm_hfe_tip4pew-Sn2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Pb2+" element="Pb" mass="207.2" name="ions234lm_hfe_tip4pew-Pb2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Eu2+" element="Eu" mass="151.96" name="ions234lm_hfe_tip4pew-Eu2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Sr2+" element="Sr" mass="87.62" name="ions234lm_hfe_tip4pew-Sr2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Sm2+" element="Sm" mass="150.36" name="ions234lm_hfe_tip4pew-Sm2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ba2+" element="Ba" mass="137.33" name="ions234lm_hfe_tip4pew-Ba2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ra2+" element="Ra" mass="226.03" name="ions234lm_hfe_tip4pew-Ra2+"/>
+    <Type class="ions234lm_hfe_tip4pew-Al3+" element="Al" mass="26.98" name="ions234lm_hfe_tip4pew-Al3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Fe3+" element="Fe" mass="55.85" name="ions234lm_hfe_tip4pew-Fe3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Cr3+" element="Cr" mass="52.00" name="ions234lm_hfe_tip4pew-Cr3+"/>
+    <Type class="ions234lm_hfe_tip4pew-In3+" element="In" mass="114.82" name="ions234lm_hfe_tip4pew-In3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Tl3+" element="Tl" mass="204.38" name="ions234lm_hfe_tip4pew-Tl3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Y3+" element="Y" mass="88.91" name="ions234lm_hfe_tip4pew-Y3+"/>
+    <Type class="ions234lm_hfe_tip4pew-La3+" element="La" mass="138.91" name="ions234lm_hfe_tip4pew-La3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ce3+" element="Ce" mass="140.12" name="ions234lm_hfe_tip4pew-Ce3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Pr3+" element="Pr" mass="140.91" name="ions234lm_hfe_tip4pew-Pr3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Nd3+" element="Nd" mass="144.24" name="ions234lm_hfe_tip4pew-Nd3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Sm3+" element="Sm" mass="150.36" name="ions234lm_hfe_tip4pew-Sm3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Eu3+" element="Eu" mass="151.96" name="ions234lm_hfe_tip4pew-Eu3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Gd3+" element="Gd" mass="157.25" name="ions234lm_hfe_tip4pew-Gd3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Tb3+" element="Tb" mass="158.93" name="ions234lm_hfe_tip4pew-Tb3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Dy3+" element="Dy" mass="162.5" name="ions234lm_hfe_tip4pew-Dy3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Er3+" element="Er" mass="167.26" name="ions234lm_hfe_tip4pew-Er3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Tm3+" element="Tm" mass="168.93" name="ions234lm_hfe_tip4pew-Tm3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Lu3+" element="Lu" mass="174.97" name="ions234lm_hfe_tip4pew-Lu3+"/>
+    <Type class="ions234lm_hfe_tip4pew-Hf4+" element="Hf" mass="178.49" name="ions234lm_hfe_tip4pew-Hf4+"/>
+    <Type class="ions234lm_hfe_tip4pew-Zr4+" element="Zr" mass="91.22" name="ions234lm_hfe_tip4pew-Zr4+"/>
+    <Type class="ions234lm_hfe_tip4pew-Ce4+" element="Ce" mass="140.12" name="ions234lm_hfe_tip4pew-Ce4+"/>
+    <Type class="ions234lm_hfe_tip4pew-U4+" element="U" mass="238.03" name="ions234lm_hfe_tip4pew-U4+"/>
+    <Type class="ions234lm_hfe_tip4pew-Pu4+" element="Pu" mass="244.06" name="ions234lm_hfe_tip4pew-Pu4+"/>
+    <Type class="ions234lm_hfe_tip4pew-Th4+" element="Th" mass="232.04" name="ions234lm_hfe_tip4pew-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ions234lm_hfe_tip4pew-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_hfe_tip4pew-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_hfe_tip4pew-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_hfe_tip4pew-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_hfe_tip4pew-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_hfe_tip4pew-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_hfe_tip4pew-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_hfe_tip4pew-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_hfe_tip4pew-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_hfe_tip4pew-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_hfe_tip4pew-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_hfe_tip4pew-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_hfe_tip4pew-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_hfe_tip4pew-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ions234lm_hfe_tip4pew-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_hfe_tip4pew-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_hfe_tip4pew-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_hfe_tip4pew-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_hfe_tip4pew-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_hfe_tip4pew-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_hfe_tip4pew-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_hfe_tip4pew-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_hfe_tip4pew-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_hfe_tip4pew-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_hfe_tip4pew-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_hfe_tip4pew-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_hfe_tip4pew-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_hfe_tip4pew-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ions234lm_hfe_tip4pew-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ions234lm_hfe_tip4pew-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_hfe_tip4pew-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ions234lm_hfe_tip4pew-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_hfe_tip4pew-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ions234lm_hfe_tip4pew-Ra2+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ions234lm_hfe_tip4pew-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_hfe_tip4pew-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_hfe_tip4pew-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_hfe_tip4pew-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_hfe_tip4pew-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_hfe_tip4pew-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_hfe_tip4pew-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_hfe_tip4pew-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_hfe_tip4pew-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_hfe_tip4pew-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_hfe_tip4pew-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ions234lm_hfe_tip4pew-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_hfe_tip4pew-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_hfe_tip4pew-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="9.24664e-08" sigma="0.14521649105687529" type="ions234lm_hfe_tip4pew-Be2+"/><!--   HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00042103592" sigma="0.19207776363105716" type="ions234lm_hfe_tip4pew-Cu2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0007001087200000001" sigma="0.19617589773450272" type="ions234lm_hfe_tip4pew-Ni2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0009216096800000001" sigma="0.19849223440166763" type="ions234lm_hfe_tip4pew-Pt2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0009409816" sigma="0.19867041414529565" type="ions234lm_hfe_tip4pew-Zn2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0015870330400000001" sigma="0.20330308747962544" type="ions234lm_hfe_tip4pew-Co2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0017148542400000002" sigma="0.20401580645413772" type="ions234lm_hfe_tip4pew-Pd2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.0027861674400000004" sigma="0.20864847978846748" type="ions234lm_hfe_tip4pew-Ag2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00333071504" sigma="0.21043027722474816" type="ions234lm_hfe_tip4pew-Cr2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00417358184" sigma="0.21274661389191302" type="ions234lm_hfe_tip4pew-Fe2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.005279036480000001" sigma="0.21524113030270597" type="ions234lm_hfe_tip4pew-Mg2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.00545564312" sigma="0.2155974897899621" type="ions234lm_hfe_tip4pew-V2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.014823368080000001" sigma="0.2273573528694146" type="ions234lm_hfe_tip4pew-Mn2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.014823368080000001" sigma="0.2273573528694146" type="ions234lm_hfe_tip4pew-Hg2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.015454189760000002" sigma="0.22789189210029878" type="ions234lm_hfe_tip4pew-Cd2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.12065898696" sigma="0.26085514467149135" type="ions234lm_hfe_tip4pew-Yb2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ions234lm_hfe_tip4pew-Ca2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.13727645424" sigma="0.2635278408259124" type="ions234lm_hfe_tip4pew-Sn2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.23958713680000002" sigma="0.27635678236713324" type="ions234lm_hfe_tip4pew-Pb2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.32372762784000003" sigma="0.2843748708303963" type="ions234lm_hfe_tip4pew-Eu2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.34459281744000003" sigma="0.286156668266677" type="ions234lm_hfe_tip4pew-Sr2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.34459281744000003" sigma="0.286156668266677" type="ions234lm_hfe_tip4pew-Sm2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.78522274416" sigma="0.315021786734424" type="ions234lm_hfe_tip4pew-Ba2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.78522274416" sigma="0.315021786734424" type="ions234lm_hfe_tip4pew-Ra2+"/><!--     HFE set for TIP4P\EW water from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.08784e-06" sigma="0.15608545541818744" type="ions234lm_hfe_tip4pew-Al3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="3.794888e-05" sigma="0.17532886773001877" type="ions234lm_hfe_tip4pew-Fe3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00062839496" sigma="0.1952849990163624" type="ions234lm_hfe_tip4pew-Cr3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0008476784" sigma="0.19777951542715533" type="ions234lm_hfe_tip4pew-In3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0009216096800000001" sigma="0.19849223440166763" type="ions234lm_hfe_tip4pew-Tl3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05043699032" sigma="0.2449971474885933" type="ions234lm_hfe_tip4pew-Y3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.24298918904" sigma="0.2767131418543894" type="ions234lm_hfe_tip4pew-La3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18934696184" sigma="0.27065503057103507" type="ions234lm_hfe_tip4pew-Ce3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.15293570184000002" sigma="0.26584417749307726" type="ions234lm_hfe_tip4pew-Pr3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.12822378448" sigma="0.26210240287688785" type="ions234lm_hfe_tip4pew-Nd3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.10174956632" sigma="0.25746972954255803" type="ions234lm_hfe_tip4pew-Sm3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.08428722392" sigma="0.25390613466999673" type="ions234lm_hfe_tip4pew-Eu3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.07796599488" sigma="0.2524806967209722" type="ions234lm_hfe_tip4pew-Gd3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.06776749488" sigma="0.2499861803101792" type="ions234lm_hfe_tip4pew-Tb3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05861307024" sigma="0.24749166389938626" type="ions234lm_hfe_tip4pew-Dy3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.038060509119999995" sigma="0.24054265389789162" type="ions234lm_hfe_tip4pew-Er3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.033838434720000005" sigma="0.23876085646161097" type="ions234lm_hfe_tip4pew-Tm3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.033838434720000005" sigma="0.23876085646161097" type="ions234lm_hfe_tip4pew-Lu3+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="3.1003440000000005e-05" sigma="0.1740816095246223" type="ions234lm_hfe_tip4pew-Hf4+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.0001355616" sigma="0.18370331568053797" type="ions234lm_hfe_tip4pew-Zr4+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.011301820800000001" sigma="0.2239719377404813" type="ions234lm_hfe_tip4pew-Ce4+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00076261768" sigma="0.196888616709015" type="ions234lm_hfe_tip4pew-U4+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.00283691936" sigma="0.20882665953209553" type="ions234lm_hfe_tip4pew-Pu4+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.047741364640000006" sigma="0.24410624877045298" type="ions234lm_hfe_tip4pew-Th4+"/><!--     HFE set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_iod_spce.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_iod_spce.xml
@@ -1,0 +1,215 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for SPC/E water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.579931</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_iod_spce" md5hash="07b58df625785b10fe11a7b220e8ceba" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_iod_spce</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_iod_spce-Be2+" element="Be" mass="9.01" name="ions234lm_iod_spce-Be2+"/>
+    <Type class="ions234lm_iod_spce-Cu2+" element="Cu" mass="63.55" name="ions234lm_iod_spce-Cu2+"/>
+    <Type class="ions234lm_iod_spce-Ni2+" element="Ni" mass="58.69" name="ions234lm_iod_spce-Ni2+"/>
+    <Type class="ions234lm_iod_spce-Zn2+" element="Zn" mass="65.4" name="ions234lm_iod_spce-Zn2+"/>
+    <Type class="ions234lm_iod_spce-Co2+" element="Co" mass="58.93" name="ions234lm_iod_spce-Co2+"/>
+    <Type class="ions234lm_iod_spce-Cr2+" element="Cr" mass="52.00" name="ions234lm_iod_spce-Cr2+"/>
+    <Type class="ions234lm_iod_spce-Fe2+" element="Fe" mass="55.85" name="ions234lm_iod_spce-Fe2+"/>
+    <Type class="ions234lm_iod_spce-Mg2+" element="Mg" mass="24.305" name="ions234lm_iod_spce-Mg2+"/>
+    <Type class="ions234lm_iod_spce-V2+" element="V" mass="50.94" name="ions234lm_iod_spce-V2+"/>
+    <Type class="ions234lm_iod_spce-Mn2+" element="Mn" mass="54.94" name="ions234lm_iod_spce-Mn2+"/>
+    <Type class="ions234lm_iod_spce-Hg2+" element="Hg" mass="200.59" name="ions234lm_iod_spce-Hg2+"/>
+    <Type class="ions234lm_iod_spce-Cd2+" element="Cd" mass="112.41" name="ions234lm_iod_spce-Cd2+"/>
+    <Type class="ions234lm_iod_spce-Ca2+" element="Ca" mass="40.08" name="ions234lm_iod_spce-Ca2+"/>
+    <Type class="ions234lm_iod_spce-Sn2+" element="Sn" mass="118.71" name="ions234lm_iod_spce-Sn2+"/>
+    <Type class="ions234lm_iod_spce-Sr2+" element="Sr" mass="87.62" name="ions234lm_iod_spce-Sr2+"/>
+    <Type class="ions234lm_iod_spce-Ba2+" element="Ba" mass="137.33" name="ions234lm_iod_spce-Ba2+"/>
+    <Type class="ions234lm_iod_spce-Al3+" element="Al" mass="26.98" name="ions234lm_iod_spce-Al3+"/>
+    <Type class="ions234lm_iod_spce-Fe3+" element="Fe" mass="55.85" name="ions234lm_iod_spce-Fe3+"/>
+    <Type class="ions234lm_iod_spce-Cr3+" element="Cr" mass="52.00" name="ions234lm_iod_spce-Cr3+"/>
+    <Type class="ions234lm_iod_spce-In3+" element="In" mass="114.82" name="ions234lm_iod_spce-In3+"/>
+    <Type class="ions234lm_iod_spce-Tl3+" element="Tl" mass="204.38" name="ions234lm_iod_spce-Tl3+"/>
+    <Type class="ions234lm_iod_spce-Y3+" element="Y" mass="88.91" name="ions234lm_iod_spce-Y3+"/>
+    <Type class="ions234lm_iod_spce-La3+" element="La" mass="138.91" name="ions234lm_iod_spce-La3+"/>
+    <Type class="ions234lm_iod_spce-Ce3+" element="Ce" mass="140.12" name="ions234lm_iod_spce-Ce3+"/>
+    <Type class="ions234lm_iod_spce-Pr3+" element="Pr" mass="140.91" name="ions234lm_iod_spce-Pr3+"/>
+    <Type class="ions234lm_iod_spce-Nd3+" element="Nd" mass="144.24" name="ions234lm_iod_spce-Nd3+"/>
+    <Type class="ions234lm_iod_spce-Sm3+" element="Sm" mass="150.36" name="ions234lm_iod_spce-Sm3+"/>
+    <Type class="ions234lm_iod_spce-Eu3+" element="Eu" mass="151.96" name="ions234lm_iod_spce-Eu3+"/>
+    <Type class="ions234lm_iod_spce-Gd3+" element="Gd" mass="157.25" name="ions234lm_iod_spce-Gd3+"/>
+    <Type class="ions234lm_iod_spce-Tb3+" element="Tb" mass="158.93" name="ions234lm_iod_spce-Tb3+"/>
+    <Type class="ions234lm_iod_spce-Dy3+" element="Dy" mass="162.5" name="ions234lm_iod_spce-Dy3+"/>
+    <Type class="ions234lm_iod_spce-Er3+" element="Er" mass="167.26" name="ions234lm_iod_spce-Er3+"/>
+    <Type class="ions234lm_iod_spce-Tm3+" element="Tm" mass="168.93" name="ions234lm_iod_spce-Tm3+"/>
+    <Type class="ions234lm_iod_spce-Lu3+" element="Lu" mass="174.97" name="ions234lm_iod_spce-Lu3+"/>
+    <Type class="ions234lm_iod_spce-Hf4+" element="Hf" mass="178.49" name="ions234lm_iod_spce-Hf4+"/>
+    <Type class="ions234lm_iod_spce-Zr4+" element="Zr" mass="91.22" name="ions234lm_iod_spce-Zr4+"/>
+    <Type class="ions234lm_iod_spce-Ce4+" element="Ce" mass="140.12" name="ions234lm_iod_spce-Ce4+"/>
+    <Type class="ions234lm_iod_spce-U4+" element="U" mass="238.03" name="ions234lm_iod_spce-U4+"/>
+    <Type class="ions234lm_iod_spce-Pu4+" element="Pu" mass="244.06" name="ions234lm_iod_spce-Pu4+"/>
+    <Type class="ions234lm_iod_spce-Th4+" element="Th" mass="232.04" name="ions234lm_iod_spce-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_iod_spce-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_iod_spce-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_iod_spce-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_iod_spce-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_iod_spce-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_iod_spce-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_iod_spce-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_iod_spce-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_iod_spce-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_iod_spce-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_iod_spce-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_iod_spce-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_iod_spce-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_iod_spce-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_iod_spce-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_iod_spce-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_iod_spce-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_iod_spce-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_iod_spce-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_iod_spce-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_iod_spce-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_iod_spce-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_iod_spce-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_iod_spce-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_iod_spce-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_iod_spce-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_iod_spce-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_iod_spce-Pu4+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_iod_spce-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_iod_spce-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_iod_spce-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_iod_spce-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_iod_spce-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_iod_spce-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_iod_spce-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_iod_spce-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_iod_spce-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_iod_spce-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_iod_spce-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_iod_spce-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0026385977600000003" sigma="0.20811394055758325" type="ions234lm_iod_spce-Be2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ions234lm_iod_spce-Cu2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ions234lm_iod_spce-Ni2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.062412728" sigma="0.24856074236115466" type="ions234lm_iod_spce-Zn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.06846053264" sigma="0.25016436005380727" type="ions234lm_iod_spce-Co2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.05799739464" sigma="0.24731348415575818" type="ions234lm_iod_spce-Cr2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ions234lm_iod_spce-Fe2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.062412728" sigma="0.24856074236115466" type="ions234lm_iod_spce-Mg2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.1338302608" sigma="0.26299330159502815" type="ions234lm_iod_spce-V2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ions234lm_iod_spce-Mn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ions234lm_iod_spce-Hg2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.17114857016" sigma="0.2683386939038702" type="ions234lm_iod_spce-Cd2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ions234lm_iod_spce-Ca2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.6903723846400001" sigma="0.309676394425582" type="ions234lm_iod_spce-Sn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.73715046696" sigma="0.312349090580003" type="ions234lm_iod_spce-Sr2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.2995585169600001" sigma="0.34085784956049386" type="ions234lm_iod_spce-Ba2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.019458696160000004" sigma="0.23092094774197594" type="ions234lm_iod_spce-Al3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05678093848" sigma="0.24695712466850203" type="ions234lm_iod_spce-Fe3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.035064095680000004" sigma="0.23929539569249514" type="ions234lm_iod_spce-Cr3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11751709584" sigma="0.26032060544060714" type="ions234lm_iod_spce-In3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18079185336" sigma="0.26958595210926667" type="ions234lm_iod_spce-Tl3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_iod_spce-Y3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.63014479248" sigma="0.3061127995530206" type="ions234lm_iod_spce-La3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.69962078192" sigma="0.3102109336564662" type="ions234lm_iod_spce-Ce3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.6781265697600001" sigma="0.3089636754510697" type="ions234lm_iod_spce-Pr3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.52569060488" sigma="0.2995201490387821" type="ions234lm_iod_spce-Nd3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.46816830344000004" sigma="0.2956001946789646" type="ions234lm_iod_spce-Sm3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_iod_spce-Eu3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.38186547936" sigma="0.2891857239083541" type="ions234lm_iod_spce-Gd3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.39786810784" sigma="0.29043298211375057" type="ions234lm_iod_spce-Tb3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.35100580160000006" sigma="0.28669120749756116" type="ions234lm_iod_spce-Dy3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_iod_spce-Er3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_iod_spce-Tm3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.30760316128000004" sigma="0.28294943288137175" type="ions234lm_iod_spce-Lu3+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16448090592" sigma="0.26744779518572986" type="ions234lm_iod_spce-Hf4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.19225856560000001" sigma="0.2710113900582912" type="ions234lm_iod_spce-Zr4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.5474740988000001" sigma="0.3009455869878066" type="ions234lm_iod_spce-Ce4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.5474740988000001" sigma="0.3009455869878066" type="ions234lm_iod_spce-U4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_iod_spce-Pu4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.61548811496" sigma="0.30522190083488027" type="ions234lm_iod_spce-Th4+"/><!--     IOD set for SPC\E water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_iod_tip3p.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_iod_tip3p.xml
@@ -1,0 +1,215 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for TIP3P water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.643011</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_iod_tip3p" md5hash="2e458b2ecd1a7bdbababfa42eb8f3221" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_iod_tip3p</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_iod_tip3p-Be2+" element="Be" mass="9.01" name="ions234lm_iod_tip3p-Be2+"/>
+    <Type class="ions234lm_iod_tip3p-Cu2+" element="Cu" mass="63.55" name="ions234lm_iod_tip3p-Cu2+"/>
+    <Type class="ions234lm_iod_tip3p-Ni2+" element="Ni" mass="58.69" name="ions234lm_iod_tip3p-Ni2+"/>
+    <Type class="ions234lm_iod_tip3p-Zn2+" element="Zn" mass="65.4" name="ions234lm_iod_tip3p-Zn2+"/>
+    <Type class="ions234lm_iod_tip3p-Co2+" element="Co" mass="58.93" name="ions234lm_iod_tip3p-Co2+"/>
+    <Type class="ions234lm_iod_tip3p-Cr2+" element="Cr" mass="52.00" name="ions234lm_iod_tip3p-Cr2+"/>
+    <Type class="ions234lm_iod_tip3p-Fe2+" element="Fe" mass="55.85" name="ions234lm_iod_tip3p-Fe2+"/>
+    <Type class="ions234lm_iod_tip3p-Mg2+" element="Mg" mass="24.305" name="ions234lm_iod_tip3p-Mg2+"/>
+    <Type class="ions234lm_iod_tip3p-V2+" element="V" mass="50.94" name="ions234lm_iod_tip3p-V2+"/>
+    <Type class="ions234lm_iod_tip3p-Mn2+" element="Mn" mass="54.94" name="ions234lm_iod_tip3p-Mn2+"/>
+    <Type class="ions234lm_iod_tip3p-Hg2+" element="Hg" mass="200.59" name="ions234lm_iod_tip3p-Hg2+"/>
+    <Type class="ions234lm_iod_tip3p-Cd2+" element="Cd" mass="112.41" name="ions234lm_iod_tip3p-Cd2+"/>
+    <Type class="ions234lm_iod_tip3p-Ca2+" element="Ca" mass="40.08" name="ions234lm_iod_tip3p-Ca2+"/>
+    <Type class="ions234lm_iod_tip3p-Sn2+" element="Sn" mass="118.71" name="ions234lm_iod_tip3p-Sn2+"/>
+    <Type class="ions234lm_iod_tip3p-Sr2+" element="Sr" mass="87.62" name="ions234lm_iod_tip3p-Sr2+"/>
+    <Type class="ions234lm_iod_tip3p-Ba2+" element="Ba" mass="137.33" name="ions234lm_iod_tip3p-Ba2+"/>
+    <Type class="ions234lm_iod_tip3p-Al3+" element="Al" mass="26.98" name="ions234lm_iod_tip3p-Al3+"/>
+    <Type class="ions234lm_iod_tip3p-Fe3+" element="Fe" mass="55.85" name="ions234lm_iod_tip3p-Fe3+"/>
+    <Type class="ions234lm_iod_tip3p-Cr3+" element="Cr" mass="52.00" name="ions234lm_iod_tip3p-Cr3+"/>
+    <Type class="ions234lm_iod_tip3p-In3+" element="In" mass="114.82" name="ions234lm_iod_tip3p-In3+"/>
+    <Type class="ions234lm_iod_tip3p-Tl3+" element="Tl" mass="204.38" name="ions234lm_iod_tip3p-Tl3+"/>
+    <Type class="ions234lm_iod_tip3p-Y3+" element="Y" mass="88.91" name="ions234lm_iod_tip3p-Y3+"/>
+    <Type class="ions234lm_iod_tip3p-La3+" element="La" mass="138.91" name="ions234lm_iod_tip3p-La3+"/>
+    <Type class="ions234lm_iod_tip3p-Ce3+" element="Ce" mass="140.12" name="ions234lm_iod_tip3p-Ce3+"/>
+    <Type class="ions234lm_iod_tip3p-Pr3+" element="Pr" mass="140.91" name="ions234lm_iod_tip3p-Pr3+"/>
+    <Type class="ions234lm_iod_tip3p-Nd3+" element="Nd" mass="144.24" name="ions234lm_iod_tip3p-Nd3+"/>
+    <Type class="ions234lm_iod_tip3p-Sm3+" element="Sm" mass="150.36" name="ions234lm_iod_tip3p-Sm3+"/>
+    <Type class="ions234lm_iod_tip3p-Eu3+" element="Eu" mass="151.96" name="ions234lm_iod_tip3p-Eu3+"/>
+    <Type class="ions234lm_iod_tip3p-Gd3+" element="Gd" mass="157.25" name="ions234lm_iod_tip3p-Gd3+"/>
+    <Type class="ions234lm_iod_tip3p-Tb3+" element="Tb" mass="158.93" name="ions234lm_iod_tip3p-Tb3+"/>
+    <Type class="ions234lm_iod_tip3p-Dy3+" element="Dy" mass="162.5" name="ions234lm_iod_tip3p-Dy3+"/>
+    <Type class="ions234lm_iod_tip3p-Er3+" element="Er" mass="167.26" name="ions234lm_iod_tip3p-Er3+"/>
+    <Type class="ions234lm_iod_tip3p-Tm3+" element="Tm" mass="168.93" name="ions234lm_iod_tip3p-Tm3+"/>
+    <Type class="ions234lm_iod_tip3p-Lu3+" element="Lu" mass="174.97" name="ions234lm_iod_tip3p-Lu3+"/>
+    <Type class="ions234lm_iod_tip3p-Hf4+" element="Hf" mass="178.49" name="ions234lm_iod_tip3p-Hf4+"/>
+    <Type class="ions234lm_iod_tip3p-Zr4+" element="Zr" mass="91.22" name="ions234lm_iod_tip3p-Zr4+"/>
+    <Type class="ions234lm_iod_tip3p-Ce4+" element="Ce" mass="140.12" name="ions234lm_iod_tip3p-Ce4+"/>
+    <Type class="ions234lm_iod_tip3p-U4+" element="U" mass="238.03" name="ions234lm_iod_tip3p-U4+"/>
+    <Type class="ions234lm_iod_tip3p-Pu4+" element="Pu" mass="244.06" name="ions234lm_iod_tip3p-Pu4+"/>
+    <Type class="ions234lm_iod_tip3p-Th4+" element="Th" mass="232.04" name="ions234lm_iod_tip3p-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_iod_tip3p-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_iod_tip3p-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_iod_tip3p-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_iod_tip3p-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_iod_tip3p-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_iod_tip3p-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_iod_tip3p-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_iod_tip3p-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_iod_tip3p-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_iod_tip3p-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_iod_tip3p-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_iod_tip3p-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_iod_tip3p-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_iod_tip3p-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_iod_tip3p-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_iod_tip3p-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_iod_tip3p-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_iod_tip3p-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_iod_tip3p-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_iod_tip3p-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_iod_tip3p-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_iod_tip3p-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_iod_tip3p-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_iod_tip3p-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_iod_tip3p-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_iod_tip3p-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_iod_tip3p-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_iod_tip3p-Pu4+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_iod_tip3p-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_iod_tip3p-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_iod_tip3p-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_iod_tip3p-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_iod_tip3p-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_iod_tip3p-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_iod_tip3p-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_iod_tip3p-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_iod_tip3p-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_iod_tip3p-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_iod_tip3p-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_iod_tip3p-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0026385977600000003" sigma="0.20811394055758325" type="ions234lm_iod_tip3p-Be2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ions234lm_iod_tip3p-Cu2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ions234lm_iod_tip3p-Ni2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.062412728" sigma="0.24856074236115466" type="ions234lm_iod_tip3p-Zn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.06846053264" sigma="0.25016436005380727" type="ions234lm_iod_tip3p-Co2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.05799739464" sigma="0.24731348415575818" type="ions234lm_iod_tip3p-Cr2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ions234lm_iod_tip3p-Fe2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.062412728" sigma="0.24856074236115466" type="ions234lm_iod_tip3p-Mg2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.1338302608" sigma="0.26299330159502815" type="ions234lm_iod_tip3p-V2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ions234lm_iod_tip3p-Mn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ions234lm_iod_tip3p-Hg2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.17114857016" sigma="0.2683386939038702" type="ions234lm_iod_tip3p-Cd2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ions234lm_iod_tip3p-Ca2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.6903723846400001" sigma="0.309676394425582" type="ions234lm_iod_tip3p-Sn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.73715046696" sigma="0.312349090580003" type="ions234lm_iod_tip3p-Sr2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.2995585169600001" sigma="0.34085784956049386" type="ions234lm_iod_tip3p-Ba2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01971831336" sigma="0.23109912748560402" type="ions234lm_iod_tip3p-Al3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05678093848" sigma="0.24695712466850203" type="ions234lm_iod_tip3p-Fe3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.03548032" sigma="0.23947357543612321" type="ions234lm_iod_tip3p-Cr3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.11751709584" sigma="0.26032060544060714" type="ions234lm_iod_tip3p-In3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18079185336" sigma="0.26958595210926667" type="ions234lm_iod_tip3p-Tl3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_iod_tip3p-Y3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.63014479248" sigma="0.3061127995530206" type="ions234lm_iod_tip3p-La3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.69962078192" sigma="0.3102109336564662" type="ions234lm_iod_tip3p-Ce3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.67508049224" sigma="0.3087854957074416" type="ions234lm_iod_tip3p-Pr3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.52569060488" sigma="0.2995201490387821" type="ions234lm_iod_tip3p-Nd3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.46816830344000004" sigma="0.2956001946789646" type="ions234lm_iod_tip3p-Sm3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ions234lm_iod_tip3p-Eu3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.38186547936" sigma="0.2891857239083541" type="ions234lm_iod_tip3p-Gd3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.39786810784" sigma="0.29043298211375057" type="ions234lm_iod_tip3p-Tb3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.35100580160000006" sigma="0.28669120749756116" type="ions234lm_iod_tip3p-Dy3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_iod_tip3p-Er3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ions234lm_iod_tip3p-Tm3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.30760316128000004" sigma="0.28294943288137175" type="ions234lm_iod_tip3p-Lu3+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16186477624" sigma="0.26709143569847377" type="ions234lm_iod_tip3p-Hf4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.18934696184" sigma="0.27065503057103507" type="ions234lm_iod_tip3p-Zr4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.53380618416" sigma="0.30005468826966625" type="ions234lm_iod_tip3p-Ce4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.53380618416" sigma="0.30005468826966625" type="ions234lm_iod_tip3p-U4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.47580293192" sigma="0.29613473390984874" type="ions234lm_iod_tip3p-Pu4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.6009964544" sigma="0.3043310021167399" type="ions234lm_iod_tip3p-Th4+"/><!--     IOD set for TIP3P water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions234lm_iod_tip4pew.xml
+++ b/wrappers/python/openmm/app/data/ions/ions234lm_iod_tip4pew.xml
@@ -1,0 +1,215 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of divalent to tetravalent ions for TIP4P/EW water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.619279</DateGenerated>
+    <Source Source="parm/frcmod.ions234lm_iod_tip4pew" md5hash="d7e60f395f85d8e1965317e4db7c21af" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions234lm_iod_tip4pew</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions234lm_iod_tip4pew-Be2+" element="Be" mass="9.01" name="ions234lm_iod_tip4pew-Be2+"/>
+    <Type class="ions234lm_iod_tip4pew-Cu2+" element="Cu" mass="63.55" name="ions234lm_iod_tip4pew-Cu2+"/>
+    <Type class="ions234lm_iod_tip4pew-Ni2+" element="Ni" mass="58.69" name="ions234lm_iod_tip4pew-Ni2+"/>
+    <Type class="ions234lm_iod_tip4pew-Zn2+" element="Zn" mass="65.4" name="ions234lm_iod_tip4pew-Zn2+"/>
+    <Type class="ions234lm_iod_tip4pew-Co2+" element="Co" mass="58.93" name="ions234lm_iod_tip4pew-Co2+"/>
+    <Type class="ions234lm_iod_tip4pew-Cr2+" element="Cr" mass="52.00" name="ions234lm_iod_tip4pew-Cr2+"/>
+    <Type class="ions234lm_iod_tip4pew-Fe2+" element="Fe" mass="55.85" name="ions234lm_iod_tip4pew-Fe2+"/>
+    <Type class="ions234lm_iod_tip4pew-Mg2+" element="Mg" mass="24.305" name="ions234lm_iod_tip4pew-Mg2+"/>
+    <Type class="ions234lm_iod_tip4pew-V2+" element="V" mass="50.94" name="ions234lm_iod_tip4pew-V2+"/>
+    <Type class="ions234lm_iod_tip4pew-Mn2+" element="Mn" mass="54.94" name="ions234lm_iod_tip4pew-Mn2+"/>
+    <Type class="ions234lm_iod_tip4pew-Hg2+" element="Hg" mass="200.59" name="ions234lm_iod_tip4pew-Hg2+"/>
+    <Type class="ions234lm_iod_tip4pew-Cd2+" element="Cd" mass="112.41" name="ions234lm_iod_tip4pew-Cd2+"/>
+    <Type class="ions234lm_iod_tip4pew-Ca2+" element="Ca" mass="40.08" name="ions234lm_iod_tip4pew-Ca2+"/>
+    <Type class="ions234lm_iod_tip4pew-Sn2+" element="Sn" mass="118.71" name="ions234lm_iod_tip4pew-Sn2+"/>
+    <Type class="ions234lm_iod_tip4pew-Sr2+" element="Sr" mass="87.62" name="ions234lm_iod_tip4pew-Sr2+"/>
+    <Type class="ions234lm_iod_tip4pew-Ba2+" element="Ba" mass="137.33" name="ions234lm_iod_tip4pew-Ba2+"/>
+    <Type class="ions234lm_iod_tip4pew-Al3+" element="Al" mass="26.98" name="ions234lm_iod_tip4pew-Al3+"/>
+    <Type class="ions234lm_iod_tip4pew-Fe3+" element="Fe" mass="55.85" name="ions234lm_iod_tip4pew-Fe3+"/>
+    <Type class="ions234lm_iod_tip4pew-Cr3+" element="Cr" mass="52.00" name="ions234lm_iod_tip4pew-Cr3+"/>
+    <Type class="ions234lm_iod_tip4pew-In3+" element="In" mass="114.82" name="ions234lm_iod_tip4pew-In3+"/>
+    <Type class="ions234lm_iod_tip4pew-Tl3+" element="Tl" mass="204.38" name="ions234lm_iod_tip4pew-Tl3+"/>
+    <Type class="ions234lm_iod_tip4pew-Y3+" element="Y" mass="88.91" name="ions234lm_iod_tip4pew-Y3+"/>
+    <Type class="ions234lm_iod_tip4pew-La3+" element="La" mass="138.91" name="ions234lm_iod_tip4pew-La3+"/>
+    <Type class="ions234lm_iod_tip4pew-Ce3+" element="Ce" mass="140.12" name="ions234lm_iod_tip4pew-Ce3+"/>
+    <Type class="ions234lm_iod_tip4pew-Pr3+" element="Pr" mass="140.91" name="ions234lm_iod_tip4pew-Pr3+"/>
+    <Type class="ions234lm_iod_tip4pew-Nd3+" element="Nd" mass="144.24" name="ions234lm_iod_tip4pew-Nd3+"/>
+    <Type class="ions234lm_iod_tip4pew-Sm3+" element="Sm" mass="150.36" name="ions234lm_iod_tip4pew-Sm3+"/>
+    <Type class="ions234lm_iod_tip4pew-Eu3+" element="Eu" mass="151.96" name="ions234lm_iod_tip4pew-Eu3+"/>
+    <Type class="ions234lm_iod_tip4pew-Gd3+" element="Gd" mass="157.25" name="ions234lm_iod_tip4pew-Gd3+"/>
+    <Type class="ions234lm_iod_tip4pew-Tb3+" element="Tb" mass="158.93" name="ions234lm_iod_tip4pew-Tb3+"/>
+    <Type class="ions234lm_iod_tip4pew-Dy3+" element="Dy" mass="162.5" name="ions234lm_iod_tip4pew-Dy3+"/>
+    <Type class="ions234lm_iod_tip4pew-Er3+" element="Er" mass="167.26" name="ions234lm_iod_tip4pew-Er3+"/>
+    <Type class="ions234lm_iod_tip4pew-Tm3+" element="Tm" mass="168.93" name="ions234lm_iod_tip4pew-Tm3+"/>
+    <Type class="ions234lm_iod_tip4pew-Lu3+" element="Lu" mass="174.97" name="ions234lm_iod_tip4pew-Lu3+"/>
+    <Type class="ions234lm_iod_tip4pew-Hf4+" element="Hf" mass="178.49" name="ions234lm_iod_tip4pew-Hf4+"/>
+    <Type class="ions234lm_iod_tip4pew-Zr4+" element="Zr" mass="91.22" name="ions234lm_iod_tip4pew-Zr4+"/>
+    <Type class="ions234lm_iod_tip4pew-Ce4+" element="Ce" mass="140.12" name="ions234lm_iod_tip4pew-Ce4+"/>
+    <Type class="ions234lm_iod_tip4pew-U4+" element="U" mass="238.03" name="ions234lm_iod_tip4pew-U4+"/>
+    <Type class="ions234lm_iod_tip4pew-Pu4+" element="Pu" mass="244.06" name="ions234lm_iod_tip4pew-Pu4+"/>
+    <Type class="ions234lm_iod_tip4pew-Th4+" element="Th" mass="232.04" name="ions234lm_iod_tip4pew-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ions234lm_iod_tip4pew-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ions234lm_iod_tip4pew-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ions234lm_iod_tip4pew-Be2+"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ions234lm_iod_tip4pew-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ions234lm_iod_tip4pew-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ions234lm_iod_tip4pew-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ions234lm_iod_tip4pew-Ce4+"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ions234lm_iod_tip4pew-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ions234lm_iod_tip4pew-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ions234lm_iod_tip4pew-Cr3+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ions234lm_iod_tip4pew-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ions234lm_iod_tip4pew-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ions234lm_iod_tip4pew-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ions234lm_iod_tip4pew-Eu3+"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ions234lm_iod_tip4pew-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ions234lm_iod_tip4pew-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ions234lm_iod_tip4pew-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ions234lm_iod_tip4pew-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ions234lm_iod_tip4pew-Hg2+"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ions234lm_iod_tip4pew-In3+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ions234lm_iod_tip4pew-La3+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ions234lm_iod_tip4pew-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions234lm_iod_tip4pew-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ions234lm_iod_tip4pew-Mn2+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ions234lm_iod_tip4pew-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ions234lm_iod_tip4pew-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ions234lm_iod_tip4pew-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ions234lm_iod_tip4pew-Pu4+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ions234lm_iod_tip4pew-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ions234lm_iod_tip4pew-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ions234lm_iod_tip4pew-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ions234lm_iod_tip4pew-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ions234lm_iod_tip4pew-Th4+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ions234lm_iod_tip4pew-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ions234lm_iod_tip4pew-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ions234lm_iod_tip4pew-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ions234lm_iod_tip4pew-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ions234lm_iod_tip4pew-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ions234lm_iod_tip4pew-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ions234lm_iod_tip4pew-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0026385977600000003" sigma="0.20811394055758325" type="ions234lm_iod_tip4pew-Be2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ions234lm_iod_tip4pew-Cu2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ions234lm_iod_tip4pew-Ni2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.062412728" sigma="0.24856074236115466" type="ions234lm_iod_tip4pew-Zn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.06846053264" sigma="0.25016436005380727" type="ions234lm_iod_tip4pew-Co2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.05799739464" sigma="0.24731348415575818" type="ions234lm_iod_tip4pew-Cr2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ions234lm_iod_tip4pew-Fe2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.062412728" sigma="0.24856074236115466" type="ions234lm_iod_tip4pew-Mg2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.1338302608" sigma="0.26299330159502815" type="ions234lm_iod_tip4pew-V2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ions234lm_iod_tip4pew-Mn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ions234lm_iod_tip4pew-Hg2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.17114857016" sigma="0.2683386939038702" type="ions234lm_iod_tip4pew-Cd2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ions234lm_iod_tip4pew-Ca2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.6903723846400001" sigma="0.309676394425582" type="ions234lm_iod_tip4pew-Sn2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.73715046696" sigma="0.312349090580003" type="ions234lm_iod_tip4pew-Sr2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="1.2995585169600001" sigma="0.34085784956049386" type="ions234lm_iod_tip4pew-Ba2+"/><!--     IOD set from Li et al., JCTC, 2013, 9, 2733 -->
+    <Atom epsilon="0.01678206584" sigma="0.22896097056206718" type="ions234lm_iod_tip4pew-Al3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.05043699032" sigma="0.2449971474885933" type="ions234lm_iod_tip4pew-Fe3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.03111050856" sigma="0.23751359825621443" type="ions234lm_iod_tip4pew-Cr3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.10650049832000001" sigma="0.2583606282606984" type="ions234lm_iod_tip4pew-In3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16579982824" sigma="0.2676259749293579" type="ions234lm_iod_tip4pew-Tl3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ions234lm_iod_tip4pew-Y3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.59811815528" sigma="0.30415282237311186" type="ions234lm_iod_tip4pew-La3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.66295839824" sigma="0.3080727767329294" type="ions234lm_iod_tip4pew-Ce3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.64198735344" sigma="0.30682551852753287" type="ions234lm_iod_tip4pew-Pr3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.49387597096" sigma="0.2973819921152453" type="ions234lm_iod_tip4pew-Nd3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.43830358088" sigma="0.29346203775542773" type="ions234lm_iod_tip4pew-Sm3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.4580931896" sigma="0.29488747570445234" type="ions234lm_iod_tip4pew-Eu3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.35748949536" sigma="0.2872257467284454" type="ions234lm_iod_tip4pew-Gd3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.37289213824" sigma="0.28847300493384187" type="ions234lm_iod_tip4pew-Tb3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.32577870832" sigma="0.28455305057402436" type="ions234lm_iod_tip4pew-Dy3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ions234lm_iod_tip4pew-Er3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ions234lm_iod_tip4pew-Tm3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.28625681168" sigma="0.280989455701463" type="ions234lm_iod_tip4pew-Lu3+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.14196839183999999" sigma="0.26424055980042466" type="ions234lm_iod_tip4pew-Hf4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.16712607256" sigma="0.26780415467298596" type="ions234lm_iod_tip4pew-Zr4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ions234lm_iod_tip4pew-Ce4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ions234lm_iod_tip4pew-U4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.43343181496" sigma="0.29310567826817163" type="ions234lm_iod_tip4pew-Pu4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+    <Atom epsilon="0.5502288444000001" sigma="0.3011237667314347" type="ions234lm_iod_tip4pew-Th4+"/><!--     IOD set for TIP4P\EW water from Li et al., JPCB, 2015, 119, 883 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ions_charmm22.xml
+++ b/wrappers/python/openmm/app/data/ions/ions_charmm22.xml
@@ -1,0 +1,35 @@
+<ForceField>
+  <Info>
+    <!-- Ion parameters from CHARMM22. Beglov D & Roux B (1994) J. Chem. Phys. 100, 9050-9063. -->
+    <DateGenerated>2022-09-11T06:28:33.596324</DateGenerated>
+    <Source Source="parm/frcmod.ions_charmm22" md5hash="011995a91088b5185d05794261faa582" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ions_charmm22</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ions_charmm22-Na+" element="Na" mass="22.99" name="ions_charmm22-Na+"/><!--          0.250               sodium -->
+    <Type class="ions_charmm22-K+" element="K" mass="39.10" name="ions_charmm22-K+"/><!--          1.060               potassium -->
+    <Type class="ions_charmm22-Cl-" element="Cl" mass="35.45" name="ions_charmm22-Cl-"/><!--          1.910               chlorine -->
+    <Type class="ions_charmm22-Mg2+" element="Mg" mass="24.305" name="ions_charmm22-Mg2+"/><!--                             magnesium -->
+  </AtomTypes>
+  <Residues>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ions_charmm22-Cl-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ions_charmm22-K+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ions_charmm22-Mg2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ions_charmm22-Na+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.1962296" sigma="0.24299262537277755" type="ions_charmm22-Na+"/>
+    <Atom epsilon="0.364008" sigma="0.3142645228240047" type="ions_charmm22-K+"/>
+    <Atom epsilon="0.6276" sigma="0.4044680180357141" type="ions_charmm22-Cl-"/>
+    <Atom epsilon="0.06276" sigma="0.2111429961992604" type="ions_charmm22-Mg2+"/>
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionsff99_tip3p.xml
+++ b/wrappers/python/openmm/app/data/ions/ionsff99_tip3p.xml
@@ -1,0 +1,60 @@
+<ForceField>
+  <Info>
+    <!-- Monovalent ion parameters for TIP3P water from Aqvist (adapeted) in parm99.dat -->
+    <DateGenerated>2022-09-11T06:28:33.593081</DateGenerated>
+    <Source Source="parm/frcmod.ionsff99_tip3p" md5hash="7a95d0238cc433073d73ad21b478f7d0" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionsff99_tip3p</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionsff99_tip3p-Li+" element="Li" mass="6.94" name="ionsff99_tip3p-Li+"/><!--          0.029          lithium   pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsff99_tip3p-Na+" element="Na" mass="22.99" name="ionsff99_tip3p-Na+"/><!--          0.250          sodium    pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsff99_tip3p-K+" element="K" mass="39.10" name="ionsff99_tip3p-K+"/><!--          1.060          potassium -->
+    <Type class="ionsff99_tip3p-Rb+" element="Rb" mass="85.47" name="ionsff99_tip3p-Rb+"/><!--                         rubidium -->
+    <Type class="ionsff99_tip3p-Cs+" element="Cs" mass="132.91" name="ionsff99_tip3p-Cs+"/><!--                         cesium -->
+    <Type class="ionsff99_tip3p-F-" element="F" mass="19.00" name="ionsff99_tip3p-F-"/><!--          0.320          fluorine -->
+    <Type class="ionsff99_tip3p-Cl-" element="Cl" mass="35.45" name="ionsff99_tip3p-Cl-"/><!--          1.910          chlorine  (Applequist) -->
+    <Type class="ionsff99_tip3p-Br-" element="Br" mass="79.90" name="ionsff99_tip3p-Br-"/><!--          2.880          bromine   (Applequist) -->
+    <Type class="ionsff99_tip3p-I-" element="I" mass="126.9" name="ionsff99_tip3p-I-"/><!--          4.690          iodine    (Applequist) -->
+  </AtomTypes>
+  <Residues>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionsff99_tip3p-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionsff99_tip3p-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionsff99_tip3p-Cs+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionsff99_tip3p-F-"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionsff99_tip3p-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionsff99_tip3p-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionsff99_tip3p-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionsff99_tip3p-Na+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionsff99_tip3p-Rb+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0765672" sigma="0.20259036850511314" type="ionsff99_tip3p-Li+"/><!--              Li+ Aqvist JPC 1990,94,8021. (adapted) -->
+    <Atom epsilon="0.01158968" sigma="0.3328397610972308" type="ionsff99_tip3p-Na+"/><!--             Na+ Aqvist JPC 1990,94,8021. (adapted) -->
+    <Atom epsilon="0.001372352" sigma="0.4736017585634044" type="ionsff99_tip3p-K+"/><!--            K+  Aqvist JPC 1990,94,8021. (adapted) -->
+    <Atom epsilon="0.0007112800000000001" sigma="0.5266993221645686" type="ionsff99_tip3p-Rb+"/><!--             Rb+ Aqvist JPC 1990,94,8021. (adapted) -->
+    <Atom epsilon="0.00033723039999999997" sigma="0.6049202296172904" type="ionsff99_tip3p-Cs+"/><!--           Cs+ Aqvist JPC 1990,94,8021. (adapted) -->
+    <Atom epsilon="0.255224" sigma="0.3118145513491188" type="ionsff99_tip3p-F-"/><!--               Gough et al. JCC 13,(1992),963. -->
+    <Atom epsilon="1.1087600000000002" sigma="0.3470941405874762" type="ionsff99_tip3p-Cl-"/><!--               Fox, JPCB,102,8070,(98),flex.mdl CHCl3 -->
+    <Atom epsilon="1.33888" sigma="0.39555903085431066" type="ionsff99_tip3p-Br-"/><!--               Junmei(?) -->
+    <Atom epsilon="1.6736000000000002" sigma="0.41872239752595947" type="ionsff99_tip3p-I-"/><!--                JCC,7,(1986),230; -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionsjc_spce.xml
+++ b/wrappers/python/openmm/app/data/ions/ionsjc_spce.xml
@@ -1,0 +1,60 @@
+<ForceField>
+  <Info>
+    <!-- Monovalent ion parameters for Ewald and SPC/E water from Joung & Cheatham JPCB (2008) -->
+    <DateGenerated>2022-09-11T06:28:33.622249</DateGenerated>
+    <Source Source="parm/frcmod.ionsjc_spce" md5hash="576c159afdaa5f4f6b05250ce4326bd3" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionsjc_spce</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionsjc_spce-Li+" element="Li" mass="6.94" name="ionsjc_spce-Li+"/><!--          0.029               lithium   pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsjc_spce-Na+" element="Na" mass="22.99" name="ionsjc_spce-Na+"/><!--          0.250               sodium    pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsjc_spce-K+" element="K" mass="39.10" name="ionsjc_spce-K+"/><!--          1.060               potassium -->
+    <Type class="ionsjc_spce-Rb+" element="Rb" mass="85.47" name="ionsjc_spce-Rb+"/><!--                              rubidium -->
+    <Type class="ionsjc_spce-Cs+" element="Cs" mass="132.91" name="ionsjc_spce-Cs+"/><!--                              cesium -->
+    <Type class="ionsjc_spce-F-" element="F" mass="19.00" name="ionsjc_spce-F-"/><!--          0.320               fluorine -->
+    <Type class="ionsjc_spce-Cl-" element="Cl" mass="35.45" name="ionsjc_spce-Cl-"/><!--          1.910               chlorine  (Applequist) -->
+    <Type class="ionsjc_spce-Br-" element="Br" mass="79.90" name="ionsjc_spce-Br-"/><!--          2.880               bromine   (Applequist) -->
+    <Type class="ionsjc_spce-I-" element="I" mass="126.9" name="ionsjc_spce-I-"/><!--          4.690               iodine    (Applequist) -->
+  </AtomTypes>
+  <Residues>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionsjc_spce-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionsjc_spce-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionsjc_spce-Cs+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionsjc_spce-F-"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionsjc_spce-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionsjc_spce-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionsjc_spce-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionsjc_spce-Na+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionsjc_spce-Rb+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="1.4088967296000001" sigma="0.14094017720980168" type="ionsjc_spce-Li+"/>
+    <Atom epsilon="1.4754532912" sigma="0.21595384927721822" type="ionsjc_spce-Na+"/>
+    <Atom epsilon="1.7978873936000002" sigma="0.2838403315995121" type="ionsjc_spce-K+"/>
+    <Atom epsilon="1.8623134624" sigma="0.3094982146819539" type="ionsjc_spce-Rb+"/>
+    <Atom epsilon="0.37595959600000006" sigma="0.36010126187232516" type="ionsjc_spce-Cs+"/>
+    <Atom epsilon="0.030963692" sigma="0.4021516813685492" type="ionsjc_spce-F-"/>
+    <Atom epsilon="0.05349244" sigma="0.48304528497569194" type="ionsjc_spce-Cl-"/>
+    <Atom epsilon="0.1127947824" sigma="0.4901724747208147" type="ionsjc_spce-Br-"/>
+    <Atom epsilon="0.179010348" sigma="0.5201066716503301" type="ionsjc_spce-I-"/>
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionsjc_tip3p.xml
+++ b/wrappers/python/openmm/app/data/ions/ionsjc_tip3p.xml
@@ -1,0 +1,60 @@
+<ForceField>
+  <Info>
+    <!-- Monovalent ion parameters for Ewald and TIP3P water from Joung & Cheatham JPCB (2008) -->
+    <DateGenerated>2022-09-11T06:28:33.558650</DateGenerated>
+    <Source Source="parm/frcmod.ionsjc_tip3p" md5hash="0e5e74a17e42382511afd4116f70ff16" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionsjc_tip3p</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionsjc_tip3p-Li+" element="Li" mass="6.94" name="ionsjc_tip3p-Li+"/><!--          0.029               lithium   pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsjc_tip3p-Na+" element="Na" mass="22.99" name="ionsjc_tip3p-Na+"/><!--          0.250               sodium    pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsjc_tip3p-K+" element="K" mass="39.10" name="ionsjc_tip3p-K+"/><!--          1.060               potassium -->
+    <Type class="ionsjc_tip3p-Rb+" element="Rb" mass="85.47" name="ionsjc_tip3p-Rb+"/><!--                              rubidium -->
+    <Type class="ionsjc_tip3p-Cs+" element="Cs" mass="132.91" name="ionsjc_tip3p-Cs+"/><!--                              cesium -->
+    <Type class="ionsjc_tip3p-F-" element="F" mass="19.00" name="ionsjc_tip3p-F-"/><!--          0.320               fluorine -->
+    <Type class="ionsjc_tip3p-Cl-" element="Cl" mass="35.45" name="ionsjc_tip3p-Cl-"/><!--          1.910               chlorine  (Applequist) -->
+    <Type class="ionsjc_tip3p-Br-" element="Br" mass="79.90" name="ionsjc_tip3p-Br-"/><!--          2.880               bromine   (Applequist) -->
+    <Type class="ionsjc_tip3p-I-" element="I" mass="126.9" name="ionsjc_tip3p-I-"/><!--          4.690               iodine    (Applequist) -->
+  </AtomTypes>
+  <Residues>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionsjc_tip3p-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionsjc_tip3p-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionsjc_tip3p-Cs+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionsjc_tip3p-F-"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionsjc_tip3p-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionsjc_tip3p-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionsjc_tip3p-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionsjc_tip3p-Na+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionsjc_tip3p-Rb+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.1171084864" sigma="0.18263423721876956" type="ionsjc_tip3p-Li+"/>
+    <Atom epsilon="0.3658460312" sigma="0.2439280690268249" type="ionsjc_tip3p-Na+"/>
+    <Atom epsilon="0.8103692536" sigma="0.3037964628858557" type="ionsjc_tip3p-K+"/>
+    <Atom epsilon="1.3716068296000001" sigma="0.32303987519768707" type="ionsjc_tip3p-Rb+"/>
+    <Atom epsilon="1.7009608496" sigma="0.35208317340906214" type="ionsjc_tip3p-Cs+"/>
+    <Atom epsilon="0.014074976" sigma="0.4103479495754403" type="ionsjc_tip3p-F-"/>
+    <Atom epsilon="0.14891274399999999" sigma="0.4477656957373345" type="ionsjc_tip3p-Cl-"/>
+    <Atom epsilon="0.24541419360000002" sigma="0.46469277138200105" type="ionsjc_tip3p-Br-"/>
+    <Atom epsilon="0.22460381440000002" sigma="0.5095940667762741" type="ionsjc_tip3p-I-"/>
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionsjc_tip4pew.xml
+++ b/wrappers/python/openmm/app/data/ions/ionsjc_tip4pew.xml
@@ -1,0 +1,60 @@
+<ForceField>
+  <Info>
+    <!-- Monovalent ion parameters for Ewald and TIP4P/EW water from Joung & Cheatham JPCB (2008) -->
+    <DateGenerated>2022-09-11T06:28:33.654271</DateGenerated>
+    <Source Source="parm/frcmod.ionsjc_tip4pew" md5hash="7aa9de49a8df5ebc45f74e1f47d13c2a" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionsjc_tip4pew</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionsjc_tip4pew-Li+" element="Li" mass="6.94" name="ionsjc_tip4pew-Li+"/><!--          0.029               lithium   pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsjc_tip4pew-Na+" element="Na" mass="22.99" name="ionsjc_tip4pew-Na+"/><!--          0.250               sodium    pol: J. Phys. Chem. 11,1541,(1978) -->
+    <Type class="ionsjc_tip4pew-K+" element="K" mass="39.10" name="ionsjc_tip4pew-K+"/><!--          1.060               potassium -->
+    <Type class="ionsjc_tip4pew-Rb+" element="Rb" mass="85.47" name="ionsjc_tip4pew-Rb+"/><!--                              rubidium -->
+    <Type class="ionsjc_tip4pew-Cs+" element="Cs" mass="132.91" name="ionsjc_tip4pew-Cs+"/><!--                              cesium -->
+    <Type class="ionsjc_tip4pew-F-" element="F" mass="19.00" name="ionsjc_tip4pew-F-"/><!--          0.320               fluorine -->
+    <Type class="ionsjc_tip4pew-Cl-" element="Cl" mass="35.45" name="ionsjc_tip4pew-Cl-"/><!--          1.910               chlorine  (Applequist) -->
+    <Type class="ionsjc_tip4pew-Br-" element="Br" mass="79.90" name="ionsjc_tip4pew-Br-"/><!--          2.880               bromine   (Applequist) -->
+    <Type class="ionsjc_tip4pew-I-" element="I" mass="126.9" name="ionsjc_tip4pew-I-"/><!--          4.690               iodine    (Applequist) -->
+  </AtomTypes>
+  <Residues>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionsjc_tip4pew-Br-"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionsjc_tip4pew-Cl-"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionsjc_tip4pew-Cs+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionsjc_tip4pew-F-"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionsjc_tip4pew-I-"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionsjc_tip4pew-K+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionsjc_tip4pew-Li+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionsjc_tip4pew-Na+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionsjc_tip4pew-Rb+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.4350874656" sigma="0.14396923285147886" type="ionsjc_tip4pew-Li+"/>
+    <Atom epsilon="0.7047424999999999" sigma="0.21844836568801118" type="ionsjc_tip4pew-Na+"/>
+    <Atom epsilon="1.1692819784000001" sigma="0.2833057923686279" type="ionsjc_tip4pew-K+"/>
+    <Atom epsilon="1.8122970896000001" sigma="0.304509181860368" type="ionsjc_tip4pew-Rb+"/>
+    <Atom epsilon="1.6503026512" sigma="0.3364033559697921" type="ionsjc_tip4pew-Cs+"/>
+    <Atom epsilon="0.0065906368" sigma="0.4522201893280362" type="ionsjc_tip4pew-F-"/>
+    <Atom epsilon="0.048791716" sigma="0.49177609241346726" type="ionsjc_tip4pew-Cl-"/>
+    <Atom epsilon="0.1270986232" sigma="0.4932015303624918" type="ionsjc_tip4pew-Br-"/>
+    <Atom epsilon="0.1745071088" sigma="0.5259866031900563" type="ionsjc_tip4pew-I-"/>
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_126_fb3.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_126_fb3.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the TIP3P-FB water model (12-6 set) -->
+    <DateGenerated>2022-09-11T06:28:33.574187</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_126_fb3" md5hash="7ea8f9fb295b9ac421e81e80b6128014" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_126_fb3</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_126_fb3-Li+" element="Li" mass="6.94" name="ionslm_126_fb3-Li+"/>
+    <Type class="ionslm_126_fb3-Na+" element="Na" mass="22.99" name="ionslm_126_fb3-Na+"/>
+    <Type class="ionslm_126_fb3-K+" element="K" mass="39.10" name="ionslm_126_fb3-K+"/>
+    <Type class="ionslm_126_fb3-Rb+" element="Rb" mass="85.47" name="ionslm_126_fb3-Rb+"/>
+    <Type class="ionslm_126_fb3-Cs+" element="Cs" mass="132.91" name="ionslm_126_fb3-Cs+"/>
+    <Type class="ionslm_126_fb3-Tl+" element="Tl" mass="204.38" name="ionslm_126_fb3-Tl+"/>
+    <Type class="ionslm_126_fb3-Cu+" element="Cu" mass="63.55" name="ionslm_126_fb3-Cu+"/>
+    <Type class="ionslm_126_fb3-Ag+" element="Ag" mass="107.87" name="ionslm_126_fb3-Ag+"/>
+    <Type class="ionslm_126_fb3-F-" element="F" mass="19.00" name="ionslm_126_fb3-F-"/>
+    <Type class="ionslm_126_fb3-Cl-" element="Cl" mass="35.45" name="ionslm_126_fb3-Cl-"/>
+    <Type class="ionslm_126_fb3-Br-" element="Br" mass="79.90" name="ionslm_126_fb3-Br-"/>
+    <Type class="ionslm_126_fb3-I-" element="I" mass="126.9" name="ionslm_126_fb3-I-"/>
+    <Type class="ionslm_126_fb3-Be2+" element="Be" mass="9.01" name="ionslm_126_fb3-Be2+"/>
+    <Type class="ionslm_126_fb3-Cu2+" element="Cu" mass="63.55" name="ionslm_126_fb3-Cu2+"/>
+    <Type class="ionslm_126_fb3-Ni2+" element="Ni" mass="58.69" name="ionslm_126_fb3-Ni2+"/>
+    <Type class="ionslm_126_fb3-Pt2+" element="Pt" mass="195.08" name="ionslm_126_fb3-Pt2+"/>
+    <Type class="ionslm_126_fb3-Zn2+" element="Zn" mass="65.4" name="ionslm_126_fb3-Zn2+"/>
+    <Type class="ionslm_126_fb3-Co2+" element="Co" mass="58.93" name="ionslm_126_fb3-Co2+"/>
+    <Type class="ionslm_126_fb3-Pd2+" element="Pd" mass="106.42" name="ionslm_126_fb3-Pd2+"/>
+    <Type class="ionslm_126_fb3-Ag2+" element="Ag" mass="107.87" name="ionslm_126_fb3-Ag2+"/>
+    <Type class="ionslm_126_fb3-Cr2+" element="Cr" mass="52.00" name="ionslm_126_fb3-Cr2+"/>
+    <Type class="ionslm_126_fb3-Fe2+" element="Fe" mass="55.85" name="ionslm_126_fb3-Fe2+"/>
+    <Type class="ionslm_126_fb3-Mg2+" element="Mg" mass="24.305" name="ionslm_126_fb3-Mg2+"/>
+    <Type class="ionslm_126_fb3-V2+" element="V" mass="50.94" name="ionslm_126_fb3-V2+"/>
+    <Type class="ionslm_126_fb3-Mn2+" element="Mn" mass="54.94" name="ionslm_126_fb3-Mn2+"/>
+    <Type class="ionslm_126_fb3-Hg2+" element="Hg" mass="200.59" name="ionslm_126_fb3-Hg2+"/>
+    <Type class="ionslm_126_fb3-Cd2+" element="Cd" mass="112.41" name="ionslm_126_fb3-Cd2+"/>
+    <Type class="ionslm_126_fb3-Yb2+" element="Yb" mass="173.05" name="ionslm_126_fb3-Yb2+"/>
+    <Type class="ionslm_126_fb3-Ca2+" element="Ca" mass="40.08" name="ionslm_126_fb3-Ca2+"/>
+    <Type class="ionslm_126_fb3-Sn2+" element="Sn" mass="118.71" name="ionslm_126_fb3-Sn2+"/>
+    <Type class="ionslm_126_fb3-Pb2+" element="Pb" mass="207.2" name="ionslm_126_fb3-Pb2+"/>
+    <Type class="ionslm_126_fb3-Eu2+" element="Eu" mass="151.96" name="ionslm_126_fb3-Eu2+"/>
+    <Type class="ionslm_126_fb3-Sr2+" element="Sr" mass="87.62" name="ionslm_126_fb3-Sr2+"/>
+    <Type class="ionslm_126_fb3-Sm2+" element="Sm" mass="150.36" name="ionslm_126_fb3-Sm2+"/>
+    <Type class="ionslm_126_fb3-Ba2+" element="Ba" mass="137.33" name="ionslm_126_fb3-Ba2+"/>
+    <Type class="ionslm_126_fb3-Ra2+" element="Ra" mass="226.03" name="ionslm_126_fb3-Ra2+"/>
+    <Type class="ionslm_126_fb3-Al3+" element="Al" mass="26.98" name="ionslm_126_fb3-Al3+"/>
+    <Type class="ionslm_126_fb3-Fe3+" element="Fe" mass="55.85" name="ionslm_126_fb3-Fe3+"/>
+    <Type class="ionslm_126_fb3-Cr3+" element="Cr" mass="52.00" name="ionslm_126_fb3-Cr3+"/>
+    <Type class="ionslm_126_fb3-In3+" element="In" mass="114.82" name="ionslm_126_fb3-In3+"/>
+    <Type class="ionslm_126_fb3-Tl3+" element="Tl" mass="204.38" name="ionslm_126_fb3-Tl3+"/>
+    <Type class="ionslm_126_fb3-Y3+" element="Y" mass="88.91" name="ionslm_126_fb3-Y3+"/>
+    <Type class="ionslm_126_fb3-La3+" element="La" mass="138.91" name="ionslm_126_fb3-La3+"/>
+    <Type class="ionslm_126_fb3-Ce3+" element="Ce" mass="140.12" name="ionslm_126_fb3-Ce3+"/>
+    <Type class="ionslm_126_fb3-Pr3+" element="Pr" mass="140.91" name="ionslm_126_fb3-Pr3+"/>
+    <Type class="ionslm_126_fb3-Nd3+" element="Nd" mass="144.24" name="ionslm_126_fb3-Nd3+"/>
+    <Type class="ionslm_126_fb3-Sm3+" element="Sm" mass="150.36" name="ionslm_126_fb3-Sm3+"/>
+    <Type class="ionslm_126_fb3-Eu3+" element="Eu" mass="151.96" name="ionslm_126_fb3-Eu3+"/>
+    <Type class="ionslm_126_fb3-Gd3+" element="Gd" mass="157.25" name="ionslm_126_fb3-Gd3+"/>
+    <Type class="ionslm_126_fb3-Tb3+" element="Tb" mass="158.93" name="ionslm_126_fb3-Tb3+"/>
+    <Type class="ionslm_126_fb3-Dy3+" element="Dy" mass="162.5" name="ionslm_126_fb3-Dy3+"/>
+    <Type class="ionslm_126_fb3-Er3+" element="Er" mass="167.26" name="ionslm_126_fb3-Er3+"/>
+    <Type class="ionslm_126_fb3-Tm3+" element="Tm" mass="168.93" name="ionslm_126_fb3-Tm3+"/>
+    <Type class="ionslm_126_fb3-Lu3+" element="Lu" mass="174.97" name="ionslm_126_fb3-Lu3+"/>
+    <Type class="ionslm_126_fb3-Hf4+" element="Hf" mass="178.49" name="ionslm_126_fb3-Hf4+"/>
+    <Type class="ionslm_126_fb3-Zr4+" element="Zr" mass="91.22" name="ionslm_126_fb3-Zr4+"/>
+    <Type class="ionslm_126_fb3-Ce4+" element="Ce" mass="140.12" name="ionslm_126_fb3-Ce4+"/>
+    <Type class="ionslm_126_fb3-U4+" element="U" mass="238.03" name="ionslm_126_fb3-U4+"/>
+    <Type class="ionslm_126_fb3-Pu4+" element="Pu" mass="244.06" name="ionslm_126_fb3-Pu4+"/>
+    <Type class="ionslm_126_fb3-Th4+" element="Th" mass="232.04" name="ionslm_126_fb3-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_126_fb3-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_126_fb3-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_126_fb3-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_126_fb3-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_126_fb3-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_126_fb3-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_126_fb3-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_126_fb3-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_126_fb3-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_126_fb3-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_126_fb3-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_126_fb3-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_126_fb3-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_126_fb3-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_126_fb3-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_126_fb3-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_126_fb3-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_126_fb3-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_126_fb3-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_126_fb3-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_126_fb3-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_126_fb3-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_126_fb3-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_126_fb3-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_126_fb3-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_126_fb3-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_126_fb3-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_126_fb3-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_126_fb3-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_126_fb3-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_126_fb3-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_126_fb3-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_126_fb3-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_126_fb3-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_126_fb3-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_126_fb3-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_126_fb3-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_126_fb3-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_126_fb3-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_126_fb3-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_126_fb3-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_126_fb3-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_126_fb3-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_126_fb3-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_126_fb3-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_126_fb3-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_126_fb3-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_126_fb3-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_126_fb3-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_126_fb3-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_126_fb3-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_126_fb3-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_126_fb3-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_126_fb3-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_126_fb3-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_126_fb3-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_126_fb3-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_126_fb3-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_126_fb3-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_126_fb3-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.011806411200000002" sigma="0.22450647697136553" type="ionslm_126_fb3-Li+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.11545547168" sigma="0.25996424595335105" type="ionslm_126_fb3-Na+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.59238168208" sigma="0.3037964628858557" type="ionslm_126_fb3-K+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.8985523254400001" sigma="0.3210798980177783" type="ionslm_126_fb3-Rb+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.51533597416" sigma="0.3510140949472937" type="ionslm_126_fb3-Cs+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.51230787168" sigma="0.29862925032064175" type="ionslm_126_fb3-Tl+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00403312496" sigma="0.2123902544046569" type="ionslm_126_fb3-Cu+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.029271431360000003" sigma="0.23662269953807413" type="ionslm_126_fb3-Ag+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.01002663744" sigma="0.3267816498138765" type="ionslm_126_fb3-F-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.66953145272" sigma="0.4098134103445561" type="ionslm_126_fb3-Cl-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.13914779672" sigma="0.4420639439412363" type="ionslm_126_fb3-Br-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.59848597736" sigma="0.48856885702816205" type="ionslm_126_fb3-I-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.045976e-05" sigma="0.17158709311382936" type="ionslm_126_fb3-Be2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0067303824" sigma="0.21791382645712704" type="ionslm_126_fb3-Cu2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.011301820800000001" sigma="0.2239719377404813" type="ionslm_126_fb3-Ni2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0144147168" sigma="0.22700099338215846" type="ionslm_126_fb3-Pt2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.014823368080000001" sigma="0.2273573528694146" type="ionslm_126_fb3-Zn2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.02161571552" sigma="0.23234638569100052" type="ionslm_126_fb3-Co2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.022764641920000002" sigma="0.2330591046655128" type="ionslm_126_fb3-Pd2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ionslm_126_fb3-Ag2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03762051968" sigma="0.24036447415426354" type="ionslm_126_fb3-Cr2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04078617592000001" sigma="0.24161173235966005" type="ionslm_126_fb3-Fe2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04415701552" sigma="0.2428589905650565" type="ionslm_126_fb3-Mg2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.045666519040000006" sigma="0.2433935297959407" type="ionslm_126_fb3-V2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07346317408" sigma="0.2514116182592038" type="ionslm_126_fb3-Mn2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07346317408" sigma="0.2514116182592038" type="ionslm_126_fb3-Hg2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07644268416000001" sigma="0.252124337233716" type="ionslm_126_fb3-Cd2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.39555874904000005" sigma="0.2902548023701225" type="ionslm_126_fb3-Yb2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.40953067312" sigma="0.2913238808318909" type="ionslm_126_fb3-Ca2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.4506155448" sigma="0.2943529364735681" type="ionslm_126_fb3-Sn2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.66597953912" sigma="0.3082509564765574" type="ionslm_126_fb3-Pb2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.83118754056" sigma="0.31751630314521695" type="ionslm_126_fb3-Eu2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8545456410400001" sigma="0.3187635613506134" type="ionslm_126_fb3-Sr2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.87475741536" sigma="0.3198326398123818" type="ionslm_126_fb3-Sm2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.56477780008" sigma="0.3533304316144586" type="ionslm_126_fb3-Ba2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.56477780008" sigma="0.3533304316144586" type="ionslm_126_fb3-Ra2+"/><!--     CM set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01724489992" sigma="0.22931733004932334" type="ionslm_126_fb3-Al3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07951189920000001" sigma="0.2528370562082283" type="ionslm_126_fb3-Fe3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_126_fb3-Cr3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.10174956632" sigma="0.25746972954255803" type="ionslm_126_fb3-In3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15799491096" sigma="0.2665568964675895" type="ionslm_126_fb3-Tl3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_fb3-Y3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ionslm_126_fb3-La3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.7403159140000001" sigma="0.31252727032363103" type="ionslm_126_fb3-Ce3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.71515496976" sigma="0.3111018323746065" type="ionslm_126_fb3-Pr3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_126_fb3-Nd3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ionslm_126_fb3-Sm3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.50965295632" sigma="0.2984510705770137" type="ionslm_126_fb3-Eu3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.38639884336" sigma="0.2895420833956103" type="ionslm_126_fb3-Gd3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.40484250112000003" sigma="0.2909675213446348" type="ionslm_126_fb3-Tb3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_126_fb3-Dy3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_fb3-Er3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_fb3-Tm3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_126_fb3-Lu3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_126_fb3-Hf4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17386691496" sigma="0.2686950533911263" type="ionslm_126_fb3-Zr4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.59238168208" sigma="0.3037964628858557" type="ionslm_126_fb3-Ce4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.59238168208" sigma="0.3037964628858557" type="ionslm_126_fb3-U4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.52838869912" sigma="0.29969832878241015" type="ionslm_126_fb3-Pu4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.63014479248" sigma="0.3061127995530206" type="ionslm_126_fb3-Th4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_126_fb4.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_126_fb4.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the TIP4P-FB water model (12-6 set) -->
+    <DateGenerated>2022-09-11T06:28:33.567685</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_126_fb4" md5hash="a61544aaeedc659b9101c33b9f728e3f" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_126_fb4</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_126_fb4-Li+" element="Li" mass="6.94" name="ionslm_126_fb4-Li+"/>
+    <Type class="ionslm_126_fb4-Na+" element="Na" mass="22.99" name="ionslm_126_fb4-Na+"/>
+    <Type class="ionslm_126_fb4-K+" element="K" mass="39.10" name="ionslm_126_fb4-K+"/>
+    <Type class="ionslm_126_fb4-Rb+" element="Rb" mass="85.47" name="ionslm_126_fb4-Rb+"/>
+    <Type class="ionslm_126_fb4-Cs+" element="Cs" mass="132.91" name="ionslm_126_fb4-Cs+"/>
+    <Type class="ionslm_126_fb4-Tl+" element="Tl" mass="204.38" name="ionslm_126_fb4-Tl+"/>
+    <Type class="ionslm_126_fb4-Cu+" element="Cu" mass="63.55" name="ionslm_126_fb4-Cu+"/>
+    <Type class="ionslm_126_fb4-Ag+" element="Ag" mass="107.87" name="ionslm_126_fb4-Ag+"/>
+    <Type class="ionslm_126_fb4-F-" element="F" mass="19.00" name="ionslm_126_fb4-F-"/>
+    <Type class="ionslm_126_fb4-Cl-" element="Cl" mass="35.45" name="ionslm_126_fb4-Cl-"/>
+    <Type class="ionslm_126_fb4-Br-" element="Br" mass="79.90" name="ionslm_126_fb4-Br-"/>
+    <Type class="ionslm_126_fb4-I-" element="I" mass="126.9" name="ionslm_126_fb4-I-"/>
+    <Type class="ionslm_126_fb4-Be2+" element="Be" mass="9.01" name="ionslm_126_fb4-Be2+"/>
+    <Type class="ionslm_126_fb4-Cu2+" element="Cu" mass="63.55" name="ionslm_126_fb4-Cu2+"/>
+    <Type class="ionslm_126_fb4-Ni2+" element="Ni" mass="58.69" name="ionslm_126_fb4-Ni2+"/>
+    <Type class="ionslm_126_fb4-Pt2+" element="Pt" mass="195.08" name="ionslm_126_fb4-Pt2+"/>
+    <Type class="ionslm_126_fb4-Zn2+" element="Zn" mass="65.4" name="ionslm_126_fb4-Zn2+"/>
+    <Type class="ionslm_126_fb4-Co2+" element="Co" mass="58.93" name="ionslm_126_fb4-Co2+"/>
+    <Type class="ionslm_126_fb4-Pd2+" element="Pd" mass="106.42" name="ionslm_126_fb4-Pd2+"/>
+    <Type class="ionslm_126_fb4-Ag2+" element="Ag" mass="107.87" name="ionslm_126_fb4-Ag2+"/>
+    <Type class="ionslm_126_fb4-Cr2+" element="Cr" mass="52.00" name="ionslm_126_fb4-Cr2+"/>
+    <Type class="ionslm_126_fb4-Fe2+" element="Fe" mass="55.85" name="ionslm_126_fb4-Fe2+"/>
+    <Type class="ionslm_126_fb4-Mg2+" element="Mg" mass="24.305" name="ionslm_126_fb4-Mg2+"/>
+    <Type class="ionslm_126_fb4-V2+" element="V" mass="50.94" name="ionslm_126_fb4-V2+"/>
+    <Type class="ionslm_126_fb4-Mn2+" element="Mn" mass="54.94" name="ionslm_126_fb4-Mn2+"/>
+    <Type class="ionslm_126_fb4-Hg2+" element="Hg" mass="200.59" name="ionslm_126_fb4-Hg2+"/>
+    <Type class="ionslm_126_fb4-Cd2+" element="Cd" mass="112.41" name="ionslm_126_fb4-Cd2+"/>
+    <Type class="ionslm_126_fb4-Yb2+" element="Yb" mass="173.05" name="ionslm_126_fb4-Yb2+"/>
+    <Type class="ionslm_126_fb4-Ca2+" element="Ca" mass="40.08" name="ionslm_126_fb4-Ca2+"/>
+    <Type class="ionslm_126_fb4-Sn2+" element="Sn" mass="118.71" name="ionslm_126_fb4-Sn2+"/>
+    <Type class="ionslm_126_fb4-Pb2+" element="Pb" mass="207.2" name="ionslm_126_fb4-Pb2+"/>
+    <Type class="ionslm_126_fb4-Eu2+" element="Eu" mass="151.96" name="ionslm_126_fb4-Eu2+"/>
+    <Type class="ionslm_126_fb4-Sr2+" element="Sr" mass="87.62" name="ionslm_126_fb4-Sr2+"/>
+    <Type class="ionslm_126_fb4-Sm2+" element="Sm" mass="150.36" name="ionslm_126_fb4-Sm2+"/>
+    <Type class="ionslm_126_fb4-Ba2+" element="Ba" mass="137.33" name="ionslm_126_fb4-Ba2+"/>
+    <Type class="ionslm_126_fb4-Ra2+" element="Ra" mass="226.03" name="ionslm_126_fb4-Ra2+"/>
+    <Type class="ionslm_126_fb4-Al3+" element="Al" mass="26.98" name="ionslm_126_fb4-Al3+"/>
+    <Type class="ionslm_126_fb4-Fe3+" element="Fe" mass="55.85" name="ionslm_126_fb4-Fe3+"/>
+    <Type class="ionslm_126_fb4-Cr3+" element="Cr" mass="52.00" name="ionslm_126_fb4-Cr3+"/>
+    <Type class="ionslm_126_fb4-In3+" element="In" mass="114.82" name="ionslm_126_fb4-In3+"/>
+    <Type class="ionslm_126_fb4-Tl3+" element="Tl" mass="204.38" name="ionslm_126_fb4-Tl3+"/>
+    <Type class="ionslm_126_fb4-Y3+" element="Y" mass="88.91" name="ionslm_126_fb4-Y3+"/>
+    <Type class="ionslm_126_fb4-La3+" element="La" mass="138.91" name="ionslm_126_fb4-La3+"/>
+    <Type class="ionslm_126_fb4-Ce3+" element="Ce" mass="140.12" name="ionslm_126_fb4-Ce3+"/>
+    <Type class="ionslm_126_fb4-Pr3+" element="Pr" mass="140.91" name="ionslm_126_fb4-Pr3+"/>
+    <Type class="ionslm_126_fb4-Nd3+" element="Nd" mass="144.24" name="ionslm_126_fb4-Nd3+"/>
+    <Type class="ionslm_126_fb4-Sm3+" element="Sm" mass="150.36" name="ionslm_126_fb4-Sm3+"/>
+    <Type class="ionslm_126_fb4-Eu3+" element="Eu" mass="151.96" name="ionslm_126_fb4-Eu3+"/>
+    <Type class="ionslm_126_fb4-Gd3+" element="Gd" mass="157.25" name="ionslm_126_fb4-Gd3+"/>
+    <Type class="ionslm_126_fb4-Tb3+" element="Tb" mass="158.93" name="ionslm_126_fb4-Tb3+"/>
+    <Type class="ionslm_126_fb4-Dy3+" element="Dy" mass="162.5" name="ionslm_126_fb4-Dy3+"/>
+    <Type class="ionslm_126_fb4-Er3+" element="Er" mass="167.26" name="ionslm_126_fb4-Er3+"/>
+    <Type class="ionslm_126_fb4-Tm3+" element="Tm" mass="168.93" name="ionslm_126_fb4-Tm3+"/>
+    <Type class="ionslm_126_fb4-Lu3+" element="Lu" mass="174.97" name="ionslm_126_fb4-Lu3+"/>
+    <Type class="ionslm_126_fb4-Hf4+" element="Hf" mass="178.49" name="ionslm_126_fb4-Hf4+"/>
+    <Type class="ionslm_126_fb4-Zr4+" element="Zr" mass="91.22" name="ionslm_126_fb4-Zr4+"/>
+    <Type class="ionslm_126_fb4-Ce4+" element="Ce" mass="140.12" name="ionslm_126_fb4-Ce4+"/>
+    <Type class="ionslm_126_fb4-U4+" element="U" mass="238.03" name="ionslm_126_fb4-U4+"/>
+    <Type class="ionslm_126_fb4-Pu4+" element="Pu" mass="244.06" name="ionslm_126_fb4-Pu4+"/>
+    <Type class="ionslm_126_fb4-Th4+" element="Th" mass="232.04" name="ionslm_126_fb4-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_126_fb4-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_126_fb4-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_126_fb4-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_126_fb4-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_126_fb4-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_126_fb4-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_126_fb4-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_126_fb4-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_126_fb4-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_126_fb4-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_126_fb4-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_126_fb4-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_126_fb4-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_126_fb4-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_126_fb4-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_126_fb4-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_126_fb4-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_126_fb4-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_126_fb4-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_126_fb4-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_126_fb4-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_126_fb4-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_126_fb4-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_126_fb4-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_126_fb4-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_126_fb4-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_126_fb4-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_126_fb4-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_126_fb4-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_126_fb4-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_126_fb4-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_126_fb4-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_126_fb4-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_126_fb4-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_126_fb4-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_126_fb4-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_126_fb4-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_126_fb4-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_126_fb4-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_126_fb4-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_126_fb4-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_126_fb4-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_126_fb4-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_126_fb4-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_126_fb4-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_126_fb4-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_126_fb4-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_126_fb4-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_126_fb4-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_126_fb4-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_126_fb4-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_126_fb4-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_126_fb4-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_126_fb4-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_126_fb4-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_126_fb4-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_126_fb4-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_126_fb4-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_126_fb4-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_126_fb4-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.008769120080000001" sigma="0.22094288209880417" type="ionslm_126_fb4-Li+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.10458113016" sigma="0.25800426877344224" type="ionslm_126_fb4-Na+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.5365256168" sigma="0.3002328680132944" type="ionslm_126_fb4-K+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.87475741536" sigma="0.3198326398123818" type="ionslm_126_fb4-Rb+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.43933871864" sigma="0.3474505000747323" type="ionslm_126_fb4-Cs+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ionslm_126_fb4-Tl+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00283691936" sigma="0.20882665953209553" type="ionslm_126_fb4-Cu+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.024269710400000002" sigma="0.23395000338365313" type="ionslm_126_fb4-Ag+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.04926352" sigma="0.32874162699378523" type="ionslm_126_fb4-F-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.70772430176" sigma="0.41212974701172095" type="ionslm_126_fb4-Cl-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.0775338361599998" sigma="0.43725309086327857" type="ionslm_126_fb4-Br-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.6763738988" sigma="0.4996160011331022" type="ionslm_126_fb4-I-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="5.94128e-06" sigma="0.16463808311233472" type="ionslm_126_fb4-Be2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00376430296" sigma="0.21043027722474816" type="ionslm_126_fb4-Cu2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00572994616" sigma="0.21613202902084636" type="ionslm_126_fb4-Ni2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00739860904" sigma="0.21898290491889544" type="ionslm_126_fb4-Pt2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00799738128" sigma="0.21987380363703576" type="ionslm_126_fb4-Zn2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.015031229200000001" sigma="0.22753553261304266" type="ionslm_126_fb4-Co2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01610689376" sigma="0.228426431331183" type="ionslm_126_fb4-Pd2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.025210566480000002" sigma="0.23448454261453733" type="ionslm_126_fb4-Ag2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.02891428512" sigma="0.23644451979444603" type="ionslm_126_fb4-Cr2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03148911872" sigma="0.23769177799984254" type="ionslm_126_fb4-Fe2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0346516788" sigma="0.2391172159488671" type="ionslm_126_fb4-Mg2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03590047728" sigma="0.2396517551797513" type="ionslm_126_fb4-V2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06176676024" sigma="0.2483825626175266" type="ionslm_126_fb4-Mn2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06176676024" sigma="0.2483825626175266" type="ionslm_126_fb4-Hg2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06438159288" sigma="0.24909528159203886" type="ionslm_126_fb4-Cd2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.37736324432" sigma="0.288829364421098" type="ionslm_126_fb4-Yb2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.39096329448" sigma="0.2898984428828664" type="ionslm_126_fb4-Ca2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.43343181496" sigma="0.29310567826817163" type="ionslm_126_fb4-Sn2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.65994353336" sigma="0.3078945969893013" type="ionslm_126_fb4-Pb2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.83118754056" sigma="0.31751630314521695" type="ionslm_126_fb4-Eu2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8545456410400001" sigma="0.3187635613506134" type="ionslm_126_fb4-Sr2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8781427316" sigma="0.3200108195560099" type="ionslm_126_fb4-Sm2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.59899451024" sigma="0.3549340493071112" type="ionslm_126_fb4-Ba2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.59899451024" sigma="0.3549340493071112" type="ionslm_126_fb4-Ra2+"/><!--     CM set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0130567996" sigma="0.22575373517676198" type="ionslm_126_fb4-Al3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06846053264" sigma="0.25016436005380727" type="ionslm_126_fb4-Fe3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.03590047728" sigma="0.2396517551797513" type="ionslm_126_fb4-Cr3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.09989325104" sigma="0.25711337005530194" type="ionslm_126_fb4-In3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14799067408" sigma="0.265131458518565" type="ionslm_126_fb4-Tl3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_126_fb4-Y3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6213311128" sigma="0.3055782603221364" type="ionslm_126_fb4-La3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6903723846400001" sigma="0.309676394425582" type="ionslm_126_fb4-Ce3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ionslm_126_fb4-Pr3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.50965295632" sigma="0.2984510705770137" type="ionslm_126_fb4-Nd3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.44566809032000004" sigma="0.29399657698631193" type="ionslm_126_fb4-Sm3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.46563832232" sigma="0.29542201493533654" type="ionslm_126_fb4-Eu3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_126_fb4-Gd3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.36845228664" sigma="0.2881166454465857" type="ionslm_126_fb4-Tb3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.315602258" sigma="0.28366215185588406" type="ionslm_126_fb4-Dy3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_126_fb4-Er3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_126_fb4-Tm3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.26767888936000006" sigma="0.2792076582651823" type="ionslm_126_fb4-Lu3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ionslm_126_fb4-Hf4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15671933488" sigma="0.26637871672396146" type="ionslm_126_fb4-Zr4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_126_fb4-Ce4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_126_fb4-U4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ionslm_126_fb4-Pu4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.60388144792" sigma="0.304509181860368" type="ionslm_126_fb4-Th4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_126_opc.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_126_opc.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the OPC water model (12-6 set) -->
+    <DateGenerated>2022-09-11T06:28:33.561532</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_126_opc" md5hash="61ee47ec99a7ebf66cf09e899a8f0581" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_126_opc</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_126_opc-Li+" element="Li" mass="6.94" name="ionslm_126_opc-Li+"/>
+    <Type class="ionslm_126_opc-Na+" element="Na" mass="22.99" name="ionslm_126_opc-Na+"/>
+    <Type class="ionslm_126_opc-K+" element="K" mass="39.10" name="ionslm_126_opc-K+"/>
+    <Type class="ionslm_126_opc-Rb+" element="Rb" mass="85.47" name="ionslm_126_opc-Rb+"/>
+    <Type class="ionslm_126_opc-Cs+" element="Cs" mass="132.91" name="ionslm_126_opc-Cs+"/>
+    <Type class="ionslm_126_opc-Tl+" element="Tl" mass="204.38" name="ionslm_126_opc-Tl+"/>
+    <Type class="ionslm_126_opc-Cu+" element="Cu" mass="63.55" name="ionslm_126_opc-Cu+"/>
+    <Type class="ionslm_126_opc-Ag+" element="Ag" mass="107.87" name="ionslm_126_opc-Ag+"/>
+    <Type class="ionslm_126_opc-F-" element="F" mass="19.00" name="ionslm_126_opc-F-"/>
+    <Type class="ionslm_126_opc-Cl-" element="Cl" mass="35.45" name="ionslm_126_opc-Cl-"/>
+    <Type class="ionslm_126_opc-Br-" element="Br" mass="79.90" name="ionslm_126_opc-Br-"/>
+    <Type class="ionslm_126_opc-I-" element="I" mass="126.9" name="ionslm_126_opc-I-"/>
+    <Type class="ionslm_126_opc-Be2+" element="Be" mass="9.01" name="ionslm_126_opc-Be2+"/>
+    <Type class="ionslm_126_opc-Cu2+" element="Cu" mass="63.55" name="ionslm_126_opc-Cu2+"/>
+    <Type class="ionslm_126_opc-Ni2+" element="Ni" mass="58.69" name="ionslm_126_opc-Ni2+"/>
+    <Type class="ionslm_126_opc-Pt2+" element="Pt" mass="195.08" name="ionslm_126_opc-Pt2+"/>
+    <Type class="ionslm_126_opc-Zn2+" element="Zn" mass="65.4" name="ionslm_126_opc-Zn2+"/>
+    <Type class="ionslm_126_opc-Co2+" element="Co" mass="58.93" name="ionslm_126_opc-Co2+"/>
+    <Type class="ionslm_126_opc-Pd2+" element="Pd" mass="106.42" name="ionslm_126_opc-Pd2+"/>
+    <Type class="ionslm_126_opc-Ag2+" element="Ag" mass="107.87" name="ionslm_126_opc-Ag2+"/>
+    <Type class="ionslm_126_opc-Cr2+" element="Cr" mass="52.00" name="ionslm_126_opc-Cr2+"/>
+    <Type class="ionslm_126_opc-Fe2+" element="Fe" mass="55.85" name="ionslm_126_opc-Fe2+"/>
+    <Type class="ionslm_126_opc-Mg2+" element="Mg" mass="24.305" name="ionslm_126_opc-Mg2+"/>
+    <Type class="ionslm_126_opc-V2+" element="V" mass="50.94" name="ionslm_126_opc-V2+"/>
+    <Type class="ionslm_126_opc-Mn2+" element="Mn" mass="54.94" name="ionslm_126_opc-Mn2+"/>
+    <Type class="ionslm_126_opc-Hg2+" element="Hg" mass="200.59" name="ionslm_126_opc-Hg2+"/>
+    <Type class="ionslm_126_opc-Cd2+" element="Cd" mass="112.41" name="ionslm_126_opc-Cd2+"/>
+    <Type class="ionslm_126_opc-Yb2+" element="Yb" mass="173.05" name="ionslm_126_opc-Yb2+"/>
+    <Type class="ionslm_126_opc-Ca2+" element="Ca" mass="40.08" name="ionslm_126_opc-Ca2+"/>
+    <Type class="ionslm_126_opc-Sn2+" element="Sn" mass="118.71" name="ionslm_126_opc-Sn2+"/>
+    <Type class="ionslm_126_opc-Pb2+" element="Pb" mass="207.2" name="ionslm_126_opc-Pb2+"/>
+    <Type class="ionslm_126_opc-Eu2+" element="Eu" mass="151.96" name="ionslm_126_opc-Eu2+"/>
+    <Type class="ionslm_126_opc-Sr2+" element="Sr" mass="87.62" name="ionslm_126_opc-Sr2+"/>
+    <Type class="ionslm_126_opc-Sm2+" element="Sm" mass="150.36" name="ionslm_126_opc-Sm2+"/>
+    <Type class="ionslm_126_opc-Ba2+" element="Ba" mass="137.33" name="ionslm_126_opc-Ba2+"/>
+    <Type class="ionslm_126_opc-Ra2+" element="Ra" mass="226.03" name="ionslm_126_opc-Ra2+"/>
+    <Type class="ionslm_126_opc-Al3+" element="Al" mass="26.98" name="ionslm_126_opc-Al3+"/>
+    <Type class="ionslm_126_opc-Fe3+" element="Fe" mass="55.85" name="ionslm_126_opc-Fe3+"/>
+    <Type class="ionslm_126_opc-Cr3+" element="Cr" mass="52.00" name="ionslm_126_opc-Cr3+"/>
+    <Type class="ionslm_126_opc-In3+" element="In" mass="114.82" name="ionslm_126_opc-In3+"/>
+    <Type class="ionslm_126_opc-Tl3+" element="Tl" mass="204.38" name="ionslm_126_opc-Tl3+"/>
+    <Type class="ionslm_126_opc-Y3+" element="Y" mass="88.91" name="ionslm_126_opc-Y3+"/>
+    <Type class="ionslm_126_opc-La3+" element="La" mass="138.91" name="ionslm_126_opc-La3+"/>
+    <Type class="ionslm_126_opc-Ce3+" element="Ce" mass="140.12" name="ionslm_126_opc-Ce3+"/>
+    <Type class="ionslm_126_opc-Pr3+" element="Pr" mass="140.91" name="ionslm_126_opc-Pr3+"/>
+    <Type class="ionslm_126_opc-Nd3+" element="Nd" mass="144.24" name="ionslm_126_opc-Nd3+"/>
+    <Type class="ionslm_126_opc-Sm3+" element="Sm" mass="150.36" name="ionslm_126_opc-Sm3+"/>
+    <Type class="ionslm_126_opc-Eu3+" element="Eu" mass="151.96" name="ionslm_126_opc-Eu3+"/>
+    <Type class="ionslm_126_opc-Gd3+" element="Gd" mass="157.25" name="ionslm_126_opc-Gd3+"/>
+    <Type class="ionslm_126_opc-Tb3+" element="Tb" mass="158.93" name="ionslm_126_opc-Tb3+"/>
+    <Type class="ionslm_126_opc-Dy3+" element="Dy" mass="162.5" name="ionslm_126_opc-Dy3+"/>
+    <Type class="ionslm_126_opc-Er3+" element="Er" mass="167.26" name="ionslm_126_opc-Er3+"/>
+    <Type class="ionslm_126_opc-Tm3+" element="Tm" mass="168.93" name="ionslm_126_opc-Tm3+"/>
+    <Type class="ionslm_126_opc-Lu3+" element="Lu" mass="174.97" name="ionslm_126_opc-Lu3+"/>
+    <Type class="ionslm_126_opc-Hf4+" element="Hf" mass="178.49" name="ionslm_126_opc-Hf4+"/>
+    <Type class="ionslm_126_opc-Zr4+" element="Zr" mass="91.22" name="ionslm_126_opc-Zr4+"/>
+    <Type class="ionslm_126_opc-Ce4+" element="Ce" mass="140.12" name="ionslm_126_opc-Ce4+"/>
+    <Type class="ionslm_126_opc-U4+" element="U" mass="238.03" name="ionslm_126_opc-U4+"/>
+    <Type class="ionslm_126_opc-Pu4+" element="Pu" mass="244.06" name="ionslm_126_opc-Pu4+"/>
+    <Type class="ionslm_126_opc-Th4+" element="Th" mass="232.04" name="ionslm_126_opc-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_126_opc-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_126_opc-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_126_opc-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_126_opc-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_126_opc-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_126_opc-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_126_opc-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_126_opc-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_126_opc-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_126_opc-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_126_opc-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_126_opc-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_126_opc-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_126_opc-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_126_opc-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_126_opc-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_126_opc-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_126_opc-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_126_opc-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_126_opc-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_126_opc-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_126_opc-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_126_opc-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_126_opc-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_126_opc-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_126_opc-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_126_opc-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_126_opc-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_126_opc-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_126_opc-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_126_opc-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_126_opc-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_126_opc-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_126_opc-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_126_opc-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_126_opc-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_126_opc-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_126_opc-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_126_opc-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_126_opc-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_126_opc-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_126_opc-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_126_opc-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_126_opc-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_126_opc-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_126_opc-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_126_opc-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_126_opc-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_126_opc-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_126_opc-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_126_opc-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_126_opc-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_126_opc-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_126_opc-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_126_opc-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_126_opc-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_126_opc-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_126_opc-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_126_opc-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_126_opc-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.009039866720000001" sigma="0.2212992415860603" type="ionslm_126_opc-Li+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ionslm_126_opc-Na+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.58382766144" sigma="0.3032619236549715" type="ionslm_126_opc-K+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.9537620464000001" sigma="0.3239307739158274" type="ionslm_126_opc-Rb+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.47731805816" sigma="0.349232297511013" type="ionslm_126_opc-Cs+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.47070573208000005" sigma="0.29577837442259264" type="ionslm_126_opc-Tl+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.0032724319200000004" sigma="0.21025209748112006" type="ionslm_126_opc-Cu+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.025210566480000002" sigma="0.23448454261453733" type="ionslm_126_opc-Ag+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.0313754556" sigma="0.3278507282756449" type="ionslm_126_opc-F-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.8400519208" sigma="0.4205041949622401" type="ionslm_126_opc-Cl-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.17863094952" sigma="0.4452711793265416" type="ionslm_126_opc-Br-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.77817463544" sigma="0.5167212565213968" type="ionslm_126_opc-I-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="5.35552e-06" sigma="0.16410354388145051" type="ionslm_126_opc-Be2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0031585016" sigma="0.20989573799386393" type="ionslm_126_opc-Cu2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00439211216" sigma="0.21328115312279727" type="ionslm_126_opc-Ni2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00631378152" sigma="0.21720110748261476" type="ionslm_126_opc-Pt2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00631378152" sigma="0.21720110748261476" type="ionslm_126_opc-Zn2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.012329536720000001" sigma="0.2250410162022497" type="ionslm_126_opc-Co2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.013433485120000001" sigma="0.2261100946640181" type="ionslm_126_opc-Pd2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0218984284" sigma="0.23252456543462854" type="ionslm_126_opc-Ag2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.025210566480000002" sigma="0.23448454261453733" type="ionslm_126_opc-Cr2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.027520218160000002" sigma="0.23573180081993375" type="ionslm_126_opc-Fe2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0299963512" sigma="0.23697905902533029" type="ionslm_126_opc-Mg2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03148911872" sigma="0.23769177799984254" type="ionslm_126_opc-V2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.053825486400000004" sigma="0.2460662259503617" type="ionslm_126_opc-Mn2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.053825486400000004" sigma="0.2460662259503617" type="ionslm_126_opc-Hg2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05861307024" sigma="0.24749166389938626" type="ionslm_126_opc-Cd2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.33615222504000003" sigma="0.2854439492921647" type="ionslm_126_opc-Yb2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_126_opc-Ca2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.38639884336" sigma="0.2895420833956103" type="ionslm_126_opc-Sn2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.59811815528" sigma="0.30415282237311186" type="ionslm_126_opc-Pb2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.73715046696" sigma="0.312349090580003" type="ionslm_126_opc-Eu2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.77874118424" sigma="0.31466542724716784" type="ionslm_126_opc-Sr2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.77874118424" sigma="0.31466542724716784" type="ionslm_126_opc-Sm2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.47731805816" sigma="0.349232297511013" type="ionslm_126_opc-Ba2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.47731805816" sigma="0.349232297511013" type="ionslm_126_opc-Ra2+"/><!--     CM set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.010193772080000002" sigma="0.22272467953508485" type="ionslm_126_opc-Al3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_126_opc-Fe3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.032257342960000004" sigma="0.2380481374870987" type="ionslm_126_opc-Cr3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.09715545064" sigma="0.2565788308244177" type="ionslm_126_opc-In3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14196839183999999" sigma="0.26424055980042466" type="ionslm_126_opc-Tl3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ionslm_126_opc-Y3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.5781589690400001" sigma="0.30290556416771536" type="ionslm_126_opc-La3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.65093680392" sigma="0.30736005775841707" type="ionslm_126_opc-Ce3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.62720034432" sigma="0.30593461980939257" type="ionslm_126_opc-Pr3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.47580293192" sigma="0.29613473390984874" type="ionslm_126_opc-Nd3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.41662062848000003" sigma="0.2918584200627751" type="ionslm_126_opc-Sm3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.43586389048" sigma="0.2932838580117997" type="ionslm_126_opc-Eu3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_opc-Gd3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_126_opc-Tb3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_126_opc-Dy3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ionslm_126_opc-Er3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ionslm_126_opc-Tm3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.25163082264000003" sigma="0.27760404057252974" type="ionslm_126_opc-Lu3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11751709584" sigma="0.26032060544060714" type="ionslm_126_opc-Hf4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14799067408" sigma="0.265131458518565" type="ionslm_126_opc-Zr4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.5310938643199999" sigma="0.2998765085260382" type="ionslm_126_opc-Ce4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.5310938643199999" sigma="0.2998765085260382" type="ionslm_126_opc-U4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.46563832232" sigma="0.29542201493533654" type="ionslm_126_opc-Pu4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.58952354984" sigma="0.3036182831422276" type="ionslm_126_opc-Th4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_126_opc3.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_126_opc3.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the OPC3 water model (12-6 set) -->
+    <DateGenerated>2022-09-11T06:28:33.599613</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_126_opc3" md5hash="5764d233aceb45e3c28df84ac16d1085" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_126_opc3</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_126_opc3-Li+" element="Li" mass="6.94" name="ionslm_126_opc3-Li+"/>
+    <Type class="ionslm_126_opc3-Na+" element="Na" mass="22.99" name="ionslm_126_opc3-Na+"/>
+    <Type class="ionslm_126_opc3-K+" element="K" mass="39.10" name="ionslm_126_opc3-K+"/>
+    <Type class="ionslm_126_opc3-Rb+" element="Rb" mass="85.47" name="ionslm_126_opc3-Rb+"/>
+    <Type class="ionslm_126_opc3-Cs+" element="Cs" mass="132.91" name="ionslm_126_opc3-Cs+"/>
+    <Type class="ionslm_126_opc3-Tl+" element="Tl" mass="204.38" name="ionslm_126_opc3-Tl+"/>
+    <Type class="ionslm_126_opc3-Cu+" element="Cu" mass="63.55" name="ionslm_126_opc3-Cu+"/>
+    <Type class="ionslm_126_opc3-Ag+" element="Ag" mass="107.87" name="ionslm_126_opc3-Ag+"/>
+    <Type class="ionslm_126_opc3-F-" element="F" mass="19.00" name="ionslm_126_opc3-F-"/>
+    <Type class="ionslm_126_opc3-Cl-" element="Cl" mass="35.45" name="ionslm_126_opc3-Cl-"/>
+    <Type class="ionslm_126_opc3-Br-" element="Br" mass="79.90" name="ionslm_126_opc3-Br-"/>
+    <Type class="ionslm_126_opc3-I-" element="I" mass="126.9" name="ionslm_126_opc3-I-"/>
+    <Type class="ionslm_126_opc3-Be2+" element="Be" mass="9.01" name="ionslm_126_opc3-Be2+"/>
+    <Type class="ionslm_126_opc3-Cu2+" element="Cu" mass="63.55" name="ionslm_126_opc3-Cu2+"/>
+    <Type class="ionslm_126_opc3-Ni2+" element="Ni" mass="58.69" name="ionslm_126_opc3-Ni2+"/>
+    <Type class="ionslm_126_opc3-Pt2+" element="Pt" mass="195.08" name="ionslm_126_opc3-Pt2+"/>
+    <Type class="ionslm_126_opc3-Zn2+" element="Zn" mass="65.4" name="ionslm_126_opc3-Zn2+"/>
+    <Type class="ionslm_126_opc3-Co2+" element="Co" mass="58.93" name="ionslm_126_opc3-Co2+"/>
+    <Type class="ionslm_126_opc3-Pd2+" element="Pd" mass="106.42" name="ionslm_126_opc3-Pd2+"/>
+    <Type class="ionslm_126_opc3-Ag2+" element="Ag" mass="107.87" name="ionslm_126_opc3-Ag2+"/>
+    <Type class="ionslm_126_opc3-Cr2+" element="Cr" mass="52.00" name="ionslm_126_opc3-Cr2+"/>
+    <Type class="ionslm_126_opc3-Fe2+" element="Fe" mass="55.85" name="ionslm_126_opc3-Fe2+"/>
+    <Type class="ionslm_126_opc3-Mg2+" element="Mg" mass="24.305" name="ionslm_126_opc3-Mg2+"/>
+    <Type class="ionslm_126_opc3-V2+" element="V" mass="50.94" name="ionslm_126_opc3-V2+"/>
+    <Type class="ionslm_126_opc3-Mn2+" element="Mn" mass="54.94" name="ionslm_126_opc3-Mn2+"/>
+    <Type class="ionslm_126_opc3-Hg2+" element="Hg" mass="200.59" name="ionslm_126_opc3-Hg2+"/>
+    <Type class="ionslm_126_opc3-Cd2+" element="Cd" mass="112.41" name="ionslm_126_opc3-Cd2+"/>
+    <Type class="ionslm_126_opc3-Yb2+" element="Yb" mass="173.05" name="ionslm_126_opc3-Yb2+"/>
+    <Type class="ionslm_126_opc3-Ca2+" element="Ca" mass="40.08" name="ionslm_126_opc3-Ca2+"/>
+    <Type class="ionslm_126_opc3-Sn2+" element="Sn" mass="118.71" name="ionslm_126_opc3-Sn2+"/>
+    <Type class="ionslm_126_opc3-Pb2+" element="Pb" mass="207.2" name="ionslm_126_opc3-Pb2+"/>
+    <Type class="ionslm_126_opc3-Eu2+" element="Eu" mass="151.96" name="ionslm_126_opc3-Eu2+"/>
+    <Type class="ionslm_126_opc3-Sr2+" element="Sr" mass="87.62" name="ionslm_126_opc3-Sr2+"/>
+    <Type class="ionslm_126_opc3-Sm2+" element="Sm" mass="150.36" name="ionslm_126_opc3-Sm2+"/>
+    <Type class="ionslm_126_opc3-Ba2+" element="Ba" mass="137.33" name="ionslm_126_opc3-Ba2+"/>
+    <Type class="ionslm_126_opc3-Ra2+" element="Ra" mass="226.03" name="ionslm_126_opc3-Ra2+"/>
+    <Type class="ionslm_126_opc3-Al3+" element="Al" mass="26.98" name="ionslm_126_opc3-Al3+"/>
+    <Type class="ionslm_126_opc3-Fe3+" element="Fe" mass="55.85" name="ionslm_126_opc3-Fe3+"/>
+    <Type class="ionslm_126_opc3-Cr3+" element="Cr" mass="52.00" name="ionslm_126_opc3-Cr3+"/>
+    <Type class="ionslm_126_opc3-In3+" element="In" mass="114.82" name="ionslm_126_opc3-In3+"/>
+    <Type class="ionslm_126_opc3-Tl3+" element="Tl" mass="204.38" name="ionslm_126_opc3-Tl3+"/>
+    <Type class="ionslm_126_opc3-Y3+" element="Y" mass="88.91" name="ionslm_126_opc3-Y3+"/>
+    <Type class="ionslm_126_opc3-La3+" element="La" mass="138.91" name="ionslm_126_opc3-La3+"/>
+    <Type class="ionslm_126_opc3-Ce3+" element="Ce" mass="140.12" name="ionslm_126_opc3-Ce3+"/>
+    <Type class="ionslm_126_opc3-Pr3+" element="Pr" mass="140.91" name="ionslm_126_opc3-Pr3+"/>
+    <Type class="ionslm_126_opc3-Nd3+" element="Nd" mass="144.24" name="ionslm_126_opc3-Nd3+"/>
+    <Type class="ionslm_126_opc3-Sm3+" element="Sm" mass="150.36" name="ionslm_126_opc3-Sm3+"/>
+    <Type class="ionslm_126_opc3-Eu3+" element="Eu" mass="151.96" name="ionslm_126_opc3-Eu3+"/>
+    <Type class="ionslm_126_opc3-Gd3+" element="Gd" mass="157.25" name="ionslm_126_opc3-Gd3+"/>
+    <Type class="ionslm_126_opc3-Tb3+" element="Tb" mass="158.93" name="ionslm_126_opc3-Tb3+"/>
+    <Type class="ionslm_126_opc3-Dy3+" element="Dy" mass="162.5" name="ionslm_126_opc3-Dy3+"/>
+    <Type class="ionslm_126_opc3-Er3+" element="Er" mass="167.26" name="ionslm_126_opc3-Er3+"/>
+    <Type class="ionslm_126_opc3-Tm3+" element="Tm" mass="168.93" name="ionslm_126_opc3-Tm3+"/>
+    <Type class="ionslm_126_opc3-Lu3+" element="Lu" mass="174.97" name="ionslm_126_opc3-Lu3+"/>
+    <Type class="ionslm_126_opc3-Hf4+" element="Hf" mass="178.49" name="ionslm_126_opc3-Hf4+"/>
+    <Type class="ionslm_126_opc3-Zr4+" element="Zr" mass="91.22" name="ionslm_126_opc3-Zr4+"/>
+    <Type class="ionslm_126_opc3-Ce4+" element="Ce" mass="140.12" name="ionslm_126_opc3-Ce4+"/>
+    <Type class="ionslm_126_opc3-U4+" element="U" mass="238.03" name="ionslm_126_opc3-U4+"/>
+    <Type class="ionslm_126_opc3-Pu4+" element="Pu" mass="244.06" name="ionslm_126_opc3-Pu4+"/>
+    <Type class="ionslm_126_opc3-Th4+" element="Th" mass="232.04" name="ionslm_126_opc3-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_126_opc3-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_126_opc3-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_126_opc3-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_126_opc3-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_126_opc3-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_126_opc3-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_126_opc3-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_126_opc3-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_126_opc3-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_126_opc3-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_126_opc3-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_126_opc3-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_126_opc3-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_126_opc3-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_126_opc3-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_126_opc3-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_126_opc3-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_126_opc3-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_126_opc3-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_126_opc3-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_126_opc3-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_126_opc3-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_126_opc3-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_126_opc3-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_126_opc3-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_126_opc3-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_126_opc3-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_126_opc3-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_126_opc3-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_126_opc3-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_126_opc3-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_126_opc3-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_126_opc3-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_126_opc3-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_126_opc3-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_126_opc3-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_126_opc3-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_126_opc3-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_126_opc3-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_126_opc3-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_126_opc3-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_126_opc3-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_126_opc3-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_126_opc3-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_126_opc3-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_126_opc3-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_126_opc3-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_126_opc3-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_126_opc3-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_126_opc3-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_126_opc3-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_126_opc3-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_126_opc3-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_126_opc3-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_126_opc3-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_126_opc3-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_126_opc3-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_126_opc3-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_126_opc3-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_126_opc3-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.013625196" sigma="0.22628827440764618" type="ionslm_126_opc3-Li+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.1260287744" sigma="0.2617460433896317" type="ionslm_126_opc3-Na+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.58667223752" sigma="0.3034401033985996" type="ionslm_126_opc3-K+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.89173069" sigma="0.32072353853052216" type="ionslm_126_opc3-Rb+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.4963237108" sigma="0.35012319622915333" type="ionslm_126_opc3-Cs+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.52838869912" sigma="0.29969832878241015" type="ionslm_126_opc3-Tl+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.004698632" sigma="0.2139938720973095" type="ionslm_126_opc3-Cu+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.0318714108" sigma="0.2378699577434706" type="ionslm_126_opc3-Ag+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.9537620464000001" sigma="0.3239307739158274" type="ionslm_126_opc3-F-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.68724395648" sigma="0.4108824888063245" type="ionslm_126_opc3-Cl-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.18294026032" sigma="0.4456275388137977" type="ionslm_126_opc3-Br-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.64743605776" sigma="0.4953396872860286" type="ionslm_126_opc3-I-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.598264e-05" sigma="0.17301253106285389" type="ionslm_126_opc3-Be2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.007283507200000001" sigma="0.2188047251752673" type="ionslm_126_opc3-Cu2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01034627888" sigma="0.2229028592787129" type="ionslm_126_opc3-Ni2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.014015354" sigma="0.22664463389490233" type="ionslm_126_opc3-Pt2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.015669289200000002" sigma="0.22807007184392686" type="ionslm_126_opc3-Zn2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.022184153760000002" sigma="0.23270274517825662" type="ionslm_126_opc3-Co2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0230594884" sigma="0.23323728440914082" type="ionslm_126_opc3-Pd2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ionslm_126_opc3-Ag2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03762051968" sigma="0.24036447415426354" type="ionslm_126_opc3-Cr2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04078617592000001" sigma="0.24161173235966005" type="ionslm_126_opc3-Fe2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04415701552" sigma="0.2428589905650565" type="ionslm_126_opc3-Mg2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.045666519040000006" sigma="0.2433935297959407" type="ionslm_126_opc3-V2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0727321456" sigma="0.25123343851557567" type="ionslm_126_opc3-Mn2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0727321456" sigma="0.25123343851557567" type="ionslm_126_opc3-Hg2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07494179968" sigma="0.25176797774645987" type="ionslm_126_opc3-Cd2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.37961047072000004" sigma="0.2890075441647261" type="ionslm_126_opc3-Yb2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.39325717248000003" sigma="0.2900766226264945" type="ionslm_126_opc3-Ca2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.423779578" sigma="0.2923929592936593" type="ionslm_126_opc3-Sn2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.64496410208" sigma="0.307003698271161" type="ionslm_126_opc3-Pb2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.7982505068" sigma="0.31573450570893624" type="ionslm_126_opc3-Eu2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8179506616000001" sigma="0.31680358417070464" type="ionslm_126_opc3-Sr2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8378363768" sigma="0.31787266263247305" type="ionslm_126_opc3-Sm2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.5001257116000002" sigma="0.35030137597278144" type="ionslm_126_opc3-Ba2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.5001257116000002" sigma="0.35030137597278144" type="ionslm_126_opc3-Ra2+"/><!--     CM set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01724489992" sigma="0.22931733004932334" type="ionslm_126_opc3-Al3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07951189920000001" sigma="0.2528370562082283" type="ionslm_126_opc3-Fe3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_126_opc3-Cr3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.10942737368000001" sigma="0.25889516749158265" type="ionslm_126_opc3-In3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15799491096" sigma="0.2665568964675895" type="ionslm_126_opc3-Tl3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_opc3-Y3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.67508049224" sigma="0.3087854957074416" type="ionslm_126_opc3-La3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.7530346464" sigma="0.3132399892981433" type="ionslm_126_opc3-Ce3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.7276888530400001" sigma="0.3118145513491188" type="ionslm_126_opc3-Pr3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_126_opc3-Nd3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ionslm_126_opc3-Sm3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.50965295632" sigma="0.2984510705770137" type="ionslm_126_opc3-Eu3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.38639884336" sigma="0.2895420833956103" type="ionslm_126_opc3-Gd3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.40484250112000003" sigma="0.2909675213446348" type="ionslm_126_opc3-Tb3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_126_opc3-Dy3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_opc3-Er3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_126_opc3-Tm3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_126_opc3-Lu3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_126_opc3-Hf4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17386691496" sigma="0.2686950533911263" type="ionslm_126_opc3-Zr4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6009964544" sigma="0.3043310021167399" type="ionslm_126_opc3-Ce4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6009964544" sigma="0.3043310021167399" type="ionslm_126_opc3-U4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.52838869912" sigma="0.29969832878241015" type="ionslm_126_opc3-Pu4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.63901700632" sigma="0.3066473387839048" type="ionslm_126_opc3-Th4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_hfe_fb3.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_hfe_fb3.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the TIP3P-FB water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.629045</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_hfe_fb3" md5hash="761b5825882b76da3520597c2607d412" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_hfe_fb3</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_hfe_fb3-Li+" element="Li" mass="6.94" name="ionslm_hfe_fb3-Li+"/>
+    <Type class="ionslm_hfe_fb3-Na+" element="Na" mass="22.99" name="ionslm_hfe_fb3-Na+"/>
+    <Type class="ionslm_hfe_fb3-K+" element="K" mass="39.10" name="ionslm_hfe_fb3-K+"/>
+    <Type class="ionslm_hfe_fb3-Rb+" element="Rb" mass="85.47" name="ionslm_hfe_fb3-Rb+"/>
+    <Type class="ionslm_hfe_fb3-Cs+" element="Cs" mass="132.91" name="ionslm_hfe_fb3-Cs+"/>
+    <Type class="ionslm_hfe_fb3-Tl+" element="Tl" mass="204.38" name="ionslm_hfe_fb3-Tl+"/>
+    <Type class="ionslm_hfe_fb3-Cu+" element="Cu" mass="63.55" name="ionslm_hfe_fb3-Cu+"/>
+    <Type class="ionslm_hfe_fb3-Ag+" element="Ag" mass="107.87" name="ionslm_hfe_fb3-Ag+"/>
+    <Type class="ionslm_hfe_fb3-F-" element="F" mass="19.00" name="ionslm_hfe_fb3-F-"/>
+    <Type class="ionslm_hfe_fb3-Cl-" element="Cl" mass="35.45" name="ionslm_hfe_fb3-Cl-"/>
+    <Type class="ionslm_hfe_fb3-Br-" element="Br" mass="79.90" name="ionslm_hfe_fb3-Br-"/>
+    <Type class="ionslm_hfe_fb3-I-" element="I" mass="126.9" name="ionslm_hfe_fb3-I-"/>
+    <Type class="ionslm_hfe_fb3-Be2+" element="Be" mass="9.01" name="ionslm_hfe_fb3-Be2+"/>
+    <Type class="ionslm_hfe_fb3-Cu2+" element="Cu" mass="63.55" name="ionslm_hfe_fb3-Cu2+"/>
+    <Type class="ionslm_hfe_fb3-Ni2+" element="Ni" mass="58.69" name="ionslm_hfe_fb3-Ni2+"/>
+    <Type class="ionslm_hfe_fb3-Pt2+" element="Pt" mass="195.08" name="ionslm_hfe_fb3-Pt2+"/>
+    <Type class="ionslm_hfe_fb3-Zn2+" element="Zn" mass="65.4" name="ionslm_hfe_fb3-Zn2+"/>
+    <Type class="ionslm_hfe_fb3-Co2+" element="Co" mass="58.93" name="ionslm_hfe_fb3-Co2+"/>
+    <Type class="ionslm_hfe_fb3-Pd2+" element="Pd" mass="106.42" name="ionslm_hfe_fb3-Pd2+"/>
+    <Type class="ionslm_hfe_fb3-Ag2+" element="Ag" mass="107.87" name="ionslm_hfe_fb3-Ag2+"/>
+    <Type class="ionslm_hfe_fb3-Cr2+" element="Cr" mass="52.00" name="ionslm_hfe_fb3-Cr2+"/>
+    <Type class="ionslm_hfe_fb3-Fe2+" element="Fe" mass="55.85" name="ionslm_hfe_fb3-Fe2+"/>
+    <Type class="ionslm_hfe_fb3-Mg2+" element="Mg" mass="24.305" name="ionslm_hfe_fb3-Mg2+"/>
+    <Type class="ionslm_hfe_fb3-V2+" element="V" mass="50.94" name="ionslm_hfe_fb3-V2+"/>
+    <Type class="ionslm_hfe_fb3-Mn2+" element="Mn" mass="54.94" name="ionslm_hfe_fb3-Mn2+"/>
+    <Type class="ionslm_hfe_fb3-Hg2+" element="Hg" mass="200.59" name="ionslm_hfe_fb3-Hg2+"/>
+    <Type class="ionslm_hfe_fb3-Cd2+" element="Cd" mass="112.41" name="ionslm_hfe_fb3-Cd2+"/>
+    <Type class="ionslm_hfe_fb3-Yb2+" element="Yb" mass="173.05" name="ionslm_hfe_fb3-Yb2+"/>
+    <Type class="ionslm_hfe_fb3-Ca2+" element="Ca" mass="40.08" name="ionslm_hfe_fb3-Ca2+"/>
+    <Type class="ionslm_hfe_fb3-Sn2+" element="Sn" mass="118.71" name="ionslm_hfe_fb3-Sn2+"/>
+    <Type class="ionslm_hfe_fb3-Pb2+" element="Pb" mass="207.2" name="ionslm_hfe_fb3-Pb2+"/>
+    <Type class="ionslm_hfe_fb3-Eu2+" element="Eu" mass="151.96" name="ionslm_hfe_fb3-Eu2+"/>
+    <Type class="ionslm_hfe_fb3-Sr2+" element="Sr" mass="87.62" name="ionslm_hfe_fb3-Sr2+"/>
+    <Type class="ionslm_hfe_fb3-Sm2+" element="Sm" mass="150.36" name="ionslm_hfe_fb3-Sm2+"/>
+    <Type class="ionslm_hfe_fb3-Ba2+" element="Ba" mass="137.33" name="ionslm_hfe_fb3-Ba2+"/>
+    <Type class="ionslm_hfe_fb3-Ra2+" element="Ra" mass="226.03" name="ionslm_hfe_fb3-Ra2+"/>
+    <Type class="ionslm_hfe_fb3-Al3+" element="Al" mass="26.98" name="ionslm_hfe_fb3-Al3+"/>
+    <Type class="ionslm_hfe_fb3-Fe3+" element="Fe" mass="55.85" name="ionslm_hfe_fb3-Fe3+"/>
+    <Type class="ionslm_hfe_fb3-Cr3+" element="Cr" mass="52.00" name="ionslm_hfe_fb3-Cr3+"/>
+    <Type class="ionslm_hfe_fb3-In3+" element="In" mass="114.82" name="ionslm_hfe_fb3-In3+"/>
+    <Type class="ionslm_hfe_fb3-Tl3+" element="Tl" mass="204.38" name="ionslm_hfe_fb3-Tl3+"/>
+    <Type class="ionslm_hfe_fb3-Y3+" element="Y" mass="88.91" name="ionslm_hfe_fb3-Y3+"/>
+    <Type class="ionslm_hfe_fb3-La3+" element="La" mass="138.91" name="ionslm_hfe_fb3-La3+"/>
+    <Type class="ionslm_hfe_fb3-Ce3+" element="Ce" mass="140.12" name="ionslm_hfe_fb3-Ce3+"/>
+    <Type class="ionslm_hfe_fb3-Pr3+" element="Pr" mass="140.91" name="ionslm_hfe_fb3-Pr3+"/>
+    <Type class="ionslm_hfe_fb3-Nd3+" element="Nd" mass="144.24" name="ionslm_hfe_fb3-Nd3+"/>
+    <Type class="ionslm_hfe_fb3-Sm3+" element="Sm" mass="150.36" name="ionslm_hfe_fb3-Sm3+"/>
+    <Type class="ionslm_hfe_fb3-Eu3+" element="Eu" mass="151.96" name="ionslm_hfe_fb3-Eu3+"/>
+    <Type class="ionslm_hfe_fb3-Gd3+" element="Gd" mass="157.25" name="ionslm_hfe_fb3-Gd3+"/>
+    <Type class="ionslm_hfe_fb3-Tb3+" element="Tb" mass="158.93" name="ionslm_hfe_fb3-Tb3+"/>
+    <Type class="ionslm_hfe_fb3-Dy3+" element="Dy" mass="162.5" name="ionslm_hfe_fb3-Dy3+"/>
+    <Type class="ionslm_hfe_fb3-Er3+" element="Er" mass="167.26" name="ionslm_hfe_fb3-Er3+"/>
+    <Type class="ionslm_hfe_fb3-Tm3+" element="Tm" mass="168.93" name="ionslm_hfe_fb3-Tm3+"/>
+    <Type class="ionslm_hfe_fb3-Lu3+" element="Lu" mass="174.97" name="ionslm_hfe_fb3-Lu3+"/>
+    <Type class="ionslm_hfe_fb3-Hf4+" element="Hf" mass="178.49" name="ionslm_hfe_fb3-Hf4+"/>
+    <Type class="ionslm_hfe_fb3-Zr4+" element="Zr" mass="91.22" name="ionslm_hfe_fb3-Zr4+"/>
+    <Type class="ionslm_hfe_fb3-Ce4+" element="Ce" mass="140.12" name="ionslm_hfe_fb3-Ce4+"/>
+    <Type class="ionslm_hfe_fb3-U4+" element="U" mass="238.03" name="ionslm_hfe_fb3-U4+"/>
+    <Type class="ionslm_hfe_fb3-Pu4+" element="Pu" mass="244.06" name="ionslm_hfe_fb3-Pu4+"/>
+    <Type class="ionslm_hfe_fb3-Th4+" element="Th" mass="232.04" name="ionslm_hfe_fb3-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_hfe_fb3-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_hfe_fb3-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_hfe_fb3-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_hfe_fb3-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_hfe_fb3-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_hfe_fb3-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_hfe_fb3-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_hfe_fb3-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_hfe_fb3-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_hfe_fb3-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_hfe_fb3-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_hfe_fb3-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_hfe_fb3-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_hfe_fb3-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_hfe_fb3-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_hfe_fb3-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_hfe_fb3-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_hfe_fb3-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_hfe_fb3-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_hfe_fb3-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_hfe_fb3-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_hfe_fb3-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_hfe_fb3-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_hfe_fb3-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_hfe_fb3-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_hfe_fb3-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_hfe_fb3-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_hfe_fb3-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_hfe_fb3-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_hfe_fb3-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_hfe_fb3-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_hfe_fb3-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_hfe_fb3-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_hfe_fb3-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_hfe_fb3-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_hfe_fb3-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_hfe_fb3-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_hfe_fb3-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_hfe_fb3-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_hfe_fb3-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_hfe_fb3-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_hfe_fb3-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_hfe_fb3-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_hfe_fb3-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_hfe_fb3-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_hfe_fb3-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_hfe_fb3-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_hfe_fb3-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_hfe_fb3-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_hfe_fb3-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_hfe_fb3-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_hfe_fb3-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_hfe_fb3-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_hfe_fb3-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_hfe_fb3-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_hfe_fb3-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_hfe_fb3-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_hfe_fb3-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_hfe_fb3-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_hfe_fb3-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.011806411200000002" sigma="0.22450647697136553" type="ionslm_hfe_fb3-Li+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.11545547168" sigma="0.25996424595335105" type="ionslm_hfe_fb3-Na+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.59238168208" sigma="0.3037964628858557" type="ionslm_hfe_fb3-K+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.8985523254400001" sigma="0.3210798980177783" type="ionslm_hfe_fb3-Rb+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.51533597416" sigma="0.3510140949472937" type="ionslm_hfe_fb3-Cs+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.51230787168" sigma="0.29862925032064175" type="ionslm_hfe_fb3-Tl+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00403312496" sigma="0.2123902544046569" type="ionslm_hfe_fb3-Cu+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.029271431360000003" sigma="0.23662269953807413" type="ionslm_hfe_fb3-Ag+"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.01002663744" sigma="0.3267816498138765" type="ionslm_hfe_fb3-F-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.66953145272" sigma="0.4098134103445561" type="ionslm_hfe_fb3-Cl-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.13914779672" sigma="0.4420639439412363" type="ionslm_hfe_fb3-Br-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.59848597736" sigma="0.48856885702816205" type="ionslm_hfe_fb3-I-"/><!--     HFE set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="4.2258400000000005e-06" sigma="0.16285628567605404" type="ionslm_hfe_fb3-Be2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00199769264" sigma="0.20544124440316225" type="ionslm_hfe_fb3-Cu2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0026870066400000005" sigma="0.20829212030121133" type="ionslm_hfe_fb3-Ni2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0030480021600000004" sigma="0.2095393785066078" type="ionslm_hfe_fb3-Pt2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00321502744" sigma="0.210073917737492" type="ionslm_hfe_fb3-Zn2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00641582928" sigma="0.21737928722624278" type="ionslm_hfe_fb3-Co2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00641582928" sigma="0.21737928722624278" type="ionslm_hfe_fb3-Pd2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.013433485120000001" sigma="0.2261100946640181" type="ionslm_hfe_fb3-Ag2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01524151704" sigma="0.22771371235667073" type="ionslm_hfe_fb3-Cr2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01655449808" sigma="0.22878279081843914" type="ionslm_hfe_fb3-Fe2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01748020808" sigma="0.2294955097929514" type="ionslm_hfe_fb3-Mg2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01844784176" sigma="0.23020822876746372" type="ionslm_hfe_fb3-V2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ionslm_hfe_fb3-Mn2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.033437523840000004" sigma="0.23858267671798283" type="ionslm_hfe_fb3-Hg2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0346516788" sigma="0.2391172159488671" type="ionslm_hfe_fb3-Cd2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.19079901904000002" sigma="0.2708332103146632" type="ionslm_hfe_fb3-Yb2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.19817206384" sigma="0.2717241090328035" type="ionslm_hfe_fb3-Ca2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.221430878" sigma="0.2743968051872245" type="ionslm_hfe_fb3-Sn2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.34672264080000004" sigma="0.28633484801030507" type="ionslm_hfe_fb3-Pb2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.45310058976" sigma="0.2945311162171962" type="ionslm_hfe_fb3-Eu2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.46816830344000004" sigma="0.2956001946789646" type="ionslm_hfe_fb3-Sr2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.48092975447999997" sigma="0.29649109339710494" type="ionslm_hfe_fb3-Sm2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.97474350936" sigma="0.3249998523775958" type="ionslm_hfe_fb3-Ba2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.97474350936" sigma="0.3249998523775958" type="ionslm_hfe_fb3-Ra2+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="2.673576e-05" sigma="0.17319071080648196" type="ionslm_hfe_fb3-Al3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0006706115200000001" sigma="0.19581953824724657" type="ionslm_hfe_fb3-Fe3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00439211216" sigma="0.21328115312279727" type="ionslm_hfe_fb3-Cr3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00554580832" sigma="0.21577566953359018" type="ionslm_hfe_fb3-In3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00554580832" sigma="0.21577566953359018" type="ionslm_hfe_fb3-Tl3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08927271096" sigma="0.25497521313176513" type="ionslm_hfe_fb3-Y3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.38412827024" sigma="0.2893639036519822" type="ionslm_hfe_fb3-La3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.30959110520000005" sigma="0.28312761262499986" type="ionslm_hfe_fb3-Ce3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.25690960808" sigma="0.2781385798034139" type="ionslm_hfe_fb3-Pr3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.221430878" sigma="0.2743968051872245" type="ionslm_hfe_fb3-Nd3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17939205432000002" sigma="0.2694077723656386" type="ionslm_hfe_fb3-Sm3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15293570184000002" sigma="0.26584417749307726" type="ionslm_hfe_fb3-Eu3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14435620064" sigma="0.2645969192876808" type="ionslm_hfe_fb3-Gd3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11545547168" sigma="0.25996424595335105" type="ionslm_hfe_fb3-Tb3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.10268711704000001" sigma="0.25764790928618614" type="ionslm_hfe_fb3-Dy3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07644268416000001" sigma="0.252124337233716" type="ionslm_hfe_fb3-Er3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07419972544" sigma="0.2515897980028318" type="ionslm_hfe_fb3-Tm3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07419972544" sigma="0.2515897980028318" type="ionslm_hfe_fb3-Lu3+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00083002192" sigma="0.19760133568352725" type="ionslm_hfe_fb3-Hf4+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0018871932" sigma="0.20490670517227805" type="ionslm_hfe_fb3-Zr4+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.03895266344" sigma="0.24089901338514777" type="ionslm_hfe_fb3-Ce4+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0067303824" sigma="0.21791382645712704" type="ionslm_hfe_fb3-U4+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.01678206584" sigma="0.22896097056206718" type="ionslm_hfe_fb3-Pu4+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11041584368" sigma="0.25907334723521064" type="ionslm_hfe_fb3-Th4+"/><!--     HFE set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_hfe_fb4.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_hfe_fb4.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the TIP4P-FB water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.570967</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_hfe_fb4" md5hash="82c0cf2481c3a06ca510272bb0087969" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_hfe_fb4</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_hfe_fb4-Li+" element="Li" mass="6.94" name="ionslm_hfe_fb4-Li+"/>
+    <Type class="ionslm_hfe_fb4-Na+" element="Na" mass="22.99" name="ionslm_hfe_fb4-Na+"/>
+    <Type class="ionslm_hfe_fb4-K+" element="K" mass="39.10" name="ionslm_hfe_fb4-K+"/>
+    <Type class="ionslm_hfe_fb4-Rb+" element="Rb" mass="85.47" name="ionslm_hfe_fb4-Rb+"/>
+    <Type class="ionslm_hfe_fb4-Cs+" element="Cs" mass="132.91" name="ionslm_hfe_fb4-Cs+"/>
+    <Type class="ionslm_hfe_fb4-Tl+" element="Tl" mass="204.38" name="ionslm_hfe_fb4-Tl+"/>
+    <Type class="ionslm_hfe_fb4-Cu+" element="Cu" mass="63.55" name="ionslm_hfe_fb4-Cu+"/>
+    <Type class="ionslm_hfe_fb4-Ag+" element="Ag" mass="107.87" name="ionslm_hfe_fb4-Ag+"/>
+    <Type class="ionslm_hfe_fb4-F-" element="F" mass="19.00" name="ionslm_hfe_fb4-F-"/>
+    <Type class="ionslm_hfe_fb4-Cl-" element="Cl" mass="35.45" name="ionslm_hfe_fb4-Cl-"/>
+    <Type class="ionslm_hfe_fb4-Br-" element="Br" mass="79.90" name="ionslm_hfe_fb4-Br-"/>
+    <Type class="ionslm_hfe_fb4-I-" element="I" mass="126.9" name="ionslm_hfe_fb4-I-"/>
+    <Type class="ionslm_hfe_fb4-Be2+" element="Be" mass="9.01" name="ionslm_hfe_fb4-Be2+"/>
+    <Type class="ionslm_hfe_fb4-Cu2+" element="Cu" mass="63.55" name="ionslm_hfe_fb4-Cu2+"/>
+    <Type class="ionslm_hfe_fb4-Ni2+" element="Ni" mass="58.69" name="ionslm_hfe_fb4-Ni2+"/>
+    <Type class="ionslm_hfe_fb4-Pt2+" element="Pt" mass="195.08" name="ionslm_hfe_fb4-Pt2+"/>
+    <Type class="ionslm_hfe_fb4-Zn2+" element="Zn" mass="65.4" name="ionslm_hfe_fb4-Zn2+"/>
+    <Type class="ionslm_hfe_fb4-Co2+" element="Co" mass="58.93" name="ionslm_hfe_fb4-Co2+"/>
+    <Type class="ionslm_hfe_fb4-Pd2+" element="Pd" mass="106.42" name="ionslm_hfe_fb4-Pd2+"/>
+    <Type class="ionslm_hfe_fb4-Ag2+" element="Ag" mass="107.87" name="ionslm_hfe_fb4-Ag2+"/>
+    <Type class="ionslm_hfe_fb4-Cr2+" element="Cr" mass="52.00" name="ionslm_hfe_fb4-Cr2+"/>
+    <Type class="ionslm_hfe_fb4-Fe2+" element="Fe" mass="55.85" name="ionslm_hfe_fb4-Fe2+"/>
+    <Type class="ionslm_hfe_fb4-Mg2+" element="Mg" mass="24.305" name="ionslm_hfe_fb4-Mg2+"/>
+    <Type class="ionslm_hfe_fb4-V2+" element="V" mass="50.94" name="ionslm_hfe_fb4-V2+"/>
+    <Type class="ionslm_hfe_fb4-Mn2+" element="Mn" mass="54.94" name="ionslm_hfe_fb4-Mn2+"/>
+    <Type class="ionslm_hfe_fb4-Hg2+" element="Hg" mass="200.59" name="ionslm_hfe_fb4-Hg2+"/>
+    <Type class="ionslm_hfe_fb4-Cd2+" element="Cd" mass="112.41" name="ionslm_hfe_fb4-Cd2+"/>
+    <Type class="ionslm_hfe_fb4-Yb2+" element="Yb" mass="173.05" name="ionslm_hfe_fb4-Yb2+"/>
+    <Type class="ionslm_hfe_fb4-Ca2+" element="Ca" mass="40.08" name="ionslm_hfe_fb4-Ca2+"/>
+    <Type class="ionslm_hfe_fb4-Sn2+" element="Sn" mass="118.71" name="ionslm_hfe_fb4-Sn2+"/>
+    <Type class="ionslm_hfe_fb4-Pb2+" element="Pb" mass="207.2" name="ionslm_hfe_fb4-Pb2+"/>
+    <Type class="ionslm_hfe_fb4-Eu2+" element="Eu" mass="151.96" name="ionslm_hfe_fb4-Eu2+"/>
+    <Type class="ionslm_hfe_fb4-Sr2+" element="Sr" mass="87.62" name="ionslm_hfe_fb4-Sr2+"/>
+    <Type class="ionslm_hfe_fb4-Sm2+" element="Sm" mass="150.36" name="ionslm_hfe_fb4-Sm2+"/>
+    <Type class="ionslm_hfe_fb4-Ba2+" element="Ba" mass="137.33" name="ionslm_hfe_fb4-Ba2+"/>
+    <Type class="ionslm_hfe_fb4-Ra2+" element="Ra" mass="226.03" name="ionslm_hfe_fb4-Ra2+"/>
+    <Type class="ionslm_hfe_fb4-Al3+" element="Al" mass="26.98" name="ionslm_hfe_fb4-Al3+"/>
+    <Type class="ionslm_hfe_fb4-Fe3+" element="Fe" mass="55.85" name="ionslm_hfe_fb4-Fe3+"/>
+    <Type class="ionslm_hfe_fb4-Cr3+" element="Cr" mass="52.00" name="ionslm_hfe_fb4-Cr3+"/>
+    <Type class="ionslm_hfe_fb4-In3+" element="In" mass="114.82" name="ionslm_hfe_fb4-In3+"/>
+    <Type class="ionslm_hfe_fb4-Tl3+" element="Tl" mass="204.38" name="ionslm_hfe_fb4-Tl3+"/>
+    <Type class="ionslm_hfe_fb4-Y3+" element="Y" mass="88.91" name="ionslm_hfe_fb4-Y3+"/>
+    <Type class="ionslm_hfe_fb4-La3+" element="La" mass="138.91" name="ionslm_hfe_fb4-La3+"/>
+    <Type class="ionslm_hfe_fb4-Ce3+" element="Ce" mass="140.12" name="ionslm_hfe_fb4-Ce3+"/>
+    <Type class="ionslm_hfe_fb4-Pr3+" element="Pr" mass="140.91" name="ionslm_hfe_fb4-Pr3+"/>
+    <Type class="ionslm_hfe_fb4-Nd3+" element="Nd" mass="144.24" name="ionslm_hfe_fb4-Nd3+"/>
+    <Type class="ionslm_hfe_fb4-Sm3+" element="Sm" mass="150.36" name="ionslm_hfe_fb4-Sm3+"/>
+    <Type class="ionslm_hfe_fb4-Eu3+" element="Eu" mass="151.96" name="ionslm_hfe_fb4-Eu3+"/>
+    <Type class="ionslm_hfe_fb4-Gd3+" element="Gd" mass="157.25" name="ionslm_hfe_fb4-Gd3+"/>
+    <Type class="ionslm_hfe_fb4-Tb3+" element="Tb" mass="158.93" name="ionslm_hfe_fb4-Tb3+"/>
+    <Type class="ionslm_hfe_fb4-Dy3+" element="Dy" mass="162.5" name="ionslm_hfe_fb4-Dy3+"/>
+    <Type class="ionslm_hfe_fb4-Er3+" element="Er" mass="167.26" name="ionslm_hfe_fb4-Er3+"/>
+    <Type class="ionslm_hfe_fb4-Tm3+" element="Tm" mass="168.93" name="ionslm_hfe_fb4-Tm3+"/>
+    <Type class="ionslm_hfe_fb4-Lu3+" element="Lu" mass="174.97" name="ionslm_hfe_fb4-Lu3+"/>
+    <Type class="ionslm_hfe_fb4-Hf4+" element="Hf" mass="178.49" name="ionslm_hfe_fb4-Hf4+"/>
+    <Type class="ionslm_hfe_fb4-Zr4+" element="Zr" mass="91.22" name="ionslm_hfe_fb4-Zr4+"/>
+    <Type class="ionslm_hfe_fb4-Ce4+" element="Ce" mass="140.12" name="ionslm_hfe_fb4-Ce4+"/>
+    <Type class="ionslm_hfe_fb4-U4+" element="U" mass="238.03" name="ionslm_hfe_fb4-U4+"/>
+    <Type class="ionslm_hfe_fb4-Pu4+" element="Pu" mass="244.06" name="ionslm_hfe_fb4-Pu4+"/>
+    <Type class="ionslm_hfe_fb4-Th4+" element="Th" mass="232.04" name="ionslm_hfe_fb4-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_hfe_fb4-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_hfe_fb4-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_hfe_fb4-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_hfe_fb4-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_hfe_fb4-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_hfe_fb4-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_hfe_fb4-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_hfe_fb4-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_hfe_fb4-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_hfe_fb4-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_hfe_fb4-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_hfe_fb4-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_hfe_fb4-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_hfe_fb4-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_hfe_fb4-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_hfe_fb4-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_hfe_fb4-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_hfe_fb4-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_hfe_fb4-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_hfe_fb4-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_hfe_fb4-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_hfe_fb4-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_hfe_fb4-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_hfe_fb4-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_hfe_fb4-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_hfe_fb4-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_hfe_fb4-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_hfe_fb4-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_hfe_fb4-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_hfe_fb4-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_hfe_fb4-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_hfe_fb4-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_hfe_fb4-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_hfe_fb4-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_hfe_fb4-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_hfe_fb4-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_hfe_fb4-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_hfe_fb4-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_hfe_fb4-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_hfe_fb4-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_hfe_fb4-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_hfe_fb4-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_hfe_fb4-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_hfe_fb4-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_hfe_fb4-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_hfe_fb4-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_hfe_fb4-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_hfe_fb4-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_hfe_fb4-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_hfe_fb4-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_hfe_fb4-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_hfe_fb4-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_hfe_fb4-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_hfe_fb4-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_hfe_fb4-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_hfe_fb4-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_hfe_fb4-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_hfe_fb4-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_hfe_fb4-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_hfe_fb4-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.008769120080000001" sigma="0.22094288209880417" type="ionslm_hfe_fb4-Li+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.10458113016" sigma="0.25800426877344224" type="ionslm_hfe_fb4-Na+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.5365256168" sigma="0.3002328680132944" type="ionslm_hfe_fb4-K+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.87475741536" sigma="0.3198326398123818" type="ionslm_hfe_fb4-Rb+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.43933871864" sigma="0.3474505000747323" type="ionslm_hfe_fb4-Cs+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.48608615792" sigma="0.29684745288436104" type="ionslm_hfe_fb4-Tl+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00283691936" sigma="0.20882665953209553" type="ionslm_hfe_fb4-Cu+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.024269710400000002" sigma="0.23395000338365313" type="ionslm_hfe_fb4-Ag+"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.04926352" sigma="0.32874162699378523" type="ionslm_hfe_fb4-F-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.70772430176" sigma="0.41212974701172095" type="ionslm_hfe_fb4-Cl-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.0775338361599998" sigma="0.43725309086327857" type="ionslm_hfe_fb4-Br-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.6763738988" sigma="0.4996160011331022" type="ionslm_hfe_fb4-I-"/><!--     HFE set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.5104e-07" sigma="0.149670984647577" type="ionslm_hfe_fb4-Be2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00079571312" sigma="0.19724497619627113" type="ionslm_hfe_fb4-Cu2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00120273264" sigma="0.20080857106883246" type="ionslm_hfe_fb4-Ni2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00152628136" sigma="0.20294672799236932" type="ionslm_hfe_fb4-Pt2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.001618162" sigma="0.20348126722325346" type="ionslm_hfe_fb4-Zn2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0024523679200000002" sigma="0.20740122158307095" type="ionslm_hfe_fb4-Co2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0026385977600000003" sigma="0.20811394055758325" type="ionslm_hfe_fb4-Pd2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00462034936" sigma="0.21381569235368142" type="ionslm_hfe_fb4-Ag2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00621311448" sigma="0.21702292773898668" type="ionslm_hfe_fb4-Cr2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00683807856" sigma="0.21809200620075508" type="ionslm_hfe_fb4-Fe2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0085052352" sigma="0.22058652261154799" type="ionslm_hfe_fb4-Mg2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0109754688" sigma="0.22361557825322517" type="ionslm_hfe_fb4-V2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.02051419384" sigma="0.23163366671648822" type="ionslm_hfe_fb4-Mn2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.02051419384" sigma="0.23163366671648822" type="ionslm_hfe_fb4-Hg2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.021059118" sigma="0.23199002620374434" type="ionslm_hfe_fb4-Cd2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.14435620064" sigma="0.2645969192876808" type="ionslm_hfe_fb4-Yb2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.14799067408" sigma="0.265131458518565" type="ionslm_hfe_fb4-Ca2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.16316922192" sigma="0.2672696154421018" type="ionslm_hfe_fb4-Sn2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.28060071312" sigma="0.28045491647057885" type="ionslm_hfe_fb4-Pb2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.37512380016" sigma="0.2886511846774699" type="ionslm_hfe_fb4-Eu2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.38867719872000006" sigma="0.2897202631392383" type="ionslm_hfe_fb4-Sr2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.40251000480000004" sigma="0.2907893416010067" type="ionslm_hfe_fb4-Sm2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.87475741536" sigma="0.3198326398123818" type="ionslm_hfe_fb4-Ba2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.87475741536" sigma="0.3198326398123818" type="ionslm_hfe_fb4-Ra2+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="4.51872e-06" sigma="0.16321264516331016" type="ionslm_hfe_fb4-Al3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="8.468416e-05" sigma="0.18049608029523273" type="ionslm_hfe_fb4-Fe3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00155636432" sigma="0.20312490773599734" type="ionslm_hfe_fb4-Cr3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00181652544" sigma="0.20455034568502187" type="ionslm_hfe_fb4-In3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00196024584" sigma="0.20526306465953414" type="ionslm_hfe_fb4-Tl3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.05985940016" sigma="0.24784802338664239" type="ionslm_hfe_fb4-Y3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28060071312" sigma="0.28045491647057885" type="ionslm_hfe_fb4-La3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.21664136952000002" sigma="0.2738622659563403" type="ionslm_hfe_fb4-Ce3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17114857016" sigma="0.2683386939038702" type="ionslm_hfe_fb4-Pr3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14435620064" sigma="0.2645969192876808" type="ionslm_hfe_fb4-Nd3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11545547168" sigma="0.25996424595335105" type="ionslm_hfe_fb4-Sm3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08842699904000001" sigma="0.25479703338813703" type="ionslm_hfe_fb4-Eu3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08108064815999999" sigma="0.2531934156954844" type="ionslm_hfe_fb4-Gd3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ionslm_hfe_fb4-Tb3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06639731856" sigma="0.24962982082292307" type="ionslm_hfe_fb4-Dy3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ionslm_hfe_fb4-Er3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_hfe_fb4-Tm3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_hfe_fb4-Lu3+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="8.698536e-05" sigma="0.1806742600388608" type="ionslm_hfe_fb4-Hf4+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0005155106400000001" sigma="0.19368138132370977" type="ionslm_hfe_fb4-Zr4+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.02078519152" sigma="0.23181184646011627" type="ionslm_hfe_fb4-Ce4+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00181652544" sigma="0.20455034568502187" type="ionslm_hfe_fb4-U4+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00591923032" sigma="0.21648838850810248" type="ionslm_hfe_fb4-Pu4+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.05799739464" sigma="0.24731348415575818" type="ionslm_hfe_fb4-Th4+"/><!--     HFE set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_hfe_opc.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_hfe_opc.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the OPC water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.632233</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_hfe_opc" md5hash="e61d3206b09c1777c5b4534cfb51edcd" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_hfe_opc</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_hfe_opc-Li+" element="Li" mass="6.94" name="ionslm_hfe_opc-Li+"/>
+    <Type class="ionslm_hfe_opc-Na+" element="Na" mass="22.99" name="ionslm_hfe_opc-Na+"/>
+    <Type class="ionslm_hfe_opc-K+" element="K" mass="39.10" name="ionslm_hfe_opc-K+"/>
+    <Type class="ionslm_hfe_opc-Rb+" element="Rb" mass="85.47" name="ionslm_hfe_opc-Rb+"/>
+    <Type class="ionslm_hfe_opc-Cs+" element="Cs" mass="132.91" name="ionslm_hfe_opc-Cs+"/>
+    <Type class="ionslm_hfe_opc-Tl+" element="Tl" mass="204.38" name="ionslm_hfe_opc-Tl+"/>
+    <Type class="ionslm_hfe_opc-Cu+" element="Cu" mass="63.55" name="ionslm_hfe_opc-Cu+"/>
+    <Type class="ionslm_hfe_opc-Ag+" element="Ag" mass="107.87" name="ionslm_hfe_opc-Ag+"/>
+    <Type class="ionslm_hfe_opc-F-" element="F" mass="19.00" name="ionslm_hfe_opc-F-"/>
+    <Type class="ionslm_hfe_opc-Cl-" element="Cl" mass="35.45" name="ionslm_hfe_opc-Cl-"/>
+    <Type class="ionslm_hfe_opc-Br-" element="Br" mass="79.90" name="ionslm_hfe_opc-Br-"/>
+    <Type class="ionslm_hfe_opc-I-" element="I" mass="126.9" name="ionslm_hfe_opc-I-"/>
+    <Type class="ionslm_hfe_opc-Be2+" element="Be" mass="9.01" name="ionslm_hfe_opc-Be2+"/>
+    <Type class="ionslm_hfe_opc-Cu2+" element="Cu" mass="63.55" name="ionslm_hfe_opc-Cu2+"/>
+    <Type class="ionslm_hfe_opc-Ni2+" element="Ni" mass="58.69" name="ionslm_hfe_opc-Ni2+"/>
+    <Type class="ionslm_hfe_opc-Pt2+" element="Pt" mass="195.08" name="ionslm_hfe_opc-Pt2+"/>
+    <Type class="ionslm_hfe_opc-Zn2+" element="Zn" mass="65.4" name="ionslm_hfe_opc-Zn2+"/>
+    <Type class="ionslm_hfe_opc-Co2+" element="Co" mass="58.93" name="ionslm_hfe_opc-Co2+"/>
+    <Type class="ionslm_hfe_opc-Pd2+" element="Pd" mass="106.42" name="ionslm_hfe_opc-Pd2+"/>
+    <Type class="ionslm_hfe_opc-Ag2+" element="Ag" mass="107.87" name="ionslm_hfe_opc-Ag2+"/>
+    <Type class="ionslm_hfe_opc-Cr2+" element="Cr" mass="52.00" name="ionslm_hfe_opc-Cr2+"/>
+    <Type class="ionslm_hfe_opc-Fe2+" element="Fe" mass="55.85" name="ionslm_hfe_opc-Fe2+"/>
+    <Type class="ionslm_hfe_opc-Mg2+" element="Mg" mass="24.305" name="ionslm_hfe_opc-Mg2+"/>
+    <Type class="ionslm_hfe_opc-V2+" element="V" mass="50.94" name="ionslm_hfe_opc-V2+"/>
+    <Type class="ionslm_hfe_opc-Mn2+" element="Mn" mass="54.94" name="ionslm_hfe_opc-Mn2+"/>
+    <Type class="ionslm_hfe_opc-Hg2+" element="Hg" mass="200.59" name="ionslm_hfe_opc-Hg2+"/>
+    <Type class="ionslm_hfe_opc-Cd2+" element="Cd" mass="112.41" name="ionslm_hfe_opc-Cd2+"/>
+    <Type class="ionslm_hfe_opc-Yb2+" element="Yb" mass="173.05" name="ionslm_hfe_opc-Yb2+"/>
+    <Type class="ionslm_hfe_opc-Ca2+" element="Ca" mass="40.08" name="ionslm_hfe_opc-Ca2+"/>
+    <Type class="ionslm_hfe_opc-Sn2+" element="Sn" mass="118.71" name="ionslm_hfe_opc-Sn2+"/>
+    <Type class="ionslm_hfe_opc-Pb2+" element="Pb" mass="207.2" name="ionslm_hfe_opc-Pb2+"/>
+    <Type class="ionslm_hfe_opc-Eu2+" element="Eu" mass="151.96" name="ionslm_hfe_opc-Eu2+"/>
+    <Type class="ionslm_hfe_opc-Sr2+" element="Sr" mass="87.62" name="ionslm_hfe_opc-Sr2+"/>
+    <Type class="ionslm_hfe_opc-Sm2+" element="Sm" mass="150.36" name="ionslm_hfe_opc-Sm2+"/>
+    <Type class="ionslm_hfe_opc-Ba2+" element="Ba" mass="137.33" name="ionslm_hfe_opc-Ba2+"/>
+    <Type class="ionslm_hfe_opc-Ra2+" element="Ra" mass="226.03" name="ionslm_hfe_opc-Ra2+"/>
+    <Type class="ionslm_hfe_opc-Al3+" element="Al" mass="26.98" name="ionslm_hfe_opc-Al3+"/>
+    <Type class="ionslm_hfe_opc-Fe3+" element="Fe" mass="55.85" name="ionslm_hfe_opc-Fe3+"/>
+    <Type class="ionslm_hfe_opc-Cr3+" element="Cr" mass="52.00" name="ionslm_hfe_opc-Cr3+"/>
+    <Type class="ionslm_hfe_opc-In3+" element="In" mass="114.82" name="ionslm_hfe_opc-In3+"/>
+    <Type class="ionslm_hfe_opc-Tl3+" element="Tl" mass="204.38" name="ionslm_hfe_opc-Tl3+"/>
+    <Type class="ionslm_hfe_opc-Y3+" element="Y" mass="88.91" name="ionslm_hfe_opc-Y3+"/>
+    <Type class="ionslm_hfe_opc-La3+" element="La" mass="138.91" name="ionslm_hfe_opc-La3+"/>
+    <Type class="ionslm_hfe_opc-Ce3+" element="Ce" mass="140.12" name="ionslm_hfe_opc-Ce3+"/>
+    <Type class="ionslm_hfe_opc-Pr3+" element="Pr" mass="140.91" name="ionslm_hfe_opc-Pr3+"/>
+    <Type class="ionslm_hfe_opc-Nd3+" element="Nd" mass="144.24" name="ionslm_hfe_opc-Nd3+"/>
+    <Type class="ionslm_hfe_opc-Sm3+" element="Sm" mass="150.36" name="ionslm_hfe_opc-Sm3+"/>
+    <Type class="ionslm_hfe_opc-Eu3+" element="Eu" mass="151.96" name="ionslm_hfe_opc-Eu3+"/>
+    <Type class="ionslm_hfe_opc-Gd3+" element="Gd" mass="157.25" name="ionslm_hfe_opc-Gd3+"/>
+    <Type class="ionslm_hfe_opc-Tb3+" element="Tb" mass="158.93" name="ionslm_hfe_opc-Tb3+"/>
+    <Type class="ionslm_hfe_opc-Dy3+" element="Dy" mass="162.5" name="ionslm_hfe_opc-Dy3+"/>
+    <Type class="ionslm_hfe_opc-Er3+" element="Er" mass="167.26" name="ionslm_hfe_opc-Er3+"/>
+    <Type class="ionslm_hfe_opc-Tm3+" element="Tm" mass="168.93" name="ionslm_hfe_opc-Tm3+"/>
+    <Type class="ionslm_hfe_opc-Lu3+" element="Lu" mass="174.97" name="ionslm_hfe_opc-Lu3+"/>
+    <Type class="ionslm_hfe_opc-Hf4+" element="Hf" mass="178.49" name="ionslm_hfe_opc-Hf4+"/>
+    <Type class="ionslm_hfe_opc-Zr4+" element="Zr" mass="91.22" name="ionslm_hfe_opc-Zr4+"/>
+    <Type class="ionslm_hfe_opc-Ce4+" element="Ce" mass="140.12" name="ionslm_hfe_opc-Ce4+"/>
+    <Type class="ionslm_hfe_opc-U4+" element="U" mass="238.03" name="ionslm_hfe_opc-U4+"/>
+    <Type class="ionslm_hfe_opc-Pu4+" element="Pu" mass="244.06" name="ionslm_hfe_opc-Pu4+"/>
+    <Type class="ionslm_hfe_opc-Th4+" element="Th" mass="232.04" name="ionslm_hfe_opc-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_hfe_opc-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_hfe_opc-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_hfe_opc-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_hfe_opc-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_hfe_opc-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_hfe_opc-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_hfe_opc-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_hfe_opc-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_hfe_opc-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_hfe_opc-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_hfe_opc-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_hfe_opc-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_hfe_opc-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_hfe_opc-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_hfe_opc-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_hfe_opc-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_hfe_opc-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_hfe_opc-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_hfe_opc-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_hfe_opc-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_hfe_opc-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_hfe_opc-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_hfe_opc-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_hfe_opc-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_hfe_opc-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_hfe_opc-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_hfe_opc-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_hfe_opc-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_hfe_opc-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_hfe_opc-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_hfe_opc-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_hfe_opc-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_hfe_opc-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_hfe_opc-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_hfe_opc-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_hfe_opc-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_hfe_opc-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_hfe_opc-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_hfe_opc-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_hfe_opc-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_hfe_opc-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_hfe_opc-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_hfe_opc-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_hfe_opc-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_hfe_opc-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_hfe_opc-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_hfe_opc-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_hfe_opc-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_hfe_opc-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_hfe_opc-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_hfe_opc-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_hfe_opc-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_hfe_opc-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_hfe_opc-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_hfe_opc-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_hfe_opc-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_hfe_opc-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_hfe_opc-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_hfe_opc-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_hfe_opc-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.009039866720000001" sigma="0.2212992415860603" type="ionslm_hfe_opc-Li+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ionslm_hfe_opc-Na+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.58382766144" sigma="0.3032619236549715" type="ionslm_hfe_opc-K+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.9537620464000001" sigma="0.3239307739158274" type="ionslm_hfe_opc-Rb+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.47731805816" sigma="0.349232297511013" type="ionslm_hfe_opc-Cs+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.47070573208000005" sigma="0.29577837442259264" type="ionslm_hfe_opc-Tl+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.0032724319200000004" sigma="0.21025209748112006" type="ionslm_hfe_opc-Cu+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.025210566480000002" sigma="0.23448454261453733" type="ionslm_hfe_opc-Ag+"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.0313754556" sigma="0.3278507282756449" type="ionslm_hfe_opc-F-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.8400519208" sigma="0.4205041949622401" type="ionslm_hfe_opc-Cl-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.17863094952" sigma="0.4452711793265416" type="ionslm_hfe_opc-Br-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.77817463544" sigma="0.5167212565213968" type="ionslm_hfe_opc-I-"/><!--     HFE set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="4.184e-07" sigma="0.1518091415711138" type="ionslm_hfe_opc-Be2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0009216096800000001" sigma="0.19849223440166763" type="ionslm_hfe_opc-Cu2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00132938232" sigma="0.20169946978697278" type="ionslm_hfe_opc-Ni2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00168209352" sigma="0.20383762671050965" type="ionslm_hfe_opc-Pt2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00192342664" sigma="0.20508488491590612" type="ionslm_hfe_opc-Zn2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00283691936" sigma="0.20882665953209553" type="ionslm_hfe_opc-Co2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00299398672" sigma="0.20936119876297973" type="ionslm_hfe_opc-Pd2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00502322672" sigma="0.21470659107182177" type="ionslm_hfe_opc-Ag2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00631378152" sigma="0.21720110748261476" type="ionslm_hfe_opc-Cr2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00739860904" sigma="0.21898290491889544" type="ionslm_hfe_opc-Fe2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.008636361759999999" sigma="0.22076470235517612" type="ionslm_hfe_opc-Mg2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0093175588" sigma="0.22165560107331644" type="ionslm_hfe_opc-V2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0218984284" sigma="0.23252456543462854" type="ionslm_hfe_opc-Mn2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0218984284" sigma="0.23252456543462854" type="ionslm_hfe_opc-Hg2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0230594884" sigma="0.23323728440914082" type="ionslm_hfe_opc-Cd2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_hfe_opc-Yb2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.15418977216000002" sigma="0.2660223572367053" type="ionslm_hfe_opc-Ca2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.17114857016" sigma="0.2683386939038702" type="ionslm_hfe_opc-Sn2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.28625681168" sigma="0.280989455701463" type="ionslm_hfe_opc-Pb2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.38639884336" sigma="0.2895420833956103" type="ionslm_hfe_opc-Eu2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.40018520704000005" sigma="0.2906111618573787" type="ionslm_hfe_opc-Sr2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.41424963936000003" sigma="0.29168024031914713" type="ionslm_hfe_opc-Sm2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8815327339200001" sigma="0.32018899929963796" type="ionslm_hfe_opc-Ba2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.8815327339200001" sigma="0.32018899929963796" type="ionslm_hfe_opc-Ra2+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="5.94128e-06" sigma="0.16463808311233472" type="ionslm_hfe_opc-Al3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0001102484" sigma="0.1822778777315134" type="ionslm_hfe_opc-Fe3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0017148542400000002" sigma="0.20401580645413772" type="ionslm_hfe_opc-Cr3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00215375584" sigma="0.20615396337767453" type="ionslm_hfe_opc-In3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00215375584" sigma="0.20615396337767453" type="ionslm_hfe_opc-Tl3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06504822960000001" sigma="0.24927346133566697" type="ionslm_hfe_opc-Y3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28625681168" sigma="0.280989455701463" type="ionslm_hfe_opc-La3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.221430878" sigma="0.2743968051872245" type="ionslm_hfe_opc-Ce3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17523713312" sigma="0.2688732331347544" type="ionslm_hfe_opc-Pr3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_hfe_opc-Nd3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11443453384" sigma="0.25978606620972294" type="ionslm_hfe_opc-Sm3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0953611004" sigma="0.2562224713371616" type="ionslm_hfe_opc-Eu3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08927271096" sigma="0.25497521313176513" type="ionslm_hfe_opc-Gd3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08029342856" sigma="0.2530152359518564" type="ionslm_hfe_opc-Tb3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07200664" sigma="0.2510552587719476" type="ionslm_hfe_opc-Dy3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.05324888936" sigma="0.24588804620673363" type="ionslm_hfe_opc-Er3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04880585792000001" sigma="0.24446260825770916" type="ionslm_hfe_opc-Tm3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04880585792000001" sigma="0.24446260825770916" type="ionslm_hfe_opc-Lu3+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0001102484" sigma="0.1822778777315134" type="ionslm_hfe_opc-Hf4+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00057576024" sigma="0.19457228004185012" type="ionslm_hfe_opc-Zr4+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.022184153760000002" sigma="0.23270274517825662" type="ionslm_hfe_opc-Ce4+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00207446904" sigma="0.2057976038904184" type="ionslm_hfe_opc-U4+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00651925776" sigma="0.21755746696987088" type="ionslm_hfe_opc-Pu4+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06112589696" sigma="0.24820438287389857" type="ionslm_hfe_opc-Th4+"/><!--     HFE set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_hfe_opc3.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_hfe_opc3.xml
@@ -1,0 +1,315 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the OPC3 water model (12-6 HFE set) -->
+    <DateGenerated>2022-09-11T06:28:33.625534</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_hfe_opc3" md5hash="d9ea0de0fc58908f9090b4a7528da8ce" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_hfe_opc3</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_hfe_opc3-Li+" element="Li" mass="6.94" name="ionslm_hfe_opc3-Li+"/>
+    <Type class="ionslm_hfe_opc3-Na+" element="Na" mass="22.99" name="ionslm_hfe_opc3-Na+"/>
+    <Type class="ionslm_hfe_opc3-K+" element="K" mass="39.10" name="ionslm_hfe_opc3-K+"/>
+    <Type class="ionslm_hfe_opc3-Rb+" element="Rb" mass="85.47" name="ionslm_hfe_opc3-Rb+"/>
+    <Type class="ionslm_hfe_opc3-Cs+" element="Cs" mass="132.91" name="ionslm_hfe_opc3-Cs+"/>
+    <Type class="ionslm_hfe_opc3-Tl+" element="Tl" mass="204.38" name="ionslm_hfe_opc3-Tl+"/>
+    <Type class="ionslm_hfe_opc3-Cu+" element="Cu" mass="63.55" name="ionslm_hfe_opc3-Cu+"/>
+    <Type class="ionslm_hfe_opc3-Ag+" element="Ag" mass="107.87" name="ionslm_hfe_opc3-Ag+"/>
+    <Type class="ionslm_hfe_opc3-F-" element="F" mass="19.00" name="ionslm_hfe_opc3-F-"/>
+    <Type class="ionslm_hfe_opc3-Cl-" element="Cl" mass="35.45" name="ionslm_hfe_opc3-Cl-"/>
+    <Type class="ionslm_hfe_opc3-Br-" element="Br" mass="79.90" name="ionslm_hfe_opc3-Br-"/>
+    <Type class="ionslm_hfe_opc3-I-" element="I" mass="126.9" name="ionslm_hfe_opc3-I-"/>
+    <Type class="ionslm_hfe_opc3-Be2+" element="Be" mass="9.01" name="ionslm_hfe_opc3-Be2+"/>
+    <Type class="ionslm_hfe_opc3-Cu2+" element="Cu" mass="63.55" name="ionslm_hfe_opc3-Cu2+"/>
+    <Type class="ionslm_hfe_opc3-Ni2+" element="Ni" mass="58.69" name="ionslm_hfe_opc3-Ni2+"/>
+    <Type class="ionslm_hfe_opc3-Pt2+" element="Pt" mass="195.08" name="ionslm_hfe_opc3-Pt2+"/>
+    <Type class="ionslm_hfe_opc3-Zn2+" element="Zn" mass="65.4" name="ionslm_hfe_opc3-Zn2+"/>
+    <Type class="ionslm_hfe_opc3-Co2+" element="Co" mass="58.93" name="ionslm_hfe_opc3-Co2+"/>
+    <Type class="ionslm_hfe_opc3-Pd2+" element="Pd" mass="106.42" name="ionslm_hfe_opc3-Pd2+"/>
+    <Type class="ionslm_hfe_opc3-Ag2+" element="Ag" mass="107.87" name="ionslm_hfe_opc3-Ag2+"/>
+    <Type class="ionslm_hfe_opc3-Cr2+" element="Cr" mass="52.00" name="ionslm_hfe_opc3-Cr2+"/>
+    <Type class="ionslm_hfe_opc3-Fe2+" element="Fe" mass="55.85" name="ionslm_hfe_opc3-Fe2+"/>
+    <Type class="ionslm_hfe_opc3-Mg2+" element="Mg" mass="24.305" name="ionslm_hfe_opc3-Mg2+"/>
+    <Type class="ionslm_hfe_opc3-V2+" element="V" mass="50.94" name="ionslm_hfe_opc3-V2+"/>
+    <Type class="ionslm_hfe_opc3-Mn2+" element="Mn" mass="54.94" name="ionslm_hfe_opc3-Mn2+"/>
+    <Type class="ionslm_hfe_opc3-Hg2+" element="Hg" mass="200.59" name="ionslm_hfe_opc3-Hg2+"/>
+    <Type class="ionslm_hfe_opc3-Cd2+" element="Cd" mass="112.41" name="ionslm_hfe_opc3-Cd2+"/>
+    <Type class="ionslm_hfe_opc3-Yb2+" element="Yb" mass="173.05" name="ionslm_hfe_opc3-Yb2+"/>
+    <Type class="ionslm_hfe_opc3-Ca2+" element="Ca" mass="40.08" name="ionslm_hfe_opc3-Ca2+"/>
+    <Type class="ionslm_hfe_opc3-Sn2+" element="Sn" mass="118.71" name="ionslm_hfe_opc3-Sn2+"/>
+    <Type class="ionslm_hfe_opc3-Pb2+" element="Pb" mass="207.2" name="ionslm_hfe_opc3-Pb2+"/>
+    <Type class="ionslm_hfe_opc3-Eu2+" element="Eu" mass="151.96" name="ionslm_hfe_opc3-Eu2+"/>
+    <Type class="ionslm_hfe_opc3-Sr2+" element="Sr" mass="87.62" name="ionslm_hfe_opc3-Sr2+"/>
+    <Type class="ionslm_hfe_opc3-Sm2+" element="Sm" mass="150.36" name="ionslm_hfe_opc3-Sm2+"/>
+    <Type class="ionslm_hfe_opc3-Ba2+" element="Ba" mass="137.33" name="ionslm_hfe_opc3-Ba2+"/>
+    <Type class="ionslm_hfe_opc3-Ra2+" element="Ra" mass="226.03" name="ionslm_hfe_opc3-Ra2+"/>
+    <Type class="ionslm_hfe_opc3-Al3+" element="Al" mass="26.98" name="ionslm_hfe_opc3-Al3+"/>
+    <Type class="ionslm_hfe_opc3-Fe3+" element="Fe" mass="55.85" name="ionslm_hfe_opc3-Fe3+"/>
+    <Type class="ionslm_hfe_opc3-Cr3+" element="Cr" mass="52.00" name="ionslm_hfe_opc3-Cr3+"/>
+    <Type class="ionslm_hfe_opc3-In3+" element="In" mass="114.82" name="ionslm_hfe_opc3-In3+"/>
+    <Type class="ionslm_hfe_opc3-Tl3+" element="Tl" mass="204.38" name="ionslm_hfe_opc3-Tl3+"/>
+    <Type class="ionslm_hfe_opc3-Y3+" element="Y" mass="88.91" name="ionslm_hfe_opc3-Y3+"/>
+    <Type class="ionslm_hfe_opc3-La3+" element="La" mass="138.91" name="ionslm_hfe_opc3-La3+"/>
+    <Type class="ionslm_hfe_opc3-Ce3+" element="Ce" mass="140.12" name="ionslm_hfe_opc3-Ce3+"/>
+    <Type class="ionslm_hfe_opc3-Pr3+" element="Pr" mass="140.91" name="ionslm_hfe_opc3-Pr3+"/>
+    <Type class="ionslm_hfe_opc3-Nd3+" element="Nd" mass="144.24" name="ionslm_hfe_opc3-Nd3+"/>
+    <Type class="ionslm_hfe_opc3-Sm3+" element="Sm" mass="150.36" name="ionslm_hfe_opc3-Sm3+"/>
+    <Type class="ionslm_hfe_opc3-Eu3+" element="Eu" mass="151.96" name="ionslm_hfe_opc3-Eu3+"/>
+    <Type class="ionslm_hfe_opc3-Gd3+" element="Gd" mass="157.25" name="ionslm_hfe_opc3-Gd3+"/>
+    <Type class="ionslm_hfe_opc3-Tb3+" element="Tb" mass="158.93" name="ionslm_hfe_opc3-Tb3+"/>
+    <Type class="ionslm_hfe_opc3-Dy3+" element="Dy" mass="162.5" name="ionslm_hfe_opc3-Dy3+"/>
+    <Type class="ionslm_hfe_opc3-Er3+" element="Er" mass="167.26" name="ionslm_hfe_opc3-Er3+"/>
+    <Type class="ionslm_hfe_opc3-Tm3+" element="Tm" mass="168.93" name="ionslm_hfe_opc3-Tm3+"/>
+    <Type class="ionslm_hfe_opc3-Lu3+" element="Lu" mass="174.97" name="ionslm_hfe_opc3-Lu3+"/>
+    <Type class="ionslm_hfe_opc3-Hf4+" element="Hf" mass="178.49" name="ionslm_hfe_opc3-Hf4+"/>
+    <Type class="ionslm_hfe_opc3-Zr4+" element="Zr" mass="91.22" name="ionslm_hfe_opc3-Zr4+"/>
+    <Type class="ionslm_hfe_opc3-Ce4+" element="Ce" mass="140.12" name="ionslm_hfe_opc3-Ce4+"/>
+    <Type class="ionslm_hfe_opc3-U4+" element="U" mass="238.03" name="ionslm_hfe_opc3-U4+"/>
+    <Type class="ionslm_hfe_opc3-Pu4+" element="Pu" mass="244.06" name="ionslm_hfe_opc3-Pu4+"/>
+    <Type class="ionslm_hfe_opc3-Th4+" element="Th" mass="232.04" name="ionslm_hfe_opc3-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_hfe_opc3-Ag+"/>
+    </Residue>
+    <Residue name="Ag">
+      <Atom charge="2.0" name="Ag" type="ionslm_hfe_opc3-Ag2+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_hfe_opc3-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_hfe_opc3-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_hfe_opc3-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_hfe_opc3-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_hfe_opc3-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_hfe_opc3-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_hfe_opc3-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_hfe_opc3-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_hfe_opc3-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_hfe_opc3-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_hfe_opc3-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_hfe_opc3-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_hfe_opc3-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_hfe_opc3-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_hfe_opc3-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_hfe_opc3-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_hfe_opc3-Er3+"/>
+    </Residue>
+    <Residue name="EU">
+      <Atom charge="2.0" name="EU" type="ionslm_hfe_opc3-Eu2+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_hfe_opc3-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_hfe_opc3-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_hfe_opc3-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_hfe_opc3-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_hfe_opc3-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_hfe_opc3-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_hfe_opc3-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_hfe_opc3-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_hfe_opc3-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_hfe_opc3-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_hfe_opc3-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_hfe_opc3-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_hfe_opc3-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_hfe_opc3-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_hfe_opc3-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_hfe_opc3-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_hfe_opc3-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_hfe_opc3-Ni2+"/>
+    </Residue>
+    <Residue name="PB">
+      <Atom charge="2.0" name="PB" type="ionslm_hfe_opc3-Pb2+"/>
+    </Residue>
+    <Residue name="PD">
+      <Atom charge="2.0" name="PD" type="ionslm_hfe_opc3-Pd2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_hfe_opc3-Pr3+"/>
+    </Residue>
+    <Residue name="PT">
+      <Atom charge="2.0" name="PT" type="ionslm_hfe_opc3-Pt2+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_hfe_opc3-Pu4+"/>
+    </Residue>
+    <Residue name="Ra">
+      <Atom charge="2.0" name="Ra" type="ionslm_hfe_opc3-Ra2+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_hfe_opc3-Rb+"/>
+    </Residue>
+    <Residue name="Sm">
+      <Atom charge="2.0" name="Sm" type="ionslm_hfe_opc3-Sm2+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_hfe_opc3-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_hfe_opc3-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_hfe_opc3-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_hfe_opc3-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_hfe_opc3-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_hfe_opc3-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_hfe_opc3-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_hfe_opc3-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_hfe_opc3-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_hfe_opc3-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_hfe_opc3-Y3+"/>
+    </Residue>
+    <Residue name="YB2">
+      <Atom charge="2.0" name="YB2" type="ionslm_hfe_opc3-Yb2+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_hfe_opc3-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_hfe_opc3-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.013625196" sigma="0.22628827440764618" type="ionslm_hfe_opc3-Li+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.1260287744" sigma="0.2617460433896317" type="ionslm_hfe_opc3-Na+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.58667223752" sigma="0.3034401033985996" type="ionslm_hfe_opc3-K+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.89173069" sigma="0.32072353853052216" type="ionslm_hfe_opc3-Rb+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.4963237108" sigma="0.35012319622915333" type="ionslm_hfe_opc3-Cs+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.52838869912" sigma="0.29969832878241015" type="ionslm_hfe_opc3-Tl+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.004698632" sigma="0.2139938720973095" type="ionslm_hfe_opc3-Cu+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.0318714108" sigma="0.2378699577434706" type="ionslm_hfe_opc3-Ag+"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.9537620464000001" sigma="0.3239307739158274" type="ionslm_hfe_opc3-F-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.68724395648" sigma="0.4108824888063245" type="ionslm_hfe_opc3-Cl-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.18294026032" sigma="0.4456275388137977" type="ionslm_hfe_opc3-Br-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.64743605776" sigma="0.4953396872860286" type="ionslm_hfe_opc3-I-"/><!--     HFE set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="8.53536e-06" sigma="0.16659806029224344" type="ionslm_hfe_opc3-Be2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0025439975199999998" sigma="0.20775758107032713" type="ionslm_hfe_opc3-Cu2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00321502744" sigma="0.210073917737492" type="ionslm_hfe_opc3-Ni2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00424537928" sigma="0.2129247936355411" type="ionslm_hfe_opc3-Pt2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.00462034936" sigma="0.21381569235368142" type="ionslm_hfe_opc3-Zn2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0078744972" sigma="0.2196956238934077" type="ionslm_hfe_opc3-Co2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.008375824080000002" sigma="0.22040834286791997" type="ionslm_hfe_opc3-Pd2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01655449808" sigma="0.22878279081843914" type="ionslm_hfe_opc3-Ag2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.018201906240000003" sigma="0.2300300490238356" type="ionslm_hfe_opc3-Cr2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.02051419384" sigma="0.23163366671648822" type="ionslm_hfe_opc3-Fe2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.022184153760000002" sigma="0.23270274517825662" type="ionslm_hfe_opc3-Mg2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.023357347360000003" sigma="0.23341546415276893" type="ionslm_hfe_opc3-V2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03940482832" sigma="0.24107719312877582" type="ionslm_hfe_opc3-Mn2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03940482832" sigma="0.24107719312877582" type="ionslm_hfe_opc3-Hg2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04125499312" sigma="0.2417899121032881" type="ionslm_hfe_opc3-Cd2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.21192098072" sigma="0.2733277267254561" type="ionslm_hfe_opc3-Yb2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.223042764" sigma="0.2745749849308526" type="ionslm_hfe_opc3-Ca2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.24815073880000002" sigma="0.2772476810852736" type="ionslm_hfe_opc3-Sn2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.38412827024" sigma="0.2893639036519822" type="ionslm_hfe_opc3-Pb2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.4991058036" sigma="0.2977383516025014" type="ionslm_hfe_opc3-Eu2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.51497002536" sigma="0.2988074300642698" type="ionslm_hfe_opc3-Sr2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.5310938643199999" sigma="0.2998765085260382" type="ionslm_hfe_opc3-Sm2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.0313754556" sigma="0.3278507282756449" type="ionslm_hfe_opc3-Ba2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.0313754556" sigma="0.3278507282756449" type="ionslm_hfe_opc3-Ra2+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="6.824104e-05" sigma="0.17907064234620818" type="ionslm_hfe_opc3-Al3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00106478616" sigma="0.19973949260706408" type="ionslm_hfe_opc3-Fe3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00611382816" sigma="0.21684474799535858" type="ionslm_hfe_opc3-Cr3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.00890363568" sigma="0.22112106184243224" type="ionslm_hfe_opc3-In3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.01065702456" sigma="0.223259218765969" type="ionslm_hfe_opc3-Tl3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11443453384" sigma="0.25978606620972294" type="ionslm_hfe_opc3-Y3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.43586389048" sigma="0.2932838580117997" type="ionslm_hfe_opc3-La3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.35315918088000003" sigma="0.28686938724118927" type="ionslm_hfe_opc3-Ce3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_hfe_opc3-Pr3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.25868487928" sigma="0.278316759547042" type="ionslm_hfe_opc3-Nd3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.20726946056" sigma="0.2727931874945719" type="ionslm_hfe_opc3-Sm3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.18219905808" sigma="0.2697641318528947" type="ionslm_hfe_opc3-Eu3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.16980040168" sigma="0.2681605141602421" type="ionslm_hfe_opc3-Gd3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.13727645424" sigma="0.2635278408259124" type="ionslm_hfe_opc3-Tb3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ionslm_hfe_opc3-Dy3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.09098208416" sigma="0.25533157261902123" type="ionslm_hfe_opc3-Er3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08267236728" sigma="0.2535497751827406" type="ionslm_hfe_opc3-Tm3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.08267236728" sigma="0.2535497751827406" type="ionslm_hfe_opc3-Lu3+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0013832304000000002" sigma="0.20205582927422894" type="ionslm_hfe_opc3-Hf4+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.0026870066400000005" sigma="0.20829212030121133" type="ionslm_hfe_opc3-Zr4+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.047741364640000006" sigma="0.24410624877045298" type="ionslm_hfe_opc3-Ce4+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.009747464800000001" sigma="0.22219014030420065" type="ionslm_hfe_opc3-U4+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.022764641920000002" sigma="0.2330591046655128" type="ionslm_hfe_opc3-Pu4+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.13269530895999998" sigma="0.2628151218514001" type="ionslm_hfe_opc3-Th4+"/><!--     HFE set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_iod_fb3.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_iod_fb3.xml
@@ -1,0 +1,275 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the TIP3P-FB water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.612943</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_iod_fb3" md5hash="cb0f7a840ba71757b77b936e48d199e4" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_iod_fb3</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_iod_fb3-Li+" element="Li" mass="6.94" name="ionslm_iod_fb3-Li+"/>
+    <Type class="ionslm_iod_fb3-Na+" element="Na" mass="22.99" name="ionslm_iod_fb3-Na+"/>
+    <Type class="ionslm_iod_fb3-K+" element="K" mass="39.10" name="ionslm_iod_fb3-K+"/>
+    <Type class="ionslm_iod_fb3-Rb+" element="Rb" mass="85.47" name="ionslm_iod_fb3-Rb+"/>
+    <Type class="ionslm_iod_fb3-Cs+" element="Cs" mass="132.91" name="ionslm_iod_fb3-Cs+"/>
+    <Type class="ionslm_iod_fb3-Tl+" element="Tl" mass="204.38" name="ionslm_iod_fb3-Tl+"/>
+    <Type class="ionslm_iod_fb3-Cu+" element="Cu" mass="63.55" name="ionslm_iod_fb3-Cu+"/>
+    <Type class="ionslm_iod_fb3-Ag+" element="Ag" mass="107.87" name="ionslm_iod_fb3-Ag+"/>
+    <Type class="ionslm_iod_fb3-F-" element="F" mass="19.00" name="ionslm_iod_fb3-F-"/>
+    <Type class="ionslm_iod_fb3-Cl-" element="Cl" mass="35.45" name="ionslm_iod_fb3-Cl-"/>
+    <Type class="ionslm_iod_fb3-Br-" element="Br" mass="79.90" name="ionslm_iod_fb3-Br-"/>
+    <Type class="ionslm_iod_fb3-I-" element="I" mass="126.9" name="ionslm_iod_fb3-I-"/>
+    <Type class="ionslm_iod_fb3-Be2+" element="Be" mass="9.01" name="ionslm_iod_fb3-Be2+"/>
+    <Type class="ionslm_iod_fb3-Cu2+" element="Cu" mass="63.55" name="ionslm_iod_fb3-Cu2+"/>
+    <Type class="ionslm_iod_fb3-Ni2+" element="Ni" mass="58.69" name="ionslm_iod_fb3-Ni2+"/>
+    <Type class="ionslm_iod_fb3-Zn2+" element="Zn" mass="65.4" name="ionslm_iod_fb3-Zn2+"/>
+    <Type class="ionslm_iod_fb3-Co2+" element="Co" mass="58.93" name="ionslm_iod_fb3-Co2+"/>
+    <Type class="ionslm_iod_fb3-Cr2+" element="Cr" mass="52.00" name="ionslm_iod_fb3-Cr2+"/>
+    <Type class="ionslm_iod_fb3-Fe2+" element="Fe" mass="55.85" name="ionslm_iod_fb3-Fe2+"/>
+    <Type class="ionslm_iod_fb3-Mg2+" element="Mg" mass="24.305" name="ionslm_iod_fb3-Mg2+"/>
+    <Type class="ionslm_iod_fb3-V2+" element="V" mass="50.94" name="ionslm_iod_fb3-V2+"/>
+    <Type class="ionslm_iod_fb3-Mn2+" element="Mn" mass="54.94" name="ionslm_iod_fb3-Mn2+"/>
+    <Type class="ionslm_iod_fb3-Hg2+" element="Hg" mass="200.59" name="ionslm_iod_fb3-Hg2+"/>
+    <Type class="ionslm_iod_fb3-Cd2+" element="Cd" mass="112.41" name="ionslm_iod_fb3-Cd2+"/>
+    <Type class="ionslm_iod_fb3-Ca2+" element="Ca" mass="40.08" name="ionslm_iod_fb3-Ca2+"/>
+    <Type class="ionslm_iod_fb3-Sn2+" element="Sn" mass="118.71" name="ionslm_iod_fb3-Sn2+"/>
+    <Type class="ionslm_iod_fb3-Sr2+" element="Sr" mass="87.62" name="ionslm_iod_fb3-Sr2+"/>
+    <Type class="ionslm_iod_fb3-Ba2+" element="Ba" mass="137.33" name="ionslm_iod_fb3-Ba2+"/>
+    <Type class="ionslm_iod_fb3-Al3+" element="Al" mass="26.98" name="ionslm_iod_fb3-Al3+"/>
+    <Type class="ionslm_iod_fb3-Fe3+" element="Fe" mass="55.85" name="ionslm_iod_fb3-Fe3+"/>
+    <Type class="ionslm_iod_fb3-Cr3+" element="Cr" mass="52.00" name="ionslm_iod_fb3-Cr3+"/>
+    <Type class="ionslm_iod_fb3-In3+" element="In" mass="114.82" name="ionslm_iod_fb3-In3+"/>
+    <Type class="ionslm_iod_fb3-Tl3+" element="Tl" mass="204.38" name="ionslm_iod_fb3-Tl3+"/>
+    <Type class="ionslm_iod_fb3-Y3+" element="Y" mass="88.91" name="ionslm_iod_fb3-Y3+"/>
+    <Type class="ionslm_iod_fb3-La3+" element="La" mass="138.91" name="ionslm_iod_fb3-La3+"/>
+    <Type class="ionslm_iod_fb3-Ce3+" element="Ce" mass="140.12" name="ionslm_iod_fb3-Ce3+"/>
+    <Type class="ionslm_iod_fb3-Pr3+" element="Pr" mass="140.91" name="ionslm_iod_fb3-Pr3+"/>
+    <Type class="ionslm_iod_fb3-Nd3+" element="Nd" mass="144.24" name="ionslm_iod_fb3-Nd3+"/>
+    <Type class="ionslm_iod_fb3-Sm3+" element="Sm" mass="150.36" name="ionslm_iod_fb3-Sm3+"/>
+    <Type class="ionslm_iod_fb3-Eu3+" element="Eu" mass="151.96" name="ionslm_iod_fb3-Eu3+"/>
+    <Type class="ionslm_iod_fb3-Gd3+" element="Gd" mass="157.25" name="ionslm_iod_fb3-Gd3+"/>
+    <Type class="ionslm_iod_fb3-Tb3+" element="Tb" mass="158.93" name="ionslm_iod_fb3-Tb3+"/>
+    <Type class="ionslm_iod_fb3-Dy3+" element="Dy" mass="162.5" name="ionslm_iod_fb3-Dy3+"/>
+    <Type class="ionslm_iod_fb3-Er3+" element="Er" mass="167.26" name="ionslm_iod_fb3-Er3+"/>
+    <Type class="ionslm_iod_fb3-Tm3+" element="Tm" mass="168.93" name="ionslm_iod_fb3-Tm3+"/>
+    <Type class="ionslm_iod_fb3-Lu3+" element="Lu" mass="174.97" name="ionslm_iod_fb3-Lu3+"/>
+    <Type class="ionslm_iod_fb3-Hf4+" element="Hf" mass="178.49" name="ionslm_iod_fb3-Hf4+"/>
+    <Type class="ionslm_iod_fb3-Zr4+" element="Zr" mass="91.22" name="ionslm_iod_fb3-Zr4+"/>
+    <Type class="ionslm_iod_fb3-Ce4+" element="Ce" mass="140.12" name="ionslm_iod_fb3-Ce4+"/>
+    <Type class="ionslm_iod_fb3-U4+" element="U" mass="238.03" name="ionslm_iod_fb3-U4+"/>
+    <Type class="ionslm_iod_fb3-Pu4+" element="Pu" mass="244.06" name="ionslm_iod_fb3-Pu4+"/>
+    <Type class="ionslm_iod_fb3-Th4+" element="Th" mass="232.04" name="ionslm_iod_fb3-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_iod_fb3-Ag+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_iod_fb3-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_iod_fb3-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_iod_fb3-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_iod_fb3-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_iod_fb3-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_iod_fb3-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_iod_fb3-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_iod_fb3-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_iod_fb3-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_iod_fb3-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_iod_fb3-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_iod_fb3-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_iod_fb3-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_iod_fb3-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_iod_fb3-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_iod_fb3-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_iod_fb3-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_iod_fb3-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_iod_fb3-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_iod_fb3-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_iod_fb3-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_iod_fb3-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_iod_fb3-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_iod_fb3-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_iod_fb3-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_iod_fb3-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_iod_fb3-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_iod_fb3-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_iod_fb3-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_iod_fb3-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_iod_fb3-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_iod_fb3-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_iod_fb3-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_iod_fb3-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_iod_fb3-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_iod_fb3-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_iod_fb3-Pu4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_iod_fb3-Rb+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_iod_fb3-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_iod_fb3-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_iod_fb3-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_iod_fb3-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_iod_fb3-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_iod_fb3-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_iod_fb3-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_iod_fb3-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_iod_fb3-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_iod_fb3-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_iod_fb3-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_iod_fb3-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_iod_fb3-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0265104516" sigma="0.2351972615890496" type="ionslm_iod_fb3-Li+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.1164829784" sigma="0.26014242569697904" type="ionslm_iod_fb3-Na+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.69962078192" sigma="0.3102109336564662" type="ionslm_iod_fb3-K+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.92601852816" sigma="0.32250533596680286" type="ionslm_iod_fb3-Rb+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.58378972872" sigma="0.35422133033259895" type="ionslm_iod_fb3-Cs+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.1216306952800001" sigma="0.3323052218663466" type="ionslm_iod_fb3-Tl+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.0058239606400000005" sigma="0.21631020876447438" type="ionslm_iod_fb3-Cu+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.16980040168" sigma="0.2681605141602421" type="ionslm_iod_fb3-Ag+"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.7058165328" sigma="0.31056729314372233" type="ionslm_iod_fb3-F-"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.23785762904" sigma="0.385937324698395" type="ionslm_iod_fb3-Cl-"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.75663199824" sigma="0.41515880265339816" type="ionslm_iod_fb3-Br-"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.3721648401600004" sigma="0.46273279420209223" type="ionslm_iod_fb3-I-"/><!--     IOD set for the TIP3P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00240764096" sigma="0.20722304183944293" type="ionslm_iod_fb3-Be2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07494179968" sigma="0.25176797774645987" type="ionslm_iod_fb3-Cu2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ionslm_iod_fb3-Ni2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_fb3-Zn2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0698627584" sigma="0.2505207195410634" type="ionslm_iod_fb3-Co2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05985940016" sigma="0.24784802338664239" type="ionslm_iod_fb3-Cr2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07494179968" sigma="0.25176797774645987" type="ionslm_iod_fb3-Fe2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_fb3-Mg2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.13843902048" sigma="0.26370602056954046" type="ionslm_iod_fb3-V2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.11855778216" sigma="0.26049878518423525" type="ionslm_iod_fb3-Mn2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.29973033768" sigma="0.2822367139068595" type="ionslm_iod_fb3-Hg2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.19079901904000002" sigma="0.2708332103146632" type="ionslm_iod_fb3-Cd2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.36845228664" sigma="0.2881166454465857" type="ionslm_iod_fb3-Ca2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.71515496976" sigma="0.3111018323746065" type="ionslm_iod_fb3-Sn2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.7658435440000001" sigma="0.3139527082726556" type="ionslm_iod_fb3-Sr2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.3183509948" sigma="0.34174874827863416" type="ionslm_iod_fb3-Ba2+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01724489992" sigma="0.22931733004932334" type="ionslm_iod_fb3-Al3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07951189920000001" sigma="0.2528370562082283" type="ionslm_iod_fb3-Fe3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_iod_fb3-Cr3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.10174956632" sigma="0.25746972954255803" type="ionslm_iod_fb3-In3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15799491096" sigma="0.2665568964675895" type="ionslm_iod_fb3-Tl3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_fb3-Y3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ionslm_iod_fb3-La3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.7403159140000001" sigma="0.31252727032363103" type="ionslm_iod_fb3-Ce3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.71515496976" sigma="0.3111018323746065" type="ionslm_iod_fb3-Pr3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_iod_fb3-Nd3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ionslm_iod_fb3-Sm3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.50965295632" sigma="0.2984510705770137" type="ionslm_iod_fb3-Eu3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.38639884336" sigma="0.2895420833956103" type="ionslm_iod_fb3-Gd3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.40484250112000003" sigma="0.2909675213446348" type="ionslm_iod_fb3-Tb3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_iod_fb3-Dy3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_fb3-Er3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_fb3-Tm3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_iod_fb3-Lu3+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_iod_fb3-Hf4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17386691496" sigma="0.2686950533911263" type="ionslm_iod_fb3-Zr4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.59238168208" sigma="0.3037964628858557" type="ionslm_iod_fb3-Ce4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.59238168208" sigma="0.3037964628858557" type="ionslm_iod_fb3-U4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.52838869912" sigma="0.29969832878241015" type="ionslm_iod_fb3-Pu4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.63014479248" sigma="0.3061127995530206" type="ionslm_iod_fb3-Th4+"/><!--     IOD set for the TIP3P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_iod_fb4.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_iod_fb4.xml
@@ -1,0 +1,275 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the TIP4P-FB water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.609813</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_iod_fb4" md5hash="5949de55c7a406ae582289ff8e5d2574" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_iod_fb4</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_iod_fb4-Li+" element="Li" mass="6.94" name="ionslm_iod_fb4-Li+"/>
+    <Type class="ionslm_iod_fb4-Na+" element="Na" mass="22.99" name="ionslm_iod_fb4-Na+"/>
+    <Type class="ionslm_iod_fb4-K+" element="K" mass="39.10" name="ionslm_iod_fb4-K+"/>
+    <Type class="ionslm_iod_fb4-Rb+" element="Rb" mass="85.47" name="ionslm_iod_fb4-Rb+"/>
+    <Type class="ionslm_iod_fb4-Cs+" element="Cs" mass="132.91" name="ionslm_iod_fb4-Cs+"/>
+    <Type class="ionslm_iod_fb4-Tl+" element="Tl" mass="204.38" name="ionslm_iod_fb4-Tl+"/>
+    <Type class="ionslm_iod_fb4-Cu+" element="Cu" mass="63.55" name="ionslm_iod_fb4-Cu+"/>
+    <Type class="ionslm_iod_fb4-Ag+" element="Ag" mass="107.87" name="ionslm_iod_fb4-Ag+"/>
+    <Type class="ionslm_iod_fb4-F-" element="F" mass="19.00" name="ionslm_iod_fb4-F-"/>
+    <Type class="ionslm_iod_fb4-Cl-" element="Cl" mass="35.45" name="ionslm_iod_fb4-Cl-"/>
+    <Type class="ionslm_iod_fb4-Br-" element="Br" mass="79.90" name="ionslm_iod_fb4-Br-"/>
+    <Type class="ionslm_iod_fb4-I-" element="I" mass="126.9" name="ionslm_iod_fb4-I-"/>
+    <Type class="ionslm_iod_fb4-Be2+" element="Be" mass="9.01" name="ionslm_iod_fb4-Be2+"/>
+    <Type class="ionslm_iod_fb4-Cu2+" element="Cu" mass="63.55" name="ionslm_iod_fb4-Cu2+"/>
+    <Type class="ionslm_iod_fb4-Ni2+" element="Ni" mass="58.69" name="ionslm_iod_fb4-Ni2+"/>
+    <Type class="ionslm_iod_fb4-Zn2+" element="Zn" mass="65.4" name="ionslm_iod_fb4-Zn2+"/>
+    <Type class="ionslm_iod_fb4-Co2+" element="Co" mass="58.93" name="ionslm_iod_fb4-Co2+"/>
+    <Type class="ionslm_iod_fb4-Cr2+" element="Cr" mass="52.00" name="ionslm_iod_fb4-Cr2+"/>
+    <Type class="ionslm_iod_fb4-Fe2+" element="Fe" mass="55.85" name="ionslm_iod_fb4-Fe2+"/>
+    <Type class="ionslm_iod_fb4-Mg2+" element="Mg" mass="24.305" name="ionslm_iod_fb4-Mg2+"/>
+    <Type class="ionslm_iod_fb4-V2+" element="V" mass="50.94" name="ionslm_iod_fb4-V2+"/>
+    <Type class="ionslm_iod_fb4-Mn2+" element="Mn" mass="54.94" name="ionslm_iod_fb4-Mn2+"/>
+    <Type class="ionslm_iod_fb4-Hg2+" element="Hg" mass="200.59" name="ionslm_iod_fb4-Hg2+"/>
+    <Type class="ionslm_iod_fb4-Cd2+" element="Cd" mass="112.41" name="ionslm_iod_fb4-Cd2+"/>
+    <Type class="ionslm_iod_fb4-Ca2+" element="Ca" mass="40.08" name="ionslm_iod_fb4-Ca2+"/>
+    <Type class="ionslm_iod_fb4-Sn2+" element="Sn" mass="118.71" name="ionslm_iod_fb4-Sn2+"/>
+    <Type class="ionslm_iod_fb4-Sr2+" element="Sr" mass="87.62" name="ionslm_iod_fb4-Sr2+"/>
+    <Type class="ionslm_iod_fb4-Ba2+" element="Ba" mass="137.33" name="ionslm_iod_fb4-Ba2+"/>
+    <Type class="ionslm_iod_fb4-Al3+" element="Al" mass="26.98" name="ionslm_iod_fb4-Al3+"/>
+    <Type class="ionslm_iod_fb4-Fe3+" element="Fe" mass="55.85" name="ionslm_iod_fb4-Fe3+"/>
+    <Type class="ionslm_iod_fb4-Cr3+" element="Cr" mass="52.00" name="ionslm_iod_fb4-Cr3+"/>
+    <Type class="ionslm_iod_fb4-In3+" element="In" mass="114.82" name="ionslm_iod_fb4-In3+"/>
+    <Type class="ionslm_iod_fb4-Tl3+" element="Tl" mass="204.38" name="ionslm_iod_fb4-Tl3+"/>
+    <Type class="ionslm_iod_fb4-Y3+" element="Y" mass="88.91" name="ionslm_iod_fb4-Y3+"/>
+    <Type class="ionslm_iod_fb4-La3+" element="La" mass="138.91" name="ionslm_iod_fb4-La3+"/>
+    <Type class="ionslm_iod_fb4-Ce3+" element="Ce" mass="140.12" name="ionslm_iod_fb4-Ce3+"/>
+    <Type class="ionslm_iod_fb4-Pr3+" element="Pr" mass="140.91" name="ionslm_iod_fb4-Pr3+"/>
+    <Type class="ionslm_iod_fb4-Nd3+" element="Nd" mass="144.24" name="ionslm_iod_fb4-Nd3+"/>
+    <Type class="ionslm_iod_fb4-Sm3+" element="Sm" mass="150.36" name="ionslm_iod_fb4-Sm3+"/>
+    <Type class="ionslm_iod_fb4-Eu3+" element="Eu" mass="151.96" name="ionslm_iod_fb4-Eu3+"/>
+    <Type class="ionslm_iod_fb4-Gd3+" element="Gd" mass="157.25" name="ionslm_iod_fb4-Gd3+"/>
+    <Type class="ionslm_iod_fb4-Tb3+" element="Tb" mass="158.93" name="ionslm_iod_fb4-Tb3+"/>
+    <Type class="ionslm_iod_fb4-Dy3+" element="Dy" mass="162.5" name="ionslm_iod_fb4-Dy3+"/>
+    <Type class="ionslm_iod_fb4-Er3+" element="Er" mass="167.26" name="ionslm_iod_fb4-Er3+"/>
+    <Type class="ionslm_iod_fb4-Tm3+" element="Tm" mass="168.93" name="ionslm_iod_fb4-Tm3+"/>
+    <Type class="ionslm_iod_fb4-Lu3+" element="Lu" mass="174.97" name="ionslm_iod_fb4-Lu3+"/>
+    <Type class="ionslm_iod_fb4-Hf4+" element="Hf" mass="178.49" name="ionslm_iod_fb4-Hf4+"/>
+    <Type class="ionslm_iod_fb4-Zr4+" element="Zr" mass="91.22" name="ionslm_iod_fb4-Zr4+"/>
+    <Type class="ionslm_iod_fb4-Ce4+" element="Ce" mass="140.12" name="ionslm_iod_fb4-Ce4+"/>
+    <Type class="ionslm_iod_fb4-U4+" element="U" mass="238.03" name="ionslm_iod_fb4-U4+"/>
+    <Type class="ionslm_iod_fb4-Pu4+" element="Pu" mass="244.06" name="ionslm_iod_fb4-Pu4+"/>
+    <Type class="ionslm_iod_fb4-Th4+" element="Th" mass="232.04" name="ionslm_iod_fb4-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_iod_fb4-Ag+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_iod_fb4-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_iod_fb4-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_iod_fb4-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_iod_fb4-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_iod_fb4-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_iod_fb4-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_iod_fb4-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_iod_fb4-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_iod_fb4-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_iod_fb4-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_iod_fb4-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_iod_fb4-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_iod_fb4-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_iod_fb4-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_iod_fb4-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_iod_fb4-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_iod_fb4-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_iod_fb4-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_iod_fb4-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_iod_fb4-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_iod_fb4-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_iod_fb4-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_iod_fb4-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_iod_fb4-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_iod_fb4-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_iod_fb4-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_iod_fb4-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_iod_fb4-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_iod_fb4-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_iod_fb4-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_iod_fb4-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_iod_fb4-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_iod_fb4-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_iod_fb4-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_iod_fb4-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_iod_fb4-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_iod_fb4-Pu4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_iod_fb4-Rb+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_iod_fb4-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_iod_fb4-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_iod_fb4-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_iod_fb4-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_iod_fb4-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_iod_fb4-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_iod_fb4-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_iod_fb4-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_iod_fb4-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_iod_fb4-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_iod_fb4-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_iod_fb4-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_iod_fb4-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.022184153760000002" sigma="0.23270274517825662" type="ionslm_iod_fb4-Li+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.10650049832000001" sigma="0.2583606282606984" type="ionslm_iod_fb4-Na+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.68730174704" sigma="0.3094982146819539" type="ionslm_iod_fb4-K+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.92601852816" sigma="0.32250533596680286" type="ionslm_iod_fb4-Rb+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.6293855800000001" sigma="0.35635948725613575" type="ionslm_iod_fb4-Cs+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.1034234335200002" sigma="0.3314143231482063" type="ionslm_iod_fb4-Tl+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.005279036480000001" sigma="0.21524113030270597" type="ionslm_iod_fb4-Cu+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.13960849032" sigma="0.2638842003131685" type="ionslm_iod_fb4-Ag+"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.6965319439200001" sigma="0.3100327539128381" type="ionslm_iod_fb4-F-"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.23785762904" sigma="0.385937324698395" type="ionslm_iod_fb4-Cl-"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.7848492708" sigma="0.4169406000896788" type="ionslm_iod_fb4-Br-"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.3558461523200003" sigma="0.46112917650943963" type="ionslm_iod_fb4-I-"/><!--     IOD set for the TIP4P-FB water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.0018871932" sigma="0.20490670517227805" type="ionslm_iod_fb4-Be2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_fb4-Cu2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04172799432" sigma="0.24196809184691617" type="ionslm_iod_fb4-Ni2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05499311528" sigma="0.24642258543761786" type="ionslm_iod_fb4-Zn2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06049009632" sigma="0.24802620313027043" type="ionslm_iod_fb4-Co2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05043699032" sigma="0.2449971474885933" type="ionslm_iod_fb4-Cr2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_fb4-Fe2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05499311528" sigma="0.24642258543761786" type="ionslm_iod_fb4-Mg2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.12171954728" sigma="0.26103332441511945" type="ionslm_iod_fb4-V2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.11545547168" sigma="0.25996424595335105" type="ionslm_iod_fb4-Mn2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.27686942192" sigma="0.2800985569833227" type="ionslm_iod_fb4-Hg2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.17799966096" sigma="0.2692295926220105" type="ionslm_iod_fb4-Cd2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_fb4-Ca2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ionslm_iod_fb4-Sn2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.71515496976" sigma="0.3111018323746065" type="ionslm_iod_fb4-Sr2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.25088989424" sigma="0.3385415128933289" type="ionslm_iod_fb4-Ba2+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0130567996" sigma="0.22575373517676198" type="ionslm_iod_fb4-Al3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06846053264" sigma="0.25016436005380727" type="ionslm_iod_fb4-Fe3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.03590047728" sigma="0.2396517551797513" type="ionslm_iod_fb4-Cr3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.09989325104" sigma="0.25711337005530194" type="ionslm_iod_fb4-In3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14799067408" sigma="0.265131458518565" type="ionslm_iod_fb4-Tl3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_iod_fb4-Y3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6213311128" sigma="0.3055782603221364" type="ionslm_iod_fb4-La3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6903723846400001" sigma="0.309676394425582" type="ionslm_iod_fb4-Ce3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ionslm_iod_fb4-Pr3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.50965295632" sigma="0.2984510705770137" type="ionslm_iod_fb4-Nd3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.44566809032000004" sigma="0.29399657698631193" type="ionslm_iod_fb4-Sm3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.46563832232" sigma="0.29542201493533654" type="ionslm_iod_fb4-Eu3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_iod_fb4-Gd3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.36845228664" sigma="0.2881166454465857" type="ionslm_iod_fb4-Tb3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.315602258" sigma="0.28366215185588406" type="ionslm_iod_fb4-Dy3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_iod_fb4-Er3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_iod_fb4-Tm3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.26767888936000006" sigma="0.2792076582651823" type="ionslm_iod_fb4-Lu3+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.12386075112" sigma="0.2613896839023756" type="ionslm_iod_fb4-Hf4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15671933488" sigma="0.26637871672396146" type="ionslm_iod_fb4-Zr4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_iod_fb4-Ce4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_iod_fb4-U4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ionslm_iod_fb4-Pu4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.60388144792" sigma="0.304509181860368" type="ionslm_iod_fb4-Th4+"/><!--     IOD set for the TIP4P-FB water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_iod_opc.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_iod_opc.xml
@@ -1,0 +1,275 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the OPC water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.639273</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_iod_opc" md5hash="684b687845cd8aa62b907b700dbe06fd" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_iod_opc</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_iod_opc-Li+" element="Li" mass="6.94" name="ionslm_iod_opc-Li+"/>
+    <Type class="ionslm_iod_opc-Na+" element="Na" mass="22.99" name="ionslm_iod_opc-Na+"/>
+    <Type class="ionslm_iod_opc-K+" element="K" mass="39.10" name="ionslm_iod_opc-K+"/>
+    <Type class="ionslm_iod_opc-Rb+" element="Rb" mass="85.47" name="ionslm_iod_opc-Rb+"/>
+    <Type class="ionslm_iod_opc-Cs+" element="Cs" mass="132.91" name="ionslm_iod_opc-Cs+"/>
+    <Type class="ionslm_iod_opc-Tl+" element="Tl" mass="204.38" name="ionslm_iod_opc-Tl+"/>
+    <Type class="ionslm_iod_opc-Cu+" element="Cu" mass="63.55" name="ionslm_iod_opc-Cu+"/>
+    <Type class="ionslm_iod_opc-Ag+" element="Ag" mass="107.87" name="ionslm_iod_opc-Ag+"/>
+    <Type class="ionslm_iod_opc-F-" element="F" mass="19.00" name="ionslm_iod_opc-F-"/>
+    <Type class="ionslm_iod_opc-Cl-" element="Cl" mass="35.45" name="ionslm_iod_opc-Cl-"/>
+    <Type class="ionslm_iod_opc-Br-" element="Br" mass="79.90" name="ionslm_iod_opc-Br-"/>
+    <Type class="ionslm_iod_opc-I-" element="I" mass="126.9" name="ionslm_iod_opc-I-"/>
+    <Type class="ionslm_iod_opc-Be2+" element="Be" mass="9.01" name="ionslm_iod_opc-Be2+"/>
+    <Type class="ionslm_iod_opc-Cu2+" element="Cu" mass="63.55" name="ionslm_iod_opc-Cu2+"/>
+    <Type class="ionslm_iod_opc-Ni2+" element="Ni" mass="58.69" name="ionslm_iod_opc-Ni2+"/>
+    <Type class="ionslm_iod_opc-Zn2+" element="Zn" mass="65.4" name="ionslm_iod_opc-Zn2+"/>
+    <Type class="ionslm_iod_opc-Co2+" element="Co" mass="58.93" name="ionslm_iod_opc-Co2+"/>
+    <Type class="ionslm_iod_opc-Cr2+" element="Cr" mass="52.00" name="ionslm_iod_opc-Cr2+"/>
+    <Type class="ionslm_iod_opc-Fe2+" element="Fe" mass="55.85" name="ionslm_iod_opc-Fe2+"/>
+    <Type class="ionslm_iod_opc-Mg2+" element="Mg" mass="24.305" name="ionslm_iod_opc-Mg2+"/>
+    <Type class="ionslm_iod_opc-V2+" element="V" mass="50.94" name="ionslm_iod_opc-V2+"/>
+    <Type class="ionslm_iod_opc-Mn2+" element="Mn" mass="54.94" name="ionslm_iod_opc-Mn2+"/>
+    <Type class="ionslm_iod_opc-Hg2+" element="Hg" mass="200.59" name="ionslm_iod_opc-Hg2+"/>
+    <Type class="ionslm_iod_opc-Cd2+" element="Cd" mass="112.41" name="ionslm_iod_opc-Cd2+"/>
+    <Type class="ionslm_iod_opc-Ca2+" element="Ca" mass="40.08" name="ionslm_iod_opc-Ca2+"/>
+    <Type class="ionslm_iod_opc-Sn2+" element="Sn" mass="118.71" name="ionslm_iod_opc-Sn2+"/>
+    <Type class="ionslm_iod_opc-Sr2+" element="Sr" mass="87.62" name="ionslm_iod_opc-Sr2+"/>
+    <Type class="ionslm_iod_opc-Ba2+" element="Ba" mass="137.33" name="ionslm_iod_opc-Ba2+"/>
+    <Type class="ionslm_iod_opc-Al3+" element="Al" mass="26.98" name="ionslm_iod_opc-Al3+"/>
+    <Type class="ionslm_iod_opc-Fe3+" element="Fe" mass="55.85" name="ionslm_iod_opc-Fe3+"/>
+    <Type class="ionslm_iod_opc-Cr3+" element="Cr" mass="52.00" name="ionslm_iod_opc-Cr3+"/>
+    <Type class="ionslm_iod_opc-In3+" element="In" mass="114.82" name="ionslm_iod_opc-In3+"/>
+    <Type class="ionslm_iod_opc-Tl3+" element="Tl" mass="204.38" name="ionslm_iod_opc-Tl3+"/>
+    <Type class="ionslm_iod_opc-Y3+" element="Y" mass="88.91" name="ionslm_iod_opc-Y3+"/>
+    <Type class="ionslm_iod_opc-La3+" element="La" mass="138.91" name="ionslm_iod_opc-La3+"/>
+    <Type class="ionslm_iod_opc-Ce3+" element="Ce" mass="140.12" name="ionslm_iod_opc-Ce3+"/>
+    <Type class="ionslm_iod_opc-Pr3+" element="Pr" mass="140.91" name="ionslm_iod_opc-Pr3+"/>
+    <Type class="ionslm_iod_opc-Nd3+" element="Nd" mass="144.24" name="ionslm_iod_opc-Nd3+"/>
+    <Type class="ionslm_iod_opc-Sm3+" element="Sm" mass="150.36" name="ionslm_iod_opc-Sm3+"/>
+    <Type class="ionslm_iod_opc-Eu3+" element="Eu" mass="151.96" name="ionslm_iod_opc-Eu3+"/>
+    <Type class="ionslm_iod_opc-Gd3+" element="Gd" mass="157.25" name="ionslm_iod_opc-Gd3+"/>
+    <Type class="ionslm_iod_opc-Tb3+" element="Tb" mass="158.93" name="ionslm_iod_opc-Tb3+"/>
+    <Type class="ionslm_iod_opc-Dy3+" element="Dy" mass="162.5" name="ionslm_iod_opc-Dy3+"/>
+    <Type class="ionslm_iod_opc-Er3+" element="Er" mass="167.26" name="ionslm_iod_opc-Er3+"/>
+    <Type class="ionslm_iod_opc-Tm3+" element="Tm" mass="168.93" name="ionslm_iod_opc-Tm3+"/>
+    <Type class="ionslm_iod_opc-Lu3+" element="Lu" mass="174.97" name="ionslm_iod_opc-Lu3+"/>
+    <Type class="ionslm_iod_opc-Hf4+" element="Hf" mass="178.49" name="ionslm_iod_opc-Hf4+"/>
+    <Type class="ionslm_iod_opc-Zr4+" element="Zr" mass="91.22" name="ionslm_iod_opc-Zr4+"/>
+    <Type class="ionslm_iod_opc-Ce4+" element="Ce" mass="140.12" name="ionslm_iod_opc-Ce4+"/>
+    <Type class="ionslm_iod_opc-U4+" element="U" mass="238.03" name="ionslm_iod_opc-U4+"/>
+    <Type class="ionslm_iod_opc-Pu4+" element="Pu" mass="244.06" name="ionslm_iod_opc-Pu4+"/>
+    <Type class="ionslm_iod_opc-Th4+" element="Th" mass="232.04" name="ionslm_iod_opc-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_iod_opc-Ag+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_iod_opc-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_iod_opc-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_iod_opc-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_iod_opc-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_iod_opc-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_iod_opc-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_iod_opc-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_iod_opc-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_iod_opc-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_iod_opc-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_iod_opc-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_iod_opc-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_iod_opc-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_iod_opc-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_iod_opc-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_iod_opc-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_iod_opc-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_iod_opc-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_iod_opc-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_iod_opc-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_iod_opc-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_iod_opc-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_iod_opc-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_iod_opc-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_iod_opc-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_iod_opc-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_iod_opc-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_iod_opc-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_iod_opc-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_iod_opc-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_iod_opc-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_iod_opc-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_iod_opc-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_iod_opc-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_iod_opc-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_iod_opc-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_iod_opc-Pu4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_iod_opc-Rb+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_iod_opc-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_iod_opc-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_iod_opc-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_iod_opc-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_iod_opc-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_iod_opc-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_iod_opc-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_iod_opc-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_iod_opc-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_iod_opc-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_iod_opc-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_iod_opc-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_iod_opc-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0218984284" sigma="0.23252456543462854" type="ionslm_iod_opc-Li+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.09715545064" sigma="0.2565788308244177" type="ionslm_iod_opc-Na+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.6903723846400001" sigma="0.309676394425582" type="ionslm_iod_opc-K+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.8985523254400001" sigma="0.3210798980177783" type="ionslm_iod_opc-Rb+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.59139272616" sigma="0.35457768981985505" type="ionslm_iod_opc-Cs+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.04926352" sigma="0.32874162699378523" type="ionslm_iod_opc-Tl+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.004698632" sigma="0.2139938720973095" type="ionslm_iod_opc-Cu+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_iod_opc-Ag+"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.6360531444" sigma="0.3064691590402767" type="ionslm_iod_opc-F-"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.1820915197599997" sigma="0.38308644880034587" type="ionslm_iod_opc-Cl-"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.70481068968" sigma="0.4119515672680929" type="ionslm_iod_opc-Br-"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.3280127199200003" sigma="0.4584564803550186" type="ionslm_iod_opc-I-"/><!--     IOD set for the OPC water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00143896128" sigma="0.20241218876148506" type="ionslm_iod_opc-Be2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05985940016" sigma="0.24784802338664239" type="ionslm_iod_opc-Cu2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.03590047728" sigma="0.2396517551797513" type="ionslm_iod_opc-Ni2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ionslm_iod_opc-Zn2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05440689504000001" sigma="0.24624440569398978" type="ionslm_iod_opc-Co2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_iod_opc-Cr2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05985940016" sigma="0.24784802338664239" type="ionslm_iod_opc-Fe2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ionslm_iod_opc-Mg2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.11241219744000001" sigma="0.2594297067224668" type="ionslm_iod_opc-V2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.1008182916" sigma="0.25729154979893" type="ionslm_iod_opc-Mn2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.26405772104" sigma="0.2788512987779262" type="ionslm_iod_opc-Hg2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.17114857016" sigma="0.2683386939038702" type="ionslm_iod_opc-Cd2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.31158691504" sigma="0.2833057923686279" type="ionslm_iod_opc-Ca2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.6213311128" sigma="0.3055782603221364" type="ionslm_iod_opc-Sn2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.669006956" sigma="0.3084291362201855" type="ionslm_iod_opc-Sr2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.1877432507999999" sigma="0.3355124572516518" type="ionslm_iod_opc-Ba2+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.010193772080000002" sigma="0.22272467953508485" type="ionslm_iod_opc-Al3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_opc-Fe3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.032257342960000004" sigma="0.2380481374870987" type="ionslm_iod_opc-Cr3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.09715545064" sigma="0.2565788308244177" type="ionslm_iod_opc-In3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14196839183999999" sigma="0.26424055980042466" type="ionslm_iod_opc-Tl3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ionslm_iod_opc-Y3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.5781589690400001" sigma="0.30290556416771536" type="ionslm_iod_opc-La3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.65093680392" sigma="0.30736005775841707" type="ionslm_iod_opc-Ce3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.62720034432" sigma="0.30593461980939257" type="ionslm_iod_opc-Pr3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.47580293192" sigma="0.29613473390984874" type="ionslm_iod_opc-Nd3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.41662062848000003" sigma="0.2918584200627751" type="ionslm_iod_opc-Sm3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.43586389048" sigma="0.2932838580117997" type="ionslm_iod_opc-Eu3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_opc-Gd3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_iod_opc-Tb3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_iod_opc-Dy3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ionslm_iod_opc-Er3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.28247819944" sigma="0.2806330962142069" type="ionslm_iod_opc-Tm3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.25163082264000003" sigma="0.27760404057252974" type="ionslm_iod_opc-Lu3+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.11751709584" sigma="0.26032060544060714" type="ionslm_iod_opc-Hf4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14799067408" sigma="0.265131458518565" type="ionslm_iod_opc-Zr4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.5310938643199999" sigma="0.2998765085260382" type="ionslm_iod_opc-Ce4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.5310938643199999" sigma="0.2998765085260382" type="ionslm_iod_opc-U4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.46563832232" sigma="0.29542201493533654" type="ionslm_iod_opc-Pu4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.58952354984" sigma="0.3036182831422276" type="ionslm_iod_opc-Th4+"/><!--     IOD set for the OPC water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>

--- a/wrappers/python/openmm/app/data/ions/ionslm_iod_opc3.xml
+++ b/wrappers/python/openmm/app/data/ions/ionslm_iod_opc3.xml
@@ -1,0 +1,275 @@
+<ForceField>
+  <Info>
+    <!-- Li/Merz ion parameters of atomic ions for the OPC3 water model (12-6 IOD set) -->
+    <DateGenerated>2022-09-11T06:28:33.554852</DateGenerated>
+    <Source Source="parm/frcmod.ionslm_iod_opc3" md5hash="2107d130ed8dd0bdee878ed84bbf8b13" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">parm/frcmod.ionslm_iod_opc3</Source>
+    <Source Source="lib/atomic_ions.lib" md5hash="e900cee0c71ec2795d25b3555de486e1" sourcePackage="AmberTools" sourcePackageVersion="22.0-py38h6177452_1">lib/atomic_ions.lib</Source>
+  </Info>
+  <AtomTypes>
+    <Type class="ionslm_iod_opc3-Li+" element="Li" mass="6.94" name="ionslm_iod_opc3-Li+"/>
+    <Type class="ionslm_iod_opc3-Na+" element="Na" mass="22.99" name="ionslm_iod_opc3-Na+"/>
+    <Type class="ionslm_iod_opc3-K+" element="K" mass="39.10" name="ionslm_iod_opc3-K+"/>
+    <Type class="ionslm_iod_opc3-Rb+" element="Rb" mass="85.47" name="ionslm_iod_opc3-Rb+"/>
+    <Type class="ionslm_iod_opc3-Cs+" element="Cs" mass="132.91" name="ionslm_iod_opc3-Cs+"/>
+    <Type class="ionslm_iod_opc3-Tl+" element="Tl" mass="204.38" name="ionslm_iod_opc3-Tl+"/>
+    <Type class="ionslm_iod_opc3-Cu+" element="Cu" mass="63.55" name="ionslm_iod_opc3-Cu+"/>
+    <Type class="ionslm_iod_opc3-Ag+" element="Ag" mass="107.87" name="ionslm_iod_opc3-Ag+"/>
+    <Type class="ionslm_iod_opc3-F-" element="F" mass="19.00" name="ionslm_iod_opc3-F-"/>
+    <Type class="ionslm_iod_opc3-Cl-" element="Cl" mass="35.45" name="ionslm_iod_opc3-Cl-"/>
+    <Type class="ionslm_iod_opc3-Br-" element="Br" mass="79.90" name="ionslm_iod_opc3-Br-"/>
+    <Type class="ionslm_iod_opc3-I-" element="I" mass="126.9" name="ionslm_iod_opc3-I-"/>
+    <Type class="ionslm_iod_opc3-Be2+" element="Be" mass="9.01" name="ionslm_iod_opc3-Be2+"/>
+    <Type class="ionslm_iod_opc3-Cu2+" element="Cu" mass="63.55" name="ionslm_iod_opc3-Cu2+"/>
+    <Type class="ionslm_iod_opc3-Ni2+" element="Ni" mass="58.69" name="ionslm_iod_opc3-Ni2+"/>
+    <Type class="ionslm_iod_opc3-Zn2+" element="Zn" mass="65.4" name="ionslm_iod_opc3-Zn2+"/>
+    <Type class="ionslm_iod_opc3-Co2+" element="Co" mass="58.93" name="ionslm_iod_opc3-Co2+"/>
+    <Type class="ionslm_iod_opc3-Cr2+" element="Cr" mass="52.00" name="ionslm_iod_opc3-Cr2+"/>
+    <Type class="ionslm_iod_opc3-Fe2+" element="Fe" mass="55.85" name="ionslm_iod_opc3-Fe2+"/>
+    <Type class="ionslm_iod_opc3-Mg2+" element="Mg" mass="24.305" name="ionslm_iod_opc3-Mg2+"/>
+    <Type class="ionslm_iod_opc3-V2+" element="V" mass="50.94" name="ionslm_iod_opc3-V2+"/>
+    <Type class="ionslm_iod_opc3-Mn2+" element="Mn" mass="54.94" name="ionslm_iod_opc3-Mn2+"/>
+    <Type class="ionslm_iod_opc3-Hg2+" element="Hg" mass="200.59" name="ionslm_iod_opc3-Hg2+"/>
+    <Type class="ionslm_iod_opc3-Cd2+" element="Cd" mass="112.41" name="ionslm_iod_opc3-Cd2+"/>
+    <Type class="ionslm_iod_opc3-Ca2+" element="Ca" mass="40.08" name="ionslm_iod_opc3-Ca2+"/>
+    <Type class="ionslm_iod_opc3-Sn2+" element="Sn" mass="118.71" name="ionslm_iod_opc3-Sn2+"/>
+    <Type class="ionslm_iod_opc3-Sr2+" element="Sr" mass="87.62" name="ionslm_iod_opc3-Sr2+"/>
+    <Type class="ionslm_iod_opc3-Ba2+" element="Ba" mass="137.33" name="ionslm_iod_opc3-Ba2+"/>
+    <Type class="ionslm_iod_opc3-Al3+" element="Al" mass="26.98" name="ionslm_iod_opc3-Al3+"/>
+    <Type class="ionslm_iod_opc3-Fe3+" element="Fe" mass="55.85" name="ionslm_iod_opc3-Fe3+"/>
+    <Type class="ionslm_iod_opc3-Cr3+" element="Cr" mass="52.00" name="ionslm_iod_opc3-Cr3+"/>
+    <Type class="ionslm_iod_opc3-In3+" element="In" mass="114.82" name="ionslm_iod_opc3-In3+"/>
+    <Type class="ionslm_iod_opc3-Tl3+" element="Tl" mass="204.38" name="ionslm_iod_opc3-Tl3+"/>
+    <Type class="ionslm_iod_opc3-Y3+" element="Y" mass="88.91" name="ionslm_iod_opc3-Y3+"/>
+    <Type class="ionslm_iod_opc3-La3+" element="La" mass="138.91" name="ionslm_iod_opc3-La3+"/>
+    <Type class="ionslm_iod_opc3-Ce3+" element="Ce" mass="140.12" name="ionslm_iod_opc3-Ce3+"/>
+    <Type class="ionslm_iod_opc3-Pr3+" element="Pr" mass="140.91" name="ionslm_iod_opc3-Pr3+"/>
+    <Type class="ionslm_iod_opc3-Nd3+" element="Nd" mass="144.24" name="ionslm_iod_opc3-Nd3+"/>
+    <Type class="ionslm_iod_opc3-Sm3+" element="Sm" mass="150.36" name="ionslm_iod_opc3-Sm3+"/>
+    <Type class="ionslm_iod_opc3-Eu3+" element="Eu" mass="151.96" name="ionslm_iod_opc3-Eu3+"/>
+    <Type class="ionslm_iod_opc3-Gd3+" element="Gd" mass="157.25" name="ionslm_iod_opc3-Gd3+"/>
+    <Type class="ionslm_iod_opc3-Tb3+" element="Tb" mass="158.93" name="ionslm_iod_opc3-Tb3+"/>
+    <Type class="ionslm_iod_opc3-Dy3+" element="Dy" mass="162.5" name="ionslm_iod_opc3-Dy3+"/>
+    <Type class="ionslm_iod_opc3-Er3+" element="Er" mass="167.26" name="ionslm_iod_opc3-Er3+"/>
+    <Type class="ionslm_iod_opc3-Tm3+" element="Tm" mass="168.93" name="ionslm_iod_opc3-Tm3+"/>
+    <Type class="ionslm_iod_opc3-Lu3+" element="Lu" mass="174.97" name="ionslm_iod_opc3-Lu3+"/>
+    <Type class="ionslm_iod_opc3-Hf4+" element="Hf" mass="178.49" name="ionslm_iod_opc3-Hf4+"/>
+    <Type class="ionslm_iod_opc3-Zr4+" element="Zr" mass="91.22" name="ionslm_iod_opc3-Zr4+"/>
+    <Type class="ionslm_iod_opc3-Ce4+" element="Ce" mass="140.12" name="ionslm_iod_opc3-Ce4+"/>
+    <Type class="ionslm_iod_opc3-U4+" element="U" mass="238.03" name="ionslm_iod_opc3-U4+"/>
+    <Type class="ionslm_iod_opc3-Pu4+" element="Pu" mass="244.06" name="ionslm_iod_opc3-Pu4+"/>
+    <Type class="ionslm_iod_opc3-Th4+" element="Th" mass="232.04" name="ionslm_iod_opc3-Th4+"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="AG">
+      <Atom charge="1.0" name="AG" type="ionslm_iod_opc3-Ag+"/>
+    </Residue>
+    <Residue name="AL">
+      <Atom charge="3.0" name="AL" type="ionslm_iod_opc3-Al3+"/>
+    </Residue>
+    <Residue name="BA">
+      <Atom charge="2.0" name="BA" type="ionslm_iod_opc3-Ba2+"/>
+    </Residue>
+    <Residue name="Be">
+      <Atom charge="2.0" name="Be" type="ionslm_iod_opc3-Be2+"/>
+    </Residue>
+    <Residue name="BR">
+      <Atom charge="-1.0" name="BR" type="ionslm_iod_opc3-Br-"/>
+    </Residue>
+    <Residue name="CA">
+      <Atom charge="2.0" name="CA" type="ionslm_iod_opc3-Ca2+"/>
+    </Residue>
+    <Residue name="CD">
+      <Atom charge="2.0" name="CD" type="ionslm_iod_opc3-Cd2+"/>
+    </Residue>
+    <Residue name="CE">
+      <Atom charge="3.0" name="CE" type="ionslm_iod_opc3-Ce3+"/>
+    </Residue>
+    <Residue name="Ce">
+      <Atom charge="4.0" name="Ce" type="ionslm_iod_opc3-Ce4+"/>
+    </Residue>
+    <Residue name="CL">
+      <Atom charge="-1.0" name="CL" type="ionslm_iod_opc3-Cl-"/>
+    </Residue>
+    <Residue name="CO">
+      <Atom charge="2.0" name="CO" type="ionslm_iod_opc3-Co2+"/>
+    </Residue>
+    <Residue name="Cr">
+      <Atom charge="2.0" name="Cr" type="ionslm_iod_opc3-Cr2+"/>
+    </Residue>
+    <Residue name="CR">
+      <Atom charge="3.0" name="CR" type="ionslm_iod_opc3-Cr3+"/>
+    </Residue>
+    <Residue name="CS">
+      <Atom charge="1.0" name="CS" type="ionslm_iod_opc3-Cs+"/>
+    </Residue>
+    <Residue name="CU1">
+      <Atom charge="1.0" name="CU1" type="ionslm_iod_opc3-Cu+"/>
+    </Residue>
+    <Residue name="CU">
+      <Atom charge="2.0" name="CU" type="ionslm_iod_opc3-Cu2+"/>
+    </Residue>
+    <Residue name="Dy">
+      <Atom charge="3.0" name="Dy" type="ionslm_iod_opc3-Dy3+"/>
+    </Residue>
+    <Residue name="Er">
+      <Atom charge="3.0" name="Er" type="ionslm_iod_opc3-Er3+"/>
+    </Residue>
+    <Residue name="EU3">
+      <Atom charge="3.0" name="EU3" type="ionslm_iod_opc3-Eu3+"/>
+    </Residue>
+    <Residue name="F">
+      <Atom charge="-1.0" name="F" type="ionslm_iod_opc3-F-"/>
+    </Residue>
+    <Residue name="FE2">
+      <Atom charge="2.0" name="FE2" type="ionslm_iod_opc3-Fe2+"/>
+    </Residue>
+    <Residue name="FE">
+      <Atom charge="3.0" name="FE" type="ionslm_iod_opc3-Fe3+"/>
+    </Residue>
+    <Residue name="GD">
+      <Atom charge="3.0" name="GD" type="ionslm_iod_opc3-Gd3+"/>
+    </Residue>
+    <Residue name="Hf">
+      <Atom charge="4.0" name="Hf" type="ionslm_iod_opc3-Hf4+"/>
+    </Residue>
+    <Residue name="HG">
+      <Atom charge="2.0" name="HG" type="ionslm_iod_opc3-Hg2+"/>
+    </Residue>
+    <Residue name="I">
+      <Atom charge="-1.0" name="I" type="ionslm_iod_opc3-I-"/>
+    </Residue>
+    <Residue name="IN">
+      <Atom charge="3.0" name="IN" type="ionslm_iod_opc3-In3+"/>
+    </Residue>
+    <Residue name="K">
+      <Atom charge="1.0" name="K" type="ionslm_iod_opc3-K+"/>
+    </Residue>
+    <Residue name="LA">
+      <Atom charge="3.0" name="LA" type="ionslm_iod_opc3-La3+"/>
+    </Residue>
+    <Residue name="LI">
+      <Atom charge="1.0" name="LI" type="ionslm_iod_opc3-Li+"/>
+    </Residue>
+    <Residue name="LU">
+      <Atom charge="3.0" name="LU" type="ionslm_iod_opc3-Lu3+"/>
+    </Residue>
+    <Residue name="MG">
+      <Atom charge="2.0" name="MG" type="ionslm_iod_opc3-Mg2+"/>
+    </Residue>
+    <Residue name="MN">
+      <Atom charge="2.0" name="MN" type="ionslm_iod_opc3-Mn2+"/>
+    </Residue>
+    <Residue name="NA">
+      <Atom charge="1.0" name="NA" type="ionslm_iod_opc3-Na+"/>
+    </Residue>
+    <Residue name="Nd">
+      <Atom charge="3.0" name="Nd" type="ionslm_iod_opc3-Nd3+"/>
+    </Residue>
+    <Residue name="NI">
+      <Atom charge="2.0" name="NI" type="ionslm_iod_opc3-Ni2+"/>
+    </Residue>
+    <Residue name="PR">
+      <Atom charge="3.0" name="PR" type="ionslm_iod_opc3-Pr3+"/>
+    </Residue>
+    <Residue name="Pu">
+      <Atom charge="4.0" name="Pu" type="ionslm_iod_opc3-Pu4+"/>
+    </Residue>
+    <Residue name="RB">
+      <Atom charge="1.0" name="RB" type="ionslm_iod_opc3-Rb+"/>
+    </Residue>
+    <Residue name="SM">
+      <Atom charge="3.0" name="SM" type="ionslm_iod_opc3-Sm3+"/>
+    </Residue>
+    <Residue name="Sn">
+      <Atom charge="2.0" name="Sn" type="ionslm_iod_opc3-Sn2+"/>
+    </Residue>
+    <Residue name="SR">
+      <Atom charge="2.0" name="SR" type="ionslm_iod_opc3-Sr2+"/>
+    </Residue>
+    <Residue name="TB">
+      <Atom charge="3.0" name="TB" type="ionslm_iod_opc3-Tb3+"/>
+    </Residue>
+    <Residue name="Th">
+      <Atom charge="4.0" name="Th" type="ionslm_iod_opc3-Th4+"/>
+    </Residue>
+    <Residue name="TL">
+      <Atom charge="1.0" name="TL" type="ionslm_iod_opc3-Tl+"/>
+    </Residue>
+    <Residue name="Tl">
+      <Atom charge="3.0" name="Tl" type="ionslm_iod_opc3-Tl3+"/>
+    </Residue>
+    <Residue name="Tm">
+      <Atom charge="3.0" name="Tm" type="ionslm_iod_opc3-Tm3+"/>
+    </Residue>
+    <Residue name="U">
+      <Atom charge="4.0" name="U" type="ionslm_iod_opc3-U4+"/>
+    </Residue>
+    <Residue name="V2+">
+      <Atom charge="2.0" name="V2+" type="ionslm_iod_opc3-V2+"/>
+    </Residue>
+    <Residue name="Y">
+      <Atom charge="3.0" name="Y" type="ionslm_iod_opc3-Y3+"/>
+    </Residue>
+    <Residue name="ZN">
+      <Atom charge="2.0" name="ZN" type="ionslm_iod_opc3-Zn2+"/>
+    </Residue>
+    <Residue name="Zr">
+      <Atom charge="4.0" name="Zr" type="ionslm_iod_opc3-Zr4+"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.0268437072" sigma="0.23537544133267763" type="ionslm_iod_opc3-Li+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.1271228904" sigma="0.26192422313325975" type="ionslm_iod_opc3-Na+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.7058165328" sigma="0.31056729314372233" type="ionslm_iod_opc3-K+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.92601852816" sigma="0.32250533596680286" type="ionslm_iod_opc3-Rb+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.59139272616" sigma="0.35457768981985505" type="ionslm_iod_opc3-Cs+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="1.1252808168800001" sigma="0.3324834016099747" type="ionslm_iod_opc3-Tl+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00572994616" sigma="0.21613202902084636" type="ionslm_iod_opc3-Cu+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.16579982824" sigma="0.2676259749293579" type="ionslm_iod_opc3-Ag+"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.68730174704" sigma="0.3094982146819539" type="ionslm_iod_opc3-F-"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.2170390073600004" sigma="0.38486824623662663" type="ionslm_iod_opc3-Cl-"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="2.7135392668000002" sigma="0.4124861064989771" type="ionslm_iod_opc3-Br-"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="3.35949706888" sigma="0.46148553599669573" type="ionslm_iod_opc3-I-"/><!--     IOD set for the OPC3 water model from Sengupta et al., JCIM, 2021, 61, 869 -->
+    <Atom epsilon="0.00236358344" sigma="0.20704486209581485" type="ionslm_iod_opc3-Be2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.07494179968" sigma="0.25176797774645987" type="ionslm_iod_opc3-Cu2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.04934496632" sigma="0.24464078800133718" type="ionslm_iod_opc3-Ni2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_opc3-Zn2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.0698627584" sigma="0.2505207195410634" type="ionslm_iod_opc3-Co2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05985940016" sigma="0.24784802338664239" type="ionslm_iod_opc3-Cr2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.05985940016" sigma="0.25176797774645987" type="ionslm_iod_opc3-Fe2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.06572013816000001" sigma="0.249451641079295" type="ionslm_iod_opc3-Mg2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.13843902048" sigma="0.26370602056954046" type="ionslm_iod_opc3-V2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.11855778216" sigma="0.26049878518423525" type="ionslm_iod_opc3-Mn2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.29973033768" sigma="0.2822367139068595" type="ionslm_iod_opc3-Hg2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.19966935008" sigma="0.2719022887764316" type="ionslm_iod_opc3-Cd2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.36845228664" sigma="0.2881166454465857" type="ionslm_iod_opc3-Ca2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.71515496976" sigma="0.3111018323746065" type="ionslm_iod_opc3-Sn2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.7658435440000001" sigma="0.3139527082726556" type="ionslm_iod_opc3-Sr2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="1.3183509948" sigma="0.34174874827863416" type="ionslm_iod_opc3-Ba2+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2020, 16, 4429 -->
+    <Atom epsilon="0.01724489992" sigma="0.22931733004932334" type="ionslm_iod_opc3-Al3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.07951189920000001" sigma="0.2528370562082283" type="ionslm_iod_opc3-Fe3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.04465579016" sigma="0.24303717030868457" type="ionslm_iod_opc3-Cr3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.10942737368000001" sigma="0.25889516749158265" type="ionslm_iod_opc3-In3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.15799491096" sigma="0.2665568964675895" type="ionslm_iod_opc3-Tl3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_opc3-Y3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.67508049224" sigma="0.3087854957074416" type="ionslm_iod_opc3-La3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.7530346464" sigma="0.3132399892981433" type="ionslm_iod_opc3-Ce3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.7276888530400001" sigma="0.3118145513491188" type="ionslm_iod_opc3-Pr3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.55575929744" sigma="0.3014801262186908" type="ionslm_iod_opc3-Nd3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.48867542632000005" sigma="0.29702563262798914" type="ionslm_iod_opc3-Sm3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.50965295632" sigma="0.2984510705770137" type="ionslm_iod_opc3-Eu3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.38639884336" sigma="0.2895420833956103" type="ionslm_iod_opc3-Gd3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.40484250112000003" sigma="0.2909675213446348" type="ionslm_iod_opc3-Tb3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.34886028824000004" sigma="0.2865130277539331" type="ionslm_iod_opc3-Dy3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_opc3-Er3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.33197918711999996" sigma="0.2850875898049086" type="ionslm_iod_opc3-Tm3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.29778189072" sigma="0.2820585341632314" type="ionslm_iod_opc3-Lu3+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.14921629320000002" sigma="0.26530963826219306" type="ionslm_iod_opc3-Hf4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.17386691496" sigma="0.2686950533911263" type="ionslm_iod_opc3-Zr4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6009964544" sigma="0.3043310021167399" type="ionslm_iod_opc3-Ce4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.6009964544" sigma="0.3043310021167399" type="ionslm_iod_opc3-U4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.52838869912" sigma="0.29969832878241015" type="ionslm_iod_opc3-Pu4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+    <Atom epsilon="0.63901700632" sigma="0.3066473387839048" type="ionslm_iod_opc3-Th4+"/><!--     IOD set for the OPC3 water model from Li et al., JCTC, 2021, 17, 2342 -->
+  </NonbondedForce>
+</ForceField>


### PR DESCRIPTION
This converts one-to-one all Amber ion frcmod files (from AmberTools 22) into OpenMM xml files with the same names and the same contents.  Implements what is proposed in #3663

Run the conversion:
```
python ./devtools/forcefield-scripts/processAmberIons.py ~/anaconda3/pkgs/ambertools-22.0-py38h6177452_1
```
(or path to wherever ambertools is installed)

There is a script that makes comparing the generated xml files with older xml files a bit easier:
```
python ./devtools/forcefield-scripts/diffIons.py wrappers/python/openmm/app/data/amber14/tip4pew.xml wrappers/python/openmm/app/data/ions/ionsjc_tip4pew.xml  
python ./devtools/forcefield-scripts/diffIons.py wrappers/python/openmm/app/data/amber14/tip4pew.xml wrappers/python/openmm/app/data/ions/ions234lm_126_tip4pew.xml  
```

As far as I can tell, aside from some changes in the names of residues used for heavy ions (where Amber itself is not perfectly consistent), this matches the old sets in any case in which the two overlap.

However, it also adds sets for OPC, OPC3, and a proper set for TIP3PFB (where it seems the old xml files use TIP3P parameters), as well as adding the iod and hfe sets, ions1lm_* sets, etc.

Usage:
```
forcefield = app.ForceField(
    'amber14-all.xml', 
    'opc3.xml', 
    'ions/ionslm_126_opc3.xml',
)

forcefield = app.ForceField(
    'amber14-all.xml', 
    'tip3pfb.xml', 
    'ions/ionslm_126_fb3.xml',
)
```

cc @zhang-ivy