### PR TITLE
Remove checks for negative pressure

### DIFF
--- a/openmmapi/src/MonteCarloBarostat.cpp
+++ b/openmmapi/src/MonteCarloBarostat.cpp
@@ -44,8 +44,6 @@ MonteCarloBarostat::MonteCarloBarostat(double defaultPressure, double defaultTem
 }
 
 void MonteCarloBarostat::setDefaultPressure(double pressure) {
-    if (pressure < 0)
-        throw OpenMMException("Pressure cannot be negative");
     defaultPressure = pressure;
 }
 

--- a/openmmapi/src/MonteCarloFlexibleBarostat.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostat.cpp
@@ -43,8 +43,6 @@ MonteCarloFlexibleBarostat::MonteCarloFlexibleBarostat(double defaultPressure, d
 }
 
 void MonteCarloFlexibleBarostat::setDefaultPressure(double pressure) {
-    if (pressure < 0)
-        throw OpenMMException("Pressure cannot be negative");
     defaultPressure = pressure;
 }
 

--- a/openmmapi/src/MonteCarloMembraneBarostat.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostat.cpp
@@ -44,8 +44,6 @@ MonteCarloMembraneBarostat::MonteCarloMembraneBarostat(double defaultPressure, d
 }
 
 void MonteCarloMembraneBarostat::setDefaultPressure(double pressure) {
-    if (pressure < 0)
-        throw OpenMMException("Pressure cannot be negative");
     defaultPressure = pressure;
 }
 

--- a/plugins/rpmd/openmmapi/src/RPMDMonteCarloBarostat.cpp
+++ b/plugins/rpmd/openmmapi/src/RPMDMonteCarloBarostat.cpp
@@ -41,8 +41,6 @@ RPMDMonteCarloBarostat::RPMDMonteCarloBarostat(double defaultPressure, int frequ
 }
 
 void RPMDMonteCarloBarostat::setDefaultPressure(double pressure) {
-    if (pressure < 0)
-        throw OpenMMException("Pressure cannot be negative");
     defaultPressure = pressure;
 }
 


### PR DESCRIPTION
Negative pressure is well defined and can be useful.  I got a report from someone that this check broke their workflow.