### PR TITLE
Allow all MC barostats to scale constrainted atom groups

### DIFF
--- a/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
@@ -90,14 +90,16 @@ public:
     /**
      * Create a MonteCarloAnisotropicBarostat.
      *
-     * @param defaultPressure     The default pressure acting on each axis (in bar)
-     * @param defaultTemperature  the default temperature at which the system is being maintained (in Kelvin)
-     * @param scaleX              whether to allow the X dimension of the periodic box to change size
-     * @param scaleY              whether to allow the Y dimension of the periodic box to change size
-     * @param scaleZ              whether to allow the Z dimension of the periodic box to change size
-     * @param frequency           the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
+     * @param defaultPressure         The default pressure acting on each axis (in bar)
+     * @param defaultTemperature      the default temperature at which the system is being maintained (in Kelvin)
+     * @param scaleX                  whether to allow the X dimension of the periodic box to change size
+     * @param scaleY                  whether to allow the Y dimension of the periodic box to change size
+     * @param scaleZ                  whether to allow the Z dimension of the periodic box to change size
+     * @param frequency               the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
+     * @param scaleMoleculesAsRigid   if true, coordinate scaling keeps molecules rigid, scaling only the center of mass
+     *                                of each one. If false, every constrained atom group is scaled independently.
      */
-    MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double defaultTemperature, bool scaleX = true, bool scaleY = true, bool scaleZ = true, int frequency = 25);
+    MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double defaultTemperature, bool scaleX = true, bool scaleY = true, bool scaleZ = true, int frequency = 25, bool scaleMoleculesAsRigid = true);
     /**
      * Get the default pressure (in bar).
      *
@@ -186,16 +188,32 @@ public:
         return false;
     }
     /**
+     * Get whether scaling is applied to the centroid of each molecule while keeping
+     * the molecules rigid, or to each atom independently.
+     *
+     * @returns true if scaling is applied to molecule centroids, false if it is applied to each atom independently.
+     */
+    bool getScaleMoleculesAsRigid() const {
+        return scaleMoleculesAsRigid;
+    }
+    /**
+     * Set whether scaling is applied to the centroid of each molecule while keeping
+     * the molecules rigid, or to each atom independently.
+     */
+    void setScaleMoleculesAsRigid(bool rigid) {
+        scaleMoleculesAsRigid = rigid;
+    }
+    /**
      * Compute the instantaneous pressure along each axis of a system to which this barostat
      * is applied.
-     * 
+     *
      * The pressure is computed from the molecular virial, using a finite difference to
      * calculate the derivative of potential energy with respect to volume.  For most systems
      * in equilibrium, the time average of the instantaneous pressure should equal the
      * pressure applied by the barostat.  Fluctuations around the average value can be
      * extremely large, however, and it may take a very long simulation to accurately
      * compute the average.
-     * 
+     *
      * @param context    the Context for which to compute the current pressure
      * @returns a vector containing the pressure along each axis
      */
@@ -203,6 +221,7 @@ public:
 protected:
     ForceImpl* createImpl() const;
 private:
+    bool scaleMoleculesAsRigid;
     Vec3 defaultPressure;
     double defaultTemperature;
     bool scaleX, scaleY, scaleZ;

--- a/openmmapi/include/openmm/MonteCarloBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloBarostat.h
@@ -68,11 +68,13 @@ public:
     /**
      * Create a MonteCarloBarostat.
      *
-     * @param defaultPressure     the default pressure acting on the system (in bar)
-     * @param defaultTemperature  the default temperature at which the system is being maintained (in Kelvin)
-     * @param frequency           the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
+     * @param defaultPressure         the default pressure acting on the system (in bar)
+     * @param defaultTemperature      the default temperature at which the system is being maintained (in Kelvin)
+     * @param frequency               the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
+     * @param scaleMoleculesAsRigid   if true, coordinate scaling keeps molecules rigid, scaling only the center of mass
+     *                                of each one. If false, every constrained atom group is scaled independently.
      */
-    MonteCarloBarostat(double defaultPressure, double defaultTemperature, int frequency = 25);
+    MonteCarloBarostat(double defaultPressure, double defaultTemperature, int frequency = 25, bool scaleMoleculesAsRigid = true);
     /**
      * Get the default pressure acting on the system (in bar).
      *
@@ -143,15 +145,31 @@ public:
         return false;
     }
     /**
+     * Get whether scaling is applied to the centroid of each molecule while keeping
+     * the molecules rigid, or to each atom independently.
+     *
+     * @returns true if scaling is applied to molecule centroids, false if it is applied to each atom independently.
+     */
+    bool getScaleMoleculesAsRigid() const {
+        return scaleMoleculesAsRigid;
+    }
+    /**
+     * Set whether scaling is applied to the centroid of each molecule while keeping
+     * the molecules rigid, or to each atom independently.
+     */
+    void setScaleMoleculesAsRigid(bool rigid) {
+        scaleMoleculesAsRigid = rigid;
+    }
+    /**
      * Compute the instantaneous pressure of a system to which this barostat is applied.
-     * 
+     *
      * The pressure is computed from the molecular virial, using a finite difference to
      * calculate the derivative of potential energy with respect to volume.  For most systems
      * in equilibrium, the time average of the instantaneous pressure should equal the
      * pressure applied by the barostat.  Fluctuations around the average value can be
      * extremely large, however, and it may take a very long simulation to accurately
      * compute the average.
-     * 
+     *
      * @param context    the Context for which to compute the current pressure
      * @returns the instantaneous pressure
      */
@@ -159,6 +177,7 @@ public:
 protected:
     ForceImpl* createImpl() const;
 private:
+    bool scaleMoleculesAsRigid;
     double defaultPressure, defaultTemperature;
     int frequency, randomNumberSeed;
 };

--- a/openmmapi/include/openmm/MonteCarloFlexibleBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloFlexibleBarostat.h
@@ -83,7 +83,7 @@ public:
      * @param defaultTemperature      the default temperature at which the system is being maintained (in Kelvin)
      * @param frequency               the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
      * @param scaleMoleculesAsRigid   if true, coordinate scaling keeps molecules rigid, scaling only the center of mass
-     *                                of each one.  If false, every atom is scaled independently.
+     *                                of each one. If false, every constrained atom group is scaled independently.
      */
     MonteCarloFlexibleBarostat(double defaultPressure, double defaultTemperature, int frequency = 25, bool scaleMoleculesAsRigid = true);
     /**

--- a/openmmapi/include/openmm/MonteCarloMembraneBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloMembraneBarostat.h
@@ -121,14 +121,16 @@ public:
     /**
      * Create a MonteCarloMembraneBarostat.
      *
-     * @param defaultPressure        the default pressure acting on the system (in bar)
-     * @param defaultSurfaceTension  the default surface tension acting on the system (in bar*nm)
-     * @param defaultTemperature     the default temperature at which the system is being maintained (in Kelvin)
-     * @param xymode                 the mode specifying the behavior of the X and Y axes
-     * @param zmode                  the mode specifying the behavior of the Z axis
-     * @param frequency              the frequency at which Monte Carlo volume changes should be attempted (in time steps)
+     * @param defaultPressure         the default pressure acting on the system (in bar)
+     * @param defaultSurfaceTension   the default surface tension acting on the system (in bar*nm)
+     * @param defaultTemperature      the default temperature at which the system is being maintained (in Kelvin)
+     * @param xymode                  the mode specifying the behavior of the X and Y axes
+     * @param zmode                   the mode specifying the behavior of the Z axis
+     * @param frequency               the frequency at which Monte Carlo volume changes should be attempted (in time steps)
+     * @param scaleMoleculesAsRigid   if true, coordinate scaling keeps molecules rigid, scaling only the center of mass
+     *                                of each one. If false, every constrained atom group is scaled independently.
      */
-    MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double defaultTemperature, XYMode xymode, ZMode zmode, int frequency = 25);
+    MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double defaultTemperature, XYMode xymode, ZMode zmode, int frequency = 25, bool scaleMoleculesAsRigid = true);
     /**
      * Get the default pressure acting on the system (in bar).
      *
@@ -238,16 +240,32 @@ public:
         return false;
     }
     /**
+     * Get whether scaling is applied to the centroid of each molecule while keeping
+     * the molecules rigid, or to each atom independently.
+     *
+     * @returns true if scaling is applied to molecule centroids, false if it is applied to each atom independently.
+     */
+    bool getScaleMoleculesAsRigid() const {
+        return scaleMoleculesAsRigid;
+    }
+    /**
+     * Set whether scaling is applied to the centroid of each molecule while keeping
+     * the molecules rigid, or to each atom independently.
+     */
+    void setScaleMoleculesAsRigid(bool rigid) {
+        scaleMoleculesAsRigid = rigid;
+    }
+    /**
      * Compute the instantaneous pressure along each axis of a system to which this barostat
      * is applied.
-     * 
+     *
      * The pressure is computed from the molecular virial, using a finite difference to
      * calculate the derivative of potential energy with respect to volume.  For most systems
      * in equilibrium, the time average of the instantaneous pressure should equal the
      * pressure applied by the barostat.  Fluctuations around the average value can be
      * extremely large, however, and it may take a very long simulation to accurately
      * compute the average.
-     * 
+     *
      * @param context    the Context for which to compute the current pressure
      * @returns a vector containing the pressure along each axis
      */
@@ -255,6 +273,7 @@ public:
 protected:
     ForceImpl* createImpl() const;
 private:
+    bool scaleMoleculesAsRigid;
     double defaultPressure, defaultSurfaceTension, defaultTemperature;
     XYMode xymode;
     ZMode zmode;

--- a/openmmapi/include/openmm/internal/ContextImpl.h
+++ b/openmmapi/include/openmm/internal/ContextImpl.h
@@ -260,6 +260,11 @@ public:
      */
     const std::vector<std::vector<int> >& getMolecules() const;
     /**
+     * Get a list of the particles in each constained group in the system.  Two particles are in the
+     * same group if they are connected by constraints or virtual sites.
+     */
+    const std::vector<std::vector<int> >& getConstrainedGroups() const;
+    /**
      * Create a checkpoint recording the current state of the Context.
      * 
      * @param stream    an output stream the checkpoint data should be written to
@@ -313,7 +318,7 @@ private:
     Integrator& integrator;
     std::vector<ForceImpl*> forceImpls;
     std::map<std::string, double> parameters;
-    mutable std::vector<std::vector<int> > molecules;
+    mutable std::vector<std::vector<int> > molecules, constrainedGroups;
     bool hasInitializedForces, hasSetPositions, integratorIsDeleted, hasMinimizeKernel;
     int lastForceGroups;
     Platform* platform;

--- a/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
@@ -32,8 +32,8 @@
 
 using namespace OpenMM;
 
-MonteCarloAnisotropicBarostat::MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double defaultTemperature, bool scaleX, bool scaleY, bool scaleZ, int frequency) :
-        scaleX(scaleX), scaleY(scaleY), scaleZ(scaleZ) {
+MonteCarloAnisotropicBarostat::MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double defaultTemperature, bool scaleX, bool scaleY, bool scaleZ, int frequency, bool scaleMoleculesAsRigid) :
+        scaleX(scaleX), scaleY(scaleY), scaleZ(scaleZ), scaleMoleculesAsRigid(scaleMoleculesAsRigid) {
     setDefaultPressure(defaultPressure);
     setDefaultTemperature(defaultTemperature);
     setFrequency(frequency);

--- a/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
@@ -48,7 +48,7 @@ void MonteCarloAnisotropicBarostatImpl::initialize(ContextImpl& context) {
     if (!context.getSystem().usesPeriodicBoundaryConditions())
         throw OpenMMException("A barostat cannot be used with a non-periodic system");
     kernel = context.getPlatform().createKernel(ApplyMonteCarloBarostatKernel::Name(), context);
-    kernel.getAs<ApplyMonteCarloBarostatKernel>().initialize(context.getSystem(), owner, 3);
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().initialize(context.getSystem(), owner, 3, owner.getScaleMoleculesAsRigid());
     Vec3 box[3];
     context.getPeriodicBoxVectors(box[0], box[1], box[2]);
     double volume = box[0][0]*box[1][1]*box[2][2];
@@ -112,10 +112,15 @@ void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context,
     kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, lengthScale[0], lengthScale[1], lengthScale[2]);
 
     // Compute the energy of the modified system.
-    
+
+    double numberOfScaledParticles;
+    if (owner.getScaleMoleculesAsRigid())
+        numberOfScaledParticles = context.getMolecules().size();
+    else
+        numberOfScaledParticles = context.getConstrainedGroups().size();
     double finalEnergy = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
     double kT = BOLTZ*context.getParameter(MonteCarloAnisotropicBarostat::Temperature());
-    double w = finalEnergy-initialEnergy + pressure*deltaVolume - context.getMolecules().size()*kT*log(newVolume/volume);
+    double w = finalEnergy-initialEnergy + pressure*deltaVolume - numberOfScaledParticles*kT*log(newVolume/volume);
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
         

--- a/openmmapi/src/MonteCarloBarostat.cpp
+++ b/openmmapi/src/MonteCarloBarostat.cpp
@@ -34,7 +34,7 @@
 
 using namespace OpenMM;
 
-MonteCarloBarostat::MonteCarloBarostat(double defaultPressure, double defaultTemperature, int frequency) {
+MonteCarloBarostat::MonteCarloBarostat(double defaultPressure, double defaultTemperature, int frequency, bool scaleMoleculesAsRigid) : scaleMoleculesAsRigid(scaleMoleculesAsRigid) {
     setDefaultPressure(defaultPressure);
     setDefaultTemperature(defaultTemperature);
     setFrequency(frequency);

--- a/openmmapi/src/MonteCarloBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloBarostatImpl.cpp
@@ -48,7 +48,7 @@ void MonteCarloBarostatImpl::initialize(ContextImpl& context) {
     if (!context.getSystem().usesPeriodicBoundaryConditions())
         throw OpenMMException("A barostat cannot be used with a non-periodic system");
     kernel = context.getPlatform().createKernel(ApplyMonteCarloBarostatKernel::Name(), context);
-    kernel.getAs<ApplyMonteCarloBarostatKernel>().initialize(context.getSystem(), owner, 1);
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().initialize(context.getSystem(), owner, 1, owner.getScaleMoleculesAsRigid());
     Vec3 box[3];
     context.getPeriodicBoxVectors(box[0], box[1], box[2]);
     double volume = box[0][0]*box[1][1]*box[2][2];
@@ -81,11 +81,16 @@ void MonteCarloBarostatImpl::updateContextState(ContextImpl& context, bool& forc
     kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, lengthScale, lengthScale, lengthScale);
 
     // Compute the energy of the modified system.
-    
+
+    double numberOfScaledParticles;
+    if (owner.getScaleMoleculesAsRigid())
+        numberOfScaledParticles = context.getMolecules().size();
+    else
+        numberOfScaledParticles = context.getConstrainedGroups().size();
     double finalEnergy = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
     double pressure = context.getParameter(MonteCarloBarostat::Pressure())*(AVOGADRO*1e-25);
     double kT = BOLTZ*context.getParameter(MonteCarloBarostat::Temperature());
-    double w = finalEnergy-initialEnergy + pressure*deltaVolume - context.getMolecules().size()*kT*log(newVolume/volume);
+    double w = finalEnergy-initialEnergy + pressure*deltaVolume - numberOfScaledParticles*kT*log(newVolume/volume);
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
 

--- a/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
@@ -103,7 +103,7 @@ void MonteCarloFlexibleBarostatImpl::updateContextState(ContextImpl& context, bo
     if (owner.getScaleMoleculesAsRigid())
         numberOfScaledParticles = context.getMolecules().size();
     else
-        numberOfScaledParticles = context.getSystem().getNumParticles();
+        numberOfScaledParticles = context.getConstrainedGroups().size();
     double finalEnergy = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
     double kT = BOLTZ*context.getParameter(MonteCarloFlexibleBarostat::Temperature());
     double w0 = finalEnergy-initialEnergy;

--- a/openmmapi/src/MonteCarloMembraneBarostat.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostat.cpp
@@ -32,8 +32,8 @@
 
 using namespace OpenMM;
 
-MonteCarloMembraneBarostat::MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double defaultTemperature, XYMode xymode, ZMode zmode, int frequency) :
-        xymode(xymode), zmode(zmode) {
+MonteCarloMembraneBarostat::MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double defaultTemperature, XYMode xymode, ZMode zmode, int frequency, bool scaleMoleculesAsRigid) :
+        xymode(xymode), zmode(zmode), scaleMoleculesAsRigid(scaleMoleculesAsRigid) {
     setDefaultPressure(defaultPressure);
     setDefaultSurfaceTension(defaultSurfaceTension);
     setDefaultTemperature(defaultTemperature);

--- a/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
@@ -48,7 +48,7 @@ void MonteCarloMembraneBarostatImpl::initialize(ContextImpl& context) {
     if (!context.getSystem().usesPeriodicBoundaryConditions())
         throw OpenMMException("A barostat cannot be used with a non-periodic system");
     kernel = context.getPlatform().createKernel(ApplyMonteCarloBarostatKernel::Name(), context);
-    kernel.getAs<ApplyMonteCarloBarostatKernel>().initialize(context.getSystem(), owner, 3);
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().initialize(context.getSystem(), owner, 3, owner.getScaleMoleculesAsRigid());
     Vec3 box[3];
     context.getPeriodicBoxVectors(box[0], box[1], box[2]);
     double volume = box[0][0]*box[1][1]*box[2][2];
@@ -114,9 +114,14 @@ void MonteCarloMembraneBarostatImpl::updateContextState(ContextImpl& context, bo
 
     // Compute the energy of the modified system.
 
+    double numberOfScaledParticles;
+    if (owner.getScaleMoleculesAsRigid())
+        numberOfScaledParticles = context.getMolecules().size();
+    else
+        numberOfScaledParticles = context.getConstrainedGroups().size();
     double finalEnergy = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
     double kT = BOLTZ*context.getParameter(MonteCarloMembraneBarostat::Temperature());
-    double w = finalEnergy-initialEnergy + pressure*deltaVolume - tension*deltaArea - context.getMolecules().size()*kT*log(newVolume/volume);
+    double w = finalEnergy-initialEnergy + pressure*deltaVolume - tension*deltaArea - numberOfScaledParticles*kT*log(newVolume/volume);
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
         

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -4291,9 +4291,7 @@ void CommonApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& context) 
         if (rigidMolecules)
             molecules = context.getMolecules();
         else {
-            molecules.resize(cc.getNumAtoms());
-            for (int i = 0; i < molecules.size(); i++)
-                molecules[i].push_back(i);
+            molecules = context.getConstrainedGroups();
         }
         numMolecules = molecules.size();
         moleculeAtoms.initialize<int>(cc, cc.getNumAtoms(), "moleculeAtoms");

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -3316,10 +3316,7 @@ void ReferenceApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& contex
         if (rigidMolecules)
             barostat = new ReferenceMonteCarloBarostat(system.getNumParticles(), context.getMolecules(), masses);
         else {
-            vector<vector<int> > molecules(system.getNumParticles());
-            for (int i = 0; i < molecules.size(); i++)
-                molecules[i].push_back(i);
-            barostat = new ReferenceMonteCarloBarostat(system.getNumParticles(), molecules, masses);
+            barostat = new ReferenceMonteCarloBarostat(system.getNumParticles(), context.getConstrainedGroups(), masses);
         }
     }
     vector<Vec3>& posData = extractPositions(context);

--- a/tests/TestMonteCarloBarostat.h
+++ b/tests/TestMonteCarloBarostat.h
@@ -31,6 +31,7 @@
 #include "openmm/MonteCarloBarostat.h"
 #include "openmm/Context.h"
 #include "openmm/HarmonicBondForce.h"
+#include "openmm/HarmonicAngleForce.h"
 #include "openmm/NonbondedForce.h"
 #include "openmm/System.h"
 #include "openmm/LangevinIntegrator.h"
@@ -197,6 +198,99 @@ void testMolecularGas() {
     }
     avgPressure /= steps;
     ASSERT_USUALLY_EQUAL_TOL(pressure, avgPressure, 0.1);
+}
+
+void testIdealMolecularGas()
+{
+    const int numMolecules = 64;
+    const int frequency = 10;
+    const int steps = 10000;
+    const double pressure = 1.5;
+    const double pressureInMD = pressure * (AVOGADRO * 1e-25); // pressure in kJ/mol/nm^3
+    const double temp[] = {300.0, 600.0};
+    const double initialVolume = numMolecules * BOLTZ * temp[1] / pressureInMD;
+    const double initialLength = std::pow(initialVolume, 1.0 / 3.0);
+
+    // Create a gas of non-interacting molecules.
+    // Each molecule contains three carbon atoms bonded in sequence.
+    // Two bonds have length of 0.15 nm. The first bond is constrained. The angle is 120 degree.
+
+    System system;
+    system.setDefaultPeriodicBoxVectors(Vec3(initialLength, 0, 0), Vec3(0, 0.5 * initialLength, 0), Vec3(0, 0, 2 * initialLength));
+    vector<Vec3> positions(numMolecules * 3);
+    OpenMM_SFMT::SFMT sfmt;
+    init_gen_rand(0, sfmt);
+    for (int i = 0; i < numMolecules; ++i)
+    {
+        system.addParticle(12.0);
+        positions[i * 3] = Vec3(initialLength * genrand_real2(sfmt), 0.5 * initialLength * genrand_real2(sfmt), 2 * initialLength * genrand_real2(sfmt));
+        system.addParticle(12.0);
+        positions[i * 3 + 1] = positions[i * 3] + Vec3(0.15, 0.0, 0.0);
+        system.addParticle(12.0);
+        positions[i * 3 + 2] = positions[i * 3] + Vec3(0.225, 0.130, 0.0);
+    }
+
+    HarmonicBondForce *bonds = new HarmonicBondForce();
+    bonds->setUsesPeriodicBoundaryConditions(true);
+    system.addForce(bonds);
+    HarmonicAngleForce *angles = new HarmonicAngleForce();
+    angles->setUsesPeriodicBoundaryConditions(true);
+    system.addForce(angles);
+    for (int i = 0; i < numMolecules; ++i)
+    {
+        system.addConstraint(i * 3, i * 3 + 1, 0.15);
+        bonds->addBond(i * 3 + 1, i * 3 + 2, 0.15, 50000.0);
+        angles->addAngle(i * 3, i * 3 + 1, i * 3 + 2, 120.0 / 180.0 * PI_M, 100.0);
+    }
+
+    // Test it for two scaling modes and two different temperatures.
+
+    for (int k = 0; k < 2; k++)
+    {
+        MonteCarloBarostat *barostat;
+        if (k == 0)
+        {
+            printf("Molecules scaled\n");
+            barostat = new MonteCarloBarostat(pressure, temp[0], frequency, true);
+        }
+        else
+        {
+            printf("Constrained groups scaled\n");
+            barostat = new MonteCarloBarostat(pressure, temp[0], frequency, false);
+        }
+        system.addForce(barostat);
+
+        for (int i = 0; i < 2; i++)
+        {
+            printf("Temperature = %f\n", temp[i]);
+            barostat->setDefaultTemperature(temp[i]);
+            LangevinIntegrator integrator(temp[i], 1.0, 0.004);
+            Context context(system, integrator, platform);
+            context.setPositions(positions);
+
+            // Let it equilibrate.
+
+            integrator.step(10000);
+
+            // Now run it for a while and see if the volume is correct.
+
+            double volume = 0.0;
+            for (int j = 0; j < steps; ++j)
+            {
+                Vec3 box[3];
+                context.getState(0).getPeriodicBoxVectors(box[0], box[1], box[2]);
+                // printf("%f\n", box[0][0] * box[1][1] * box[2][2]);
+                volume += box[0][0] * box[1][1] * box[2][2];
+                ASSERT_EQUAL_TOL(0.5 * box[0][0], box[1][1], 1e-5);
+                ASSERT_EQUAL_TOL(2 * box[0][0], box[2][2], 1e-5);
+                integrator.step(frequency);
+            }
+            volume /= steps;
+            double expected = (numMolecules + 1) * BOLTZ * temp[i] / pressureInMD;
+            ASSERT_USUALLY_EQUAL_TOL(expected, volume, 3 / std::sqrt((double)steps));
+        }
+        system.removeForce(system.getNumForces() - 1);
+    }
 }
 
 void testRandomSeed() {
@@ -382,6 +476,7 @@ int main(int argc, char* argv[]) {
         testChangingBoxSize();
         testIdealGas();
         testMolecularGas();
+        testIdealMolecularGas();
         testRandomSeed();
         // Don't run testWater() or testLJPressure() here, because they're very slow on
         // Reference platform.  Individual platforms can run them from runPlatformTests().


### PR DESCRIPTION
This pull request addresses issue #3723. In the discussion, there are two approaches: 1) scale all atoms independently and then apply constraints; 2) scale constrained atom groups directly. This pull request implements the second method because it's more efficient and it's sufficient to meet most cases I can imagine.

An argument `scaleMoleculesAsRigid=true` is added to all MC barostats. When set to `false`, the barostat scaling will be performed on the center of constrained atom groups, instead of molecules. The default behavior is the same as the current.

It is mainly useful for systems containing only a few molecules, e.g. covalent crystals, cross-linked polymers, etc...

The current `MonteCarloFlexibleBarostat` already has this argument. However, it doesn't respect constraints. It is also fixed in this pull request.

