### PR TITLE
Minor spelling nit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,4 +24,4 @@ The core developers will review the pull request and may suggest changes.  Simpl
 changes to the branch that is being pulled from, and they will automatically be added to the
 pull request.  In addition, the full test suite is automatically run on every pull request,
 and rerun every time a change is added.  Once the tests are passing and everyone is satisfied
-with the code, the pull request will be merged.  Congratulations on a succesful contribution!
+with the code, the pull request will be merged.  Congratulations on a successful contribution!


### PR DESCRIPTION
I just encountered this while reading through the contributing guidelines, and thought it might be important to fix since it's public documentation. I have a bad habit of pointing out typos, so for less important cases like typos in source code comments I probably won't make a PR.

If this is discouraged because it triggers integration tests, please let me know so I can avoid repeating something similar in the future.