### PR TITLE
Avoid pointer aliasing issues in Lepton library by memcpy()

### DIFF
--- a/libraries/lepton/src/CompiledExpression.cpp
+++ b/libraries/lepton/src/CompiledExpression.cpp
@@ -32,6 +32,7 @@
 #include "lepton/CompiledExpression.h"
 #include "lepton/Operation.h"
 #include "lepton/ParsedExpression.h"
+#include <cstring>
 #include <utility>
 
 using namespace Lepton;
@@ -547,7 +548,7 @@ void CompiledExpression::generateJitCode() {
         // Find the constant value (if any) used by this operation.
         
         Operation& op = *operation[step];
-        double value;
+        double value = 0.0;
         if (op.getId() == Operation::CONSTANT)
             value = dynamic_cast<Operation::Constant&>(op).getValue();
         else if (op.getId() == Operation::ADD_CONSTANT)
@@ -562,7 +563,7 @@ void CompiledExpression::generateJitCode() {
             value = 1.0;
         else if (op.getId() == Operation::ABS) {
             long long mask = 0x7FFFFFFFFFFFFFFF;
-            value = *reinterpret_cast<double*>(&mask);
+            memcpy(&value, &mask, sizeof(mask));
         }
         else if (op.getId() == Operation::POWER_CONSTANT) {
             if (stepGroup[step] == -1)

--- a/libraries/lepton/src/CompiledVectorExpression.cpp
+++ b/libraries/lepton/src/CompiledVectorExpression.cpp
@@ -33,6 +33,7 @@
 #include "lepton/Operation.h"
 #include "lepton/ParsedExpression.h"
 #include <algorithm>
+#include <cstring>
 #include <utility>
 
 using namespace Lepton;
@@ -610,7 +611,7 @@ void CompiledVectorExpression::generateJitCode() {
         // Find the constant value (if any) used by this operation.
 
         Operation& op = *operation[step];
-        double value;
+        double value = 0.0;
         if (op.getId() == Operation::CONSTANT)
             value = dynamic_cast<Operation::Constant&> (op).getValue();
         else if (op.getId() == Operation::ADD_CONSTANT)
@@ -625,7 +626,7 @@ void CompiledVectorExpression::generateJitCode() {
             value = 1.0;
         else if (op.getId() == Operation::ABS) {
             int mask = 0x7FFFFFFF;
-            value = *reinterpret_cast<float*>(&mask);
+            memcpy(&value, &mask, sizeof(mask));
         }
         else if (op.getId() == Operation::POWER_CONSTANT) {
             if (stepGroup[step] == -1)


### PR DESCRIPTION
Casting an integer pointer to a floating point pointer and vice versa violates ANSI C++ aliasing rules and can produce miscompiled code with compilers that assume strict aliasing rules. In LAMMPS we've been able to avoid this by using a union. This applies the same kind of change to two such cases found in the Lepton library.