### PR TITLE
Minimizer does not move constrained massless particles

### DIFF
--- a/openmmapi/src/LocalEnergyMinimizer.cpp
+++ b/openmmapi/src/LocalEnergyMinimizer.cpp
@@ -137,12 +137,16 @@ static lbfgsfloatval_t evaluate(void *instance, const lbfgsfloatval_t *x, lbfgsf
         double dr = r-distance;
         double kdr = k*dr;
         energy += 0.5*kdr*dr;
-        g[3*particle1] -= kdr*delta[0];
-        g[3*particle1+1] -= kdr*delta[1];
-        g[3*particle1+2] -= kdr*delta[2];
-        g[3*particle2] += kdr*delta[0];
-        g[3*particle2+1] += kdr*delta[1];
-        g[3*particle2+2] += kdr*delta[2];
+        if (system.getParticleMass(particle1) != 0) {
+            g[3*particle1] -= kdr*delta[0];
+            g[3*particle1+1] -= kdr*delta[1];
+            g[3*particle1+2] -= kdr*delta[2];
+        }
+        if (system.getParticleMass(particle2) != 0) {
+            g[3*particle2] += kdr*delta[0];
+            g[3*particle2+1] += kdr*delta[1];
+            g[3*particle2+2] += kdr*delta[2];
+        }
     }
     return energy;
 }


### PR DESCRIPTION
Fixes #3884.  This addresses an obscure situation.  Normally we don't allow a constraint to involve a massless particle.  But if both particles connected by a constraint are massless we do allow it, since the constraint will just be ignored.  That makes it easy to immobilize whole molecules without worrying about what constraints they contain.  In that situation, the minimizer was incorrectly enforcing the constraint rather than ignoring it.