### PR TITLE
Made `Atom` objects be hashed by values.

### DIFF
--- a/wrappers/python/openmm/app/topology.py
+++ b/wrappers/python/openmm/app/topology.py
@@ -463,6 +463,14 @@ class Atom(object):
         ## A user defined identifier for this Atom
         self.id = id
 
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        if isinstance(other, Atom):
+            return str(other) == str(self)
+        return False
+
     def __repr__(self):
         return "<Atom %d (%s) of chain %d residue %d (%s)>" % (self.index, self.name, self.residue.chain.index, self.residue.index, self.residue.name)
 


### PR DESCRIPTION
When an `Atom` object is copied, the copy should give the same hash. This is needed when `Atom` objects are used as dictionary keys, e.g., at here: https://github.com/openmm/openmm/blob/master/wrappers/python/openmm/app/pdbfile.py#L439