### PR TITLE
4 thread blocks per RDNA CU SIMD

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -255,10 +255,7 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
                         // set instead of the VLIW instruction set. It therefore needs more thread blocks per
                         // compute unit to hide memory latency.
                         if (simdPerComputeUnit > 1) {
-                            if (simdWidth == 32)
-                                numThreadBlocksPerComputeUnit = 6*simdPerComputeUnit; // Navi seems to like more thread blocks than older GPUs
-                            else
-                                numThreadBlocksPerComputeUnit = 4*simdPerComputeUnit;
+                            numThreadBlocksPerComputeUnit = 4*simdPerComputeUnit;
                         }
 
                         // If the queries are supported then must be newer than SDK 2.4.


### PR DESCRIPTION
RDNA has lower latency and shouldn't need more threads than GCN to hide latency.
https://www.amd.com/system/files/documents/rdna-whitepaper.pdf

AMD Radeon RX 6600 benchmark runs comparing 6x multiplier to 4x multiplier. Each test was run 3 times for 30 seconds.
- 4 tests are +/- <1%
- apoa1rf is 1.8% slower
- 3 pme tests are 2-8% faster

| Benchmark<br>3 runs   | 6x Avg   | 4x Avg   | Change |   | 6x Best  | 4x Best  | Change |
|-------------|---------:|---------:|-------:|---|---------:|---------:|-------:|
| gbsa        | 406.921  | 404.850  | -0.51% |   | 407.889  | 409.965  | 0.51%  |
| rf          | 440.085  | 438.272  | -0.41% |   | 447.963  | 445.797  | -0.48% |
| pme         | 263.757  | 284.875  | 8.01%  |   | 271.442  | 291.939  | 7.55%  |
| apoa1rf     | 118.589  | 116.404  | -1.84% |   | 119.405  | 117.245  | -1.81% |
| apoa1pme    | 74.5205  | 76.5444  | 2.72%  |   | 75.4482  | 77.0721  | 2.15%  |
| apoa1ljpme  | 57.9107  | 59.7324  | 3.15%  |   | 58.2195  | 60.0651  | 3.17%  |
| amoebagk    | 1.39630  | 1.39295  | -0.24% |   | 1.39913  | 1.39642  | -0.19% |
| amoebapme   | 3.72194  | 3.76003  | 1.02%  |   | 3.78116  | 3.78194  | 0.02%  |

AMD Radeon RX 6600 FAH project runs . Each test was run 2 times for 2500 steps.
- 3 projects are +/- <1%
- 3 projects are 1-2% faster
- 2 projects are 3% faster

| FAH Project<br>2 runs | 6x Avg   | 4x Avg   | Change |   | 6x Best  | 4x Best  | Change |
|-------------|---------:|---------:|-------:|---|---------:|---------:|-------:|
| 13415       | 127.6575 | 126.8654 | -0.62% |   | 128.5378 | 129.6393 | 0.86%  |
| 13428       | 9.6810   | 10.0322  | 3.63%  |   | 9.7362   | 10.0517  | 3.24%  |
| 14908       | 16.9763  | 17.0387  | 0.37%  |   | 16.9946  | 17.0946  | 0.59%  |
| 14944       | 41.1417  | 41.5054  | 0.88%  |   | 41.4319  | 41.5295  | 0.24%  |
| 16918       | 48.0210  | 49.6890  | 3.47%  |   | 48.3870  | 49.9465  | 3.22%  |
| 17308       | 45.1781  | 45.9747  | 1.76%  |   | 45.3333  | 46.1448  | 1.79%  |
| 17424       | 44.9890  | 46.0178  | 2.29%  |   | 45.3668  | 46.0421  | 1.49%  |
| 18717       | 35.4719  | 36.1814  | 3.78%  |   | 36.0810  | 36.6799  | 1.66%  |

Is this sufficient data to justify the change or are there other tests that need to be run?

[6x vs 4x Mulitiplier.xlsx](https://github.com/openmm/openmm/files/10528747/6x.vs.4x.Mulitiplier.xlsx)
