### PR TITLE
Fixed errors in Python wrapper for AmoebaVdwForce

### DIFF
--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -300,8 +300,8 @@ UNITS = {
 ("AmoebaVdwForce",                        "getSoftcoreAlpha")                              :  ( None, ()),
 ("AmoebaVdwForce",                        "getCutoff")                                     :  ( 'unit.nanometer', ()),
 ("AmoebaVdwForce",                        "getParticleParameters")                         :  ( None, (None, 'unit.nanometer', 'unit.kilojoule_per_mole', None, None, None)),
-("AmoebaVdwForce",                        "getParticleTypeParameters")                     :  ( None, (None, 'unit.nanometer', 'unit.kilojoule_per_mole')),
-("AmoebaVdwForce",                        "getTypePairParameters")                         :  ( None, (None, None, None, 'unit.nanometer', 'unit.kilojoule_per_mole')),
+("AmoebaVdwForce",                        "getParticleTypeParameters")                     :  ( None, ('unit.nanometer', 'unit.kilojoule_per_mole')),
+("AmoebaVdwForce",                        "getTypePairParameters")                         :  ( None, (None, None, 'unit.nanometer', 'unit.kilojoule_per_mole')),
 
 ("AmoebaWcaDispersionForce",              "getParticleParameters")                         :  ( None, ('unit.nanometer', 'unit.kilojoule_per_mole')),
 ("AmoebaWcaDispersionForce",              "getAwater")                                     :  ( '1/(unit.nanometer*unit.nanometer*unit.nanometer)',()),


### PR DESCRIPTION
Fixes #3921.  If you called `getParticleTypeParameters()` or `getTypePairParameters()`, it would throw an exception due to the number of return values being specified incorrectly.