### PR TITLE
Add support for writing atom subsets to PDBReporter

### DIFF
--- a/wrappers/python/openmm/app/pdbreporter.py
+++ b/wrappers/python/openmm/app/pdbreporter.py
@@ -130,16 +130,22 @@ class PDBReporter(object):
         """
         # check atomSubset is valid 
         if len(self._atomSubset) == 0:
+            self._out.close()
             raise ValueError('atomSubset cannot be an empty list')
         if not all(a == int(a) for a in self._atomSubset):
+            self._out.close()
             raise ValueError('all of the indices in atomSubset must be integers')
         if len(set(self._atomSubset)) != len(self._atomSubset):
+            self._out.close()
             raise ValueError('atomSubset must contain unique indices')
         if sorted(self._atomSubset) != self._atomSubset:
+            self._out.close()
             raise ValueError('atomSubset must be sorted in ascending order')
         if self._atomSubset[0] < 0:
+            self._out.close()
             raise ValueError('The smallest allowed value in atomSubset is zero')
         if self._atomSubset[-1] >= topology.getNumAtoms():
+            self._out.close()
             raise ValueError('The maximum allowed value in atomSubset must be less than the total number of particles')
         
         self._subsetTopology = Topology()

--- a/wrappers/python/openmm/app/pdbreporter.py
+++ b/wrappers/python/openmm/app/pdbreporter.py
@@ -32,7 +32,8 @@ from __future__ import absolute_import
 __author__ = "Peter Eastman"
 __version__ = "1.0"
 
-from openmm.app import PDBFile, PDBxFile
+from openmm.app import PDBFile, PDBxFile, Topology
+from openmm.unit import nanometers, Quantity
 
 class PDBReporter(object):
     """PDBReporter outputs a series of frames from a Simulation to a PDB file.
@@ -40,7 +41,7 @@ class PDBReporter(object):
     To use it, create a PDBReporter, then add it to the Simulation's list of reporters.
     """
 
-    def __init__(self, file, reportInterval, enforcePeriodicBox=None):
+    def __init__(self, file, reportInterval, enforcePeriodicBox=None, atomSubset=None):
         """Create a PDBReporter.
 
         Parameters
@@ -54,12 +55,15 @@ class PDBReporter(object):
             lies in the same periodic box.  If None (the default), it will automatically decide whether
             to translate molecules based on whether the system being simulated uses periodic boundary
             conditions.
+        atomSubset: list
+            Atom indices (zero indexed) of the particles to output. if None (the default), all particles will be output.
         """
         self._reportInterval = reportInterval
         self._enforcePeriodicBox = enforcePeriodicBox
         self._out = open(file, 'w')
         self._topology = None
         self._nextModel = 0
+        self._atomSubset = atomSubset
 
     def describeNextReport(self, simulation):
         """Get information about the next report this object will generate.
@@ -91,11 +95,27 @@ class PDBReporter(object):
         state : State
             The current state of the simulation
         """
+        if self._atomSubset is not None:
+            if not all(a==int(a) for a in self._atomSubset):
+                raise ValueError('all of the indices in atomSubset must be integers')
+            if min(self._atomSubset) < 0:
+                raise ValueError('The smallest allowed value in atomSubset is zero')
+            if max(self._atomSubset) >= simulation.topology.getNumAtoms():
+                raise ValueError('The maximum allowed value in atomSubset must be less than the total number of particles')
+            if len(set(self._atomSubset)) != len(self._atomSubset):
+                raise ValueError('atomSubset must contain unique indices')
+
+            topology = _subsetTopology(simulation.topology, self._atomSubset)
+            positions = _subsetPositions(state.getPositions(), self._atomSubset)
+        else:
+            topology = simulation.topology
+            positions = state.getPositions()
+
         if self._nextModel == 0:
-            PDBFile.writeHeader(simulation.topology, self._out)
-            self._topology = simulation.topology
+            PDBFile.writeHeader(topology, self._out)
+            self._topology = topology
             self._nextModel += 1
-        PDBFile.writeModel(simulation.topology, state.getPositions(), self._out, self._nextModel)
+        PDBFile.writeModel(topology, positions, self._out, self._nextModel)
         self._nextModel += 1
         if hasattr(self._out, 'flush') and callable(self._out.flush):
             self._out.flush()
@@ -131,3 +151,54 @@ class PDBxReporter(PDBReporter):
 
     def __del__(self):
         self._out.close()
+
+def _subsetPositions(positions, atomSubset):
+    """Create a subset of the positions
+
+    Parameters
+    ----------
+    positions : list
+        The positions
+    atomSubset : list
+        The list of atomic indices in the subset
+
+    Returns
+    -------
+    subsetPositions : list
+        A subset of the input positions that only contains the atoms
+        specified in atomSubset.
+    """
+
+    return Quantity([positions[i].value_in_unit(nanometers) for i in atomSubset], unit=nanometers)
+
+    
+def _subsetTopology(topology, atomSubset):
+    """Create a subset of an existing topology.
+
+    Parameters
+    ----------
+    topology : Topology
+        The Topology to create a subset from
+    atomSubset : list
+        The list of atomic indices in the subset
+
+    Returns
+    -------
+    subsetTopology : Topology
+        A new Topology copied from the input topology that only contains the atoms
+        specified in atomSubset.
+    """
+    subsetTopology = Topology()
+
+    posIndex = 0
+    for chain in topology.chains():
+        c = subsetTopology.addChain(chain.id)
+        residues = list(chain.residues())
+        for res in residues:
+            r = subsetTopology.addResidue(res.name,c,res.id,res.insertionCode)
+            for atom in res.atoms():
+                    if posIndex in atomSubset:
+                        atom = subsetTopology.addAtom(atom.name, atom.element, r, atom.id)
+                    posIndex += 1
+
+    return subsetTopology

--- a/wrappers/python/openmm/app/pdbreporter.py
+++ b/wrappers/python/openmm/app/pdbreporter.py
@@ -129,9 +129,9 @@ class PDBReporter(object):
             The Topology to create a subset from
         """
         # check atomSubset is valid 
-        if len(self._atomSubset)==0:
+        if len(self._atomSubset) == 0:
             raise ValueError('atomSubset cannot be an empty list')
-        if not all(a==int(a) for a in self._atomSubset):
+        if not all(a == int(a) for a in self._atomSubset):
             raise ValueError('all of the indices in atomSubset must be integers')
         if len(set(self._atomSubset)) != len(self._atomSubset):
             raise ValueError('atomSubset must contain unique indices')
@@ -142,26 +142,21 @@ class PDBReporter(object):
         if self._atomSubset[-1] >= topology.getNumAtoms():
             raise ValueError('The maximum allowed value in atomSubset must be less than the total number of particles')
         
-
         self._subsetTopology = Topology()
         
         # convert to set for fast look up
-        atomSubsetSet=set(self._atomSubset)
+        atomSubsetSet = set(self._atomSubset)
 
         # store a map from posIndex to Atom object for when we add the bonds
         indexToAtom = {}
 
-        posIndex = 0
         for chain in topology.chains():
             c = self._subsetTopology.addChain(chain.id)
-            residues = list(chain.residues())
-            for res in residues:
-                r = self._subsetTopology.addResidue(res.name,c,res.id,res.insertionCode)
+            for res in chain.residues():
+                r = self._subsetTopology.addResidue(res.name, c, res.id, res.insertionCode)
                 for atom in res.atoms():
-                        if posIndex in atomSubsetSet:
-                            atom = self._subsetTopology.addAtom(atom.name, atom.element, r, atom.id)
-                            indexToAtom[posIndex] = atom
-                        posIndex += 1
+                    if atom.index in atomSubsetSet:
+                        indexToAtom[atom.index] = self._subsetTopology.addAtom(atom.name, atom.element, r, atom.id)
 
         self._subsetTopology.setPeriodicBoxVectors(topology.getPeriodicBoxVectors())
 

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -59,4 +59,59 @@ class TestPDBReporter(unittest.TestCase):
                 simulation.reporters.append(app.PDBReporter(filename, 10, atomSubset=subset))
                 
                 self.assertRaises(ValueError, lambda: simulation.step(10))
+
+class TestPDBxReporter(unittest.TestCase):
+    def setUp(self):
+        self.pdb = app.PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.forcefield = app.ForceField('amber99sbildn.xml','tip3p.xml')
+        self.system = self.forcefield.createSystem(self.pdb.topology, nonbondedMethod=app.CutoffNonPeriodic, constraints=app.HBonds)
+
+    def testSubset(self):
+        """Test writing out a subset of atoms"""
+    
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temptraj.pdbx')
+            simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
+            simulation.context.setPositions(self.pdb.positions)
+
+            # just the alanine-dipeptide atoms
+            subset = list(range(0,22))
+
+            simulation.reporters.append(app.PDBxReporter(filename, 10, atomSubset=subset))
+            simulation.step(10)
+
+            # check if the output out trajectory contains the expected number of atoms
+            checkpdb = app.PDBxFile(filename)
+            self.assertEqual(len(checkpdb.positions), len(subset))
+
+    def testWriteAll(self):
+        """Test all atoms are written when atomSubset is not specified"""
+        
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temptraj.pdbx')
+            simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
+            simulation.context.setPositions(self.pdb.positions)
+
+
+            simulation.reporters.append(app.PDBxReporter(filename, 10))
+            simulation.step(10)
+
+            # check if the output out trajectory contains the expected number of atoms
+            checkpdb = app.PDBxFile(filename)
+            self.assertEqual(len(checkpdb.positions), simulation.topology.getNumAtoms())
+    
+    def testInvalidSubsets(self):
+        """Test that an exception is raised when the indices in atomSubset are invalid"""
+    
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temptraj.pdbx')
+
+            for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]:
+
+                simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
+                simulation.context.setPositions(self.pdb.positions)
+
+                simulation.reporters.append(app.PDBxReporter(filename, 10, atomSubset=subset))
+                
+                self.assertRaises(ValueError, lambda: simulation.step(10))
     

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -48,10 +48,9 @@ class TestPDBReporter(unittest.TestCase):
     def testInvalidSubsets(self):
         """Test that an exception is raised when the indices in atomSubset are invalid"""
     
-        with tempfile.TemporaryDirectory() as tempdir:
-            filename = os.path.join(tempdir, 'temptraj.pdb')
-
-            for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]:
+        for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]:
+            with tempfile.TemporaryDirectory() as tempdir:
+                filename = os.path.join(tempdir, 'temptraj.pdb')
 
                 simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
                 simulation.context.setPositions(self.pdb.positions)
@@ -77,8 +76,6 @@ class TestPDBReporter(unittest.TestCase):
             filename = os.path.join(tempdir, 'temptraj.pdb')
             simulation = app.Simulation(modeller.topology, system, mm.LangevinMiddleIntegrator(1.0*unit.kelvin, 1.0/unit.picosecond, 0.0000001*unit.picoseconds))
             simulation.context.setPositions(modeller.positions)
-
-            simulation.minimizeEnergy(maxIterations=100)
 
             # output just the glycopeptide atoms
             atomSubset=list(range(pdb.topology.getNumAtoms()))
@@ -136,7 +133,6 @@ class TestPDBxReporter(unittest.TestCase):
             simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
             simulation.context.setPositions(self.pdb.positions)
 
-
             simulation.reporters.append(app.PDBxReporter(filename, 10))
             simulation.step(10)
 
@@ -147,10 +143,9 @@ class TestPDBxReporter(unittest.TestCase):
     def testInvalidSubsets(self):
         """Test that an exception is raised when the indices in atomSubset are invalid"""
     
-        with tempfile.TemporaryDirectory() as tempdir:
-            filename = os.path.join(tempdir, 'temptraj.pdbx')
-
-            for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]:
+        for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]:
+            with tempfile.TemporaryDirectory() as tempdir:
+                filename = os.path.join(tempdir, 'temptraj.pdbx')
 
                 simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
                 simulation.context.setPositions(self.pdb.positions)
@@ -177,8 +172,6 @@ class TestPDBxReporter(unittest.TestCase):
             filename = os.path.join(tempdir, 'temptraj.pdbx')
             simulation = app.Simulation(modeller.topology, system, mm.LangevinMiddleIntegrator(1.0*unit.kelvin, 1.0/unit.picosecond, 0.0000001*unit.picoseconds))
             simulation.context.setPositions(modeller.positions)
-
-            simulation.minimizeEnergy(maxIterations=100)
 
             # output just the glycopeptide atoms
             atomSubset=list(range(pdb.topology.getNumAtoms()))

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -28,6 +28,22 @@ class TestPDBReporter(unittest.TestCase):
             # check if the output out trajectory contains the expected number of atoms
             checkpdb = app.PDBFile(filename)
             self.assertEqual(len(checkpdb.positions), len(subset))
+
+    def testWriteAll(self):
+        """Test all atoms are written when atomSubset is not specified"""
+        
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temptraj.pdb')
+            simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
+            simulation.context.setPositions(self.pdb.positions)
+
+
+            simulation.reporters.append(app.PDBReporter(filename, 10))
+            simulation.step(10)
+
+            # check if the output out trajectory contains the expected number of atoms
+            checkpdb = app.PDBFile(filename)
+            self.assertEqual(len(checkpdb.positions), simulation.topology.getNumAtoms())
     
     def testInvalidSubsets(self):
         """Test that an exception is raised when the indices in atomSubset are invalid"""
@@ -35,7 +51,7 @@ class TestPDBReporter(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, 'temptraj.pdb')
 
-            for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2]]:
+            for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]:
 
                 simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
                 simulation.context.setPositions(self.pdb.positions)

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -1,0 +1,46 @@
+import unittest
+import tempfile
+from openmm import app
+import openmm as mm
+from openmm import unit
+import os
+
+class TestPDBReporter(unittest.TestCase):
+    def setUp(self):
+        self.pdb = app.PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.forcefield = app.ForceField('amber99sbildn.xml','tip3p.xml')
+        self.system = self.forcefield.createSystem(self.pdb.topology, nonbondedMethod=app.CutoffNonPeriodic, constraints=app.HBonds)
+
+    def testSubset(self):
+        """Test writing out a subset of atoms"""
+    
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temptraj.pdb')
+            simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
+            simulation.context.setPositions(self.pdb.positions)
+
+            # just the alanine-dipeptide atoms
+            subset = list(range(0,22))
+
+            simulation.reporters.append(app.PDBReporter(filename, 10, atomSubset=subset))
+            simulation.step(10)
+
+            # check if the output out trajectory contains the expected number of atoms
+            checkpdb = app.PDBFile(filename)
+            self.assertEqual(len(checkpdb.positions), len(subset))
+    
+    def testInvalidSubsets(self):
+        """Test that an exception is raised when the indices in atomSubset are invalid"""
+    
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temptraj.pdb')
+
+            for subset in [[-1,10], [0,99999], [0,0,0,1], [0.1,0.2]]:
+
+                simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
+                simulation.context.setPositions(self.pdb.positions)
+
+                simulation.reporters.append(app.PDBReporter(filename, 10, atomSubset=subset))
+                
+                self.assertRaises(ValueError, lambda: simulation.step(10))
+    

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -7,6 +7,15 @@ from openmm.unit.unit_math import norm
 import os
 import gc
 
+def assertVecAlmostEqual(p1, p2, tol=1e-7):
+    unit = p1.unit
+    p1 = p1.value_in_unit(unit)
+    p2 = p2.value_in_unit(unit)
+    scale = max(1.0, norm(p1),)
+    for i in range(3):
+        diff = abs(p1[i]-p2[i])/scale
+        assert(diff < tol)
+
 
 class TestPDBReporter(unittest.TestCase):
     def setUp(self):
@@ -42,7 +51,7 @@ class TestPDBReporter(unittest.TestCase):
                 validPositions[i] = [round(validPositions[i][j]._value, 4) for j in (0, 1, 2)]*unit.nanometer
                 
             for (p1, p2) in zip(checkpdb.positions, validPositions):
-                self.assertVecAlmostEqual(p1, p2)
+                assertVecAlmostEqual(p1, p2)
 
             # check elements and residue names are correct
             validAtoms = [list(self.pdb.topology.atoms())[i] for i in subset]
@@ -77,7 +86,7 @@ class TestPDBReporter(unittest.TestCase):
                 validPositions[i] = [round(validPositions[i][j]._value, 4) for j in (0, 1, 2)]*unit.nanometer
 
             for (p1, p2) in zip(checkpdb.positions, validPositions):
-                self.assertVecAlmostEqual(p1, p2)
+                assertVecAlmostEqual(p1, p2)
 
             # check elements and residue names are correct
             validAtoms = list(self.pdb.topology.atoms())
@@ -92,7 +101,7 @@ class TestPDBReporter(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir:
             for i, subset in enumerate([[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]):
-                # give them different names to try and stop Windows complaining
+                
                 filename = os.path.join(tempdir, 'temptraj'+str(i)+'.pdb')
 
                 simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
@@ -146,18 +155,6 @@ class TestPDBReporter(unittest.TestCase):
                 self.assertEqual(str(validBond), str(testBond))
 
 
-    def assertVecAlmostEqual(self, p1, p2, tol=1e-7):
-        unit = p1.unit
-        p1 = p1.value_in_unit(unit)
-        p2 = p2.value_in_unit(unit)
-        scale = max(1.0, norm(p1),)
-        for i in range(3):
-            diff = abs(p1[i]-p2[i])/scale
-            self.assertTrue(diff < tol)
-
-
-
-
 class TestPDBxReporter(unittest.TestCase):
     def setUp(self):
         self.pdb = app.PDBFile('systems/alanine-dipeptide-explicit.pdb')
@@ -192,7 +189,7 @@ class TestPDBxReporter(unittest.TestCase):
                 validPositions[i] = [round(validPositions[i][j]._value, 5) for j in (0, 1, 2)]*unit.nanometer
                 
             for (p1, p2) in zip(checkpdb.positions, validPositions):
-                self.assertVecAlmostEqual(p1, p2)
+                assertVecAlmostEqual(p1, p2)
 
             # check elements and residue names are correct
             validAtoms = [list(self.pdb.topology.atoms())[i] for i in subset]
@@ -227,7 +224,7 @@ class TestPDBxReporter(unittest.TestCase):
                 validPositions[i] = [round(validPositions[i][j]._value, 5) for j in (0, 1, 2)]*unit.nanometer
 
             for (p1, p2) in zip(checkpdb.positions, validPositions):
-                self.assertVecAlmostEqual(p1, p2)
+                assertVecAlmostEqual(p1, p2)
 
             # check elements and residue names are correct
             validAtoms = list(self.pdb.topology.atoms())
@@ -242,7 +239,7 @@ class TestPDBxReporter(unittest.TestCase):
     
         with tempfile.TemporaryDirectory() as tempdir:
             for i,subset in enumerate([[-1,10], [0,99999], [0,0,0,1], [0.1,0.2], [5,10,0,9], ["C", "H"],[]]):
-                # give them different names to try and stop Windows complaining
+                
                 filename = os.path.join(tempdir, 'temptraj'+str(i)+'.pdbx')
 
                 simulation = app.Simulation(self.pdb.topology, self.system, mm.LangevinMiddleIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds))
@@ -290,16 +287,6 @@ class TestPDBxReporter(unittest.TestCase):
 
             for validBond, testBond in zip(validBonds, testBonds):
                 self.assertEqual(str(validBond), str(testBond))
-
-
-    def assertVecAlmostEqual(self, p1, p2, tol=1e-7):
-        unit = p1.unit
-        p1 = p1.value_in_unit(unit)
-        p2 = p2.value_in_unit(unit)
-        scale = max(1.0, norm(p1),)
-        for i in range(3):
-            diff = abs(p1[i]-p2[i])/scale
-            self.assertTrue(diff < tol)
 
 
 

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -106,7 +106,7 @@ class TestPDBReporter(unittest.TestCase):
     def testBondSubset(self):
         """ Test that CONECT records are output correctly when using atomSubset"""
 
-        # use a testcase that has CONNECT records in the input pdb file
+        # use a testcase that has CONECT records in the input pdb file
         ff = app.ForceField('amber14/protein.ff14SB.xml', 'amber14/GLYCAM_06j-1.xml','amber14/tip3pfb.xml')
         pdb = app.PDBFile('systems/glycopeptide.pdb')
 
@@ -256,7 +256,7 @@ class TestPDBxReporter(unittest.TestCase):
     def testBondSubset(self):
         """ Test that struct_conn records are output correctly when using atomSubset"""
 
-        # use a testcase that has CONNECT records in the input pdb file
+        # use a testcase that has CONECT records in the input pdb file
         ff = app.ForceField('amber14/protein.ff14SB.xml', 'amber14/GLYCAM_06j-1.xml','amber14/tip3pfb.xml')
         pdb = app.PDBFile('systems/glycopeptide.pdb')
 


### PR DESCRIPTION
This is a first attempt at a way to output atom subsets with PDBReporter addressing issue #3925
It creates a subset topology and position list with just the specified atoms, similar to [MDTraj](https://www.mdtraj.org/1.9.8.dev0/api/generated/mdtraj.reporters.DCDReporter.html#mdtraj.reporters.DCDReporter).
It then passes the new topology and positions to PDBFile.
