### PR TITLE
Initialize pinnedBuffer at OpenCLContext creation

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -79,7 +79,7 @@ static bool isSupported(cl::Platform platform) {
 
 OpenCLContext::OpenCLContext(const System& system, int platformIndex, int deviceIndex, const string& precision, OpenCLPlatform::PlatformData& platformData, OpenCLContext* originalContext) :
         ComputeContext(system), platformData(platformData), numForceBuffers(0), hasAssignedPosqCharges(false),
-        integration(NULL), expression(NULL), bonded(NULL), nonbonded(NULL) {
+        integration(NULL), expression(NULL), bonded(NULL), nonbonded(NULL), pinnedBuffer(NULL) {
     if (precision == "single") {
         useDoublePrecision = false;
         useMixedPrecision = false;


### PR DESCRIPTION
This initialization is needed to prevent segfault during object destruction in certain circumstances (e.g., when a `Force` is changed before calling `Context.reinitialize()` and this change causes the corresponding `ForceImpl` to throw an exception).