### PR TITLE
Fix #3790: Collision rate for MTS BAOAB Langevin integrator now correctly accounts for number of substeps

### DIFF
--- a/wrappers/python/openmm/mtsintegrator.py
+++ b/wrappers/python/openmm/mtsintegrator.py
@@ -167,8 +167,9 @@ class MTSLangevinIntegrator(CustomIntegrator):
         self.temperature = temperature
         self.friction = friction
         import math
-        self.addGlobalVariable("a", math.exp(-friction*dt))
-        self.addGlobalVariable("b", math.sqrt(1-math.exp(-2*friction*dt)))
+        total_substeps = math.prod( [group_size for (group_id, group_size) in groups] )
+        self.addGlobalVariable("a", math.exp(-friction*dt / total_substeps))
+        self.addGlobalVariable("b", math.sqrt(1-math.exp(-2*friction*dt / total_substeps)))
         from openmm.unit import MOLAR_GAS_CONSTANT_R
         self.addGlobalVariable('kT', MOLAR_GAS_CONSTANT_R*temperature)
         self.addPerDofVariable("x1", 0)

--- a/wrappers/python/openmm/mtsintegrator.py
+++ b/wrappers/python/openmm/mtsintegrator.py
@@ -167,7 +167,7 @@ class MTSLangevinIntegrator(CustomIntegrator):
         self.temperature = temperature
         self.friction = friction
         import math
-        total_substeps = math.prod( [group_size for (group_id, group_size) in groups] )
+        total_substeps = groups[-1][1]
         self.addGlobalVariable("a", math.exp(-friction*dt / total_substeps))
         self.addGlobalVariable("b", math.sqrt(1-math.exp(-2*friction*dt / total_substeps)))
         from openmm.unit import MOLAR_GAS_CONSTANT_R

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -165,10 +165,12 @@ class TestIntegrators(unittest.TestCase):
         initial_positions = [Vec3(0,0,0)]
         initial_velocities = [Vec3(1,0,0)]
         nsteps = 125 # number of steps to take
+        collision_rate = 1/picosecond
+        timestep = 4*femtoseconds
 
         def get_final_velocities(nsubsteps):
             """Get the final velocity vector after a fixed number of steps for the specified number of substeps"""
-            integrator = MTSLangevinIntegrator(0*kelvin, 1/picosecond, 4*femtoseconds, [(0,nsubsteps)])
+            integrator = MTSLangevinIntegrator(0*kelvin, collision_rate, timestep, [(0,nsubsteps)])
             context = Context(system, integrator, platform)
             context.setPositions(initial_positions)
             context.setVelocities(initial_velocity)
@@ -181,7 +183,7 @@ class TestIntegrators(unittest.TestCase):
         reference_velocities = get_final_velocities(1)
         for nsubsteps in range(2,6):
             mts_velocities = get_final_velocities(nsubsteps)
-            self.assertAlmostEqual(math.exp(-context.getTime()*friction), mts_velocities.x)
+            self.assertAlmostEqual(math.exp(-timestep*nsteps*collision_rate), mts_velocities.x)
             self.assertAlmostEqual(0, mts_velocities.y)
             self.assertAlmostEqual(0, mts_velocities.z)
 

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -161,7 +161,7 @@ class TestIntegrators(unittest.TestCase):
         # Create a System with a single particle and no forces
         system = System()
         system.addParticle(12.0*amu)
-        platform = Platform.GetPlatformByName('Reference')
+        platform = Platform.getPlatformByName('Reference')
         initial_positions = Vec3(0,0,0)
         initial_velocities = Vec3(1,0,0)
         nsteps = 125 # number of steps to take

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -143,7 +143,7 @@ class TestIntegrators(unittest.TestCase):
         context = Context(system, integrator)
         context.setPositions(pdb.positions)
         context.setVelocitiesToTemperature(300*kelvin)
-        integrator.step(500)
+        integrator.step(5000)
 
         # See if the temperature is correct.
         totalEnergy = 0*kilojoules_per_mole

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -137,7 +137,7 @@ class TestIntegrators(unittest.TestCase):
                 force.setForceGroup(0)
 
         # Create an integrator
-        integrator = MTSLangevinIntegrator(300*kelvin, 1/picosecond, 4*femtoseconds, [(2,1), (1,2), (0,4)])
+        integrator = MTSLangevinIntegrator(300*kelvin, 5/picosecond, 4*femtoseconds, [(2,1), (1,2), (0,4)])
 
         # Run some equilibration.
         context = Context(system, integrator)

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -143,7 +143,7 @@ class TestIntegrators(unittest.TestCase):
         context = Context(system, integrator)
         context.setPositions(pdb.positions)
         context.setVelocitiesToTemperature(300*kelvin)
-        integrator.step(5000)
+        integrator.step(500)
 
         # See if the temperature is correct.
         totalEnergy = 0*kilojoules_per_mole

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -168,7 +168,7 @@ class TestIntegrators(unittest.TestCase):
 
         def get_final_velocities(nsubsteps):
             """Get the final velocity vector after a fixed number of steps for the specified number of substeps"""
-            integrator = MTSLangevinIntegrator(0*kelvin, 1/picosecond, 4*femtoseconds, [(0,ngroups)])
+            integrator = MTSLangevinIntegrator(0*kelvin, 1/picosecond, 4*femtoseconds, [(0,nsubsteps)])
             context = Context(system, integrator, platform)
             context.setPositions(initial_positions)
             context.setVelocities(initial_velocity)

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -162,8 +162,8 @@ class TestIntegrators(unittest.TestCase):
         system = System()
         system.addParticle(12.0*amu)
         platform = Platform.getPlatformByName('Reference')
-        initial_positions = Vec3(0,0,0)
-        initial_velocities = Vec3(1,0,0)
+        initial_positions = [Vec3(0,0,0)]
+        initial_velocities = [Vec3(1,0,0)]
         nsteps = 125 # number of steps to take
 
         def get_final_velocities(nsubsteps):
@@ -181,9 +181,9 @@ class TestIntegrators(unittest.TestCase):
         reference_velocities = get_final_velocities(1)
         for nsubsteps in range(2,6):
             mts_velocities = get_final_velocities(nsubsteps)
-            self.assertAlmostEqual(reference_velocities.x, mts_velocities.x)
-            self.assertAlmostEqual(reference_velocities.y, mts_velocities.y)
-            self.assertAlmostEqual(reference_velocities.z, mts_velocities.z)
+            self.assertAlmostEqual(math.exp(-context.getTime()*friction), mts_velocities.x)
+            self.assertAlmostEqual(0, mts_velocities.y)
+            self.assertAlmostEqual(0, mts_velocities.z)
 
     def testNoseHooverIntegrator(self):
         """Test partial thermostating in the NoseHooverIntegrator (only API)"""

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -182,9 +182,9 @@ class TestIntegrators(unittest.TestCase):
         # Compare sub-stepped MTS with single-step MTS
         for nsubsteps in range(2,6):
             mts_velocities = get_final_velocities(nsubsteps)
-            self.assertAlmostEqual(math.exp(-timestep*nsteps*collision_rate), mts_velocities.x)
-            self.assertAlmostEqual(0, mts_velocities.y)
-            self.assertAlmostEqual(0, mts_velocities.z)
+            self.assertAlmostEqual(math.exp(-timestep*nsteps*collision_rate), mts_velocities[0].x)
+            self.assertAlmostEqual(0, mts_velocities[0].y)
+            self.assertAlmostEqual(0, mts_velocities[0].z)
 
     def testNoseHooverIntegrator(self):
         """Test partial thermostating in the NoseHooverIntegrator (only API)"""

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -173,14 +173,13 @@ class TestIntegrators(unittest.TestCase):
             integrator = MTSLangevinIntegrator(0*kelvin, collision_rate, timestep, [(0,nsubsteps)])
             context = Context(system, integrator, platform)
             context.setPositions(initial_positions)
-            context.setVelocities(initial_velocity)
+            context.setVelocities(initial_velocities)
             integrator.step(nsteps)
             final_velocities = context.getState(getVelocities=True).getVelocities()
             del context, integrator
             return final_velocities
 
         # Compare sub-stepped MTS with single-step MTS
-        reference_velocities = get_final_velocities(1)
         for nsubsteps in range(2,6):
             mts_velocities = get_final_velocities(nsubsteps)
             self.assertAlmostEqual(math.exp(-timestep*nsteps*collision_rate), mts_velocities.x)


### PR DESCRIPTION
Previously, `openmm.MTSLangevinIntegrator` would use an effective collision rate that is too large when there were multiple steps, since every substep used the outer timestep instead of the inner substep timestep to apply the friction.

This PR corrects this, using a fix suggested by Charlie Matthews (@c-matthews) in #3790.