### PR TITLE
Optimize `findBlocksWithInteractions` for Apple silicon GPUs

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -218,6 +218,7 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
       
         if (vendor.size() >= 5 && vendor.substr(0, 5) == "Apple") {
             simdWidth = 32;
+            compilationDefines["APPLE_GPU_FAMILY"] = "";
         }
         else if (vendor.size() >= 6 && vendor.substr(0, 6) == "NVIDIA") {
             compilationDefines["WARPS_ARE_ATOMIC"] = "";


### PR DESCRIPTION
The Apple Metal/AIR backend compiler does not auto-inline loops, even when attempting to force-inline it. This should speedup the kernel by under 19%, speeding up the actual performance by the order of 1% in some benchmarks.

Resolves https://github.com/openmm/openmm/issues/3924