### PR TITLE
Fix SIMD width and force thread blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 build
 build?
+
+# macOS
+.DS_Store

--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -211,7 +211,15 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
             throw OpenMMException("This device does not support double precision");
         string vendor = device.getInfo<CL_DEVICE_VENDOR>();
         int numThreadBlocksPerComputeUnit = 6;
-        if (vendor.size() >= 6 && vendor.substr(0, 6) == "NVIDIA") {
+        
+        if (vendor.size() >= 5 && vendor.substr(0, 5) == "Apple") {
+            simdWidth = 32;
+            
+            // TODO: Vary threadgroups/core based on number of cores and/or simulation size.
+            // Some workloads perform better with <6, others perform better with >6.
+//            numThreadBlocksPerComputeUnit = 12;
+        }
+        else if (vendor.size() >= 6 && vendor.substr(0, 6) == "NVIDIA") {
             compilationDefines["WARPS_ARE_ATOMIC"] = "";
             simdWidth = 32;
             if (device.getInfo<CL_DEVICE_EXTENSIONS>().find("cl_nv_device_attribute_query") != string::npos) {
@@ -276,6 +284,7 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
         }
         else
             simdWidth = 1;
+    
         if (supports64BitGlobalAtomics)
             compilationDefines["SUPPORTS_64_BIT_ATOMICS"] = "";
         if (supportsDoublePrecision)

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -65,8 +65,14 @@ OpenCLNonbondedUtilities::OpenCLNonbondedUtilities(OpenCLContext& context) : con
         forceThreadBlockSize = 1;
     }
     else if (context.getSIMDWidth() == 32) {
-            numForceThreadBlocks = 4*context.getDevice().getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
-            forceThreadBlockSize = 256;
+        string vendor = context.getDevice().getInfo<CL_DEVICE_VENDOR>();
+        int blocksPerCore = 4;
+        if (vendor.size() >= 5 && vendor.substr(0, 5) == "Apple") {
+            // Allocate 768 threads/core, a magic number regarding ALU utilization.
+            blocksPerCore = 3;
+        }
+        numForceThreadBlocks = blocksPerCore*context.getDevice().getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
+        forceThreadBlockSize = 256;
     }
     else {
         numForceThreadBlocks = context.getNumThreadBlocks();


### PR DESCRIPTION
Cherry picked optimizations from https://github.com/openmm/openmm/pull/3911 which are strongly confirmed by evidence.

#### Fix SIMD width

Set the proper SIMD width, which boosts apoa1rf performance from 38 ns/day to 103 ns/day (+171%).

#### Fix force thread blocks

Changing force thread blocks only increases performance in every benchmark. There are twin maxima at 768 and 1536 threads/core, except GBSA (only 768 threads/core). This boosts apoa1rf to 109 ns/day (+6%).

[OpenMM ForceThreadBlocks Tests.xlsx](https://github.com/openmm/openmm/files/10431103/OpenMM.ForceThreadBlocks.Tests.xlsx)

#### Not implemented

apoa1rf could reach 113 ns/day (+4%) if we change generic thread blocks from 384 to 768 threads/core. That doesn't harm GBSA, but GBSA's maximum is at 192 threads/core. We defer dealing with that disparity to another PR.
