### PR TITLE
[macOS GPU Support] Fix `MTLCommandBuffer` bottlenecks for Apple silicon GPUs

### DIFF
--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -358,7 +358,7 @@ void OpenCLNonbondedUtilities::prepareInteractions(int forceGroups) {
 
     #if __APPLE__ && defined(__aarch64__)
     // Segment the command stream to avoid stalls later.
-    if (groupKernels[forceGroups].hasForces && useCutoff && numTiles > 0)
+    if (groupKernels[forceGroups].hasForces)
         context.getQueue().flush();
     #endif
 }

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -354,7 +354,13 @@ void OpenCLNonbondedUtilities::prepareInteractions(int forceGroups) {
     context.executeKernel(kernels.findInteractingBlocksKernel, context.getNumAtoms(), interactingBlocksThreadBlockSize);
     forceRebuildNeighborList = false;
     lastCutoff = kernels.cutoffDistance;
-    context.getQueue().enqueueReadBuffer(interactionCount.getDeviceBuffer(), CL_FALSE, 0, sizeof(int), pinnedCountMemory, NULL, &downloadCountEvent); 
+    context.getQueue().enqueueReadBuffer(interactionCount.getDeviceBuffer(), CL_FALSE, 0, sizeof(int), pinnedCountMemory, NULL, &downloadCountEvent);
+
+    #if __APPLE__ && defined(__aarch64__)
+    // Segment the command stream to avoid stalls later.
+    if (groupKernels[forceGroups].hasForces && useCutoff && numTiles > 0)
+        context.getQueue().flush();
+    #endif
 }
 
 void OpenCLNonbondedUtilities::computeInteractions(int forceGroups, bool includeForces, bool includeEnergy) {
@@ -370,6 +376,11 @@ void OpenCLNonbondedUtilities::computeInteractions(int forceGroups, bool include
         context.executeKernel(kernel, numForceThreadBlocks*forceThreadBlockSize, forceThreadBlockSize);
     }
     if (useCutoff && numTiles > 0) {
+        #if __APPLE__ && defined(__aarch64__)
+        // Ensure cached up work executes while you're waiting.
+        if (kernels.hasForces)
+            context.getQueue().flush();
+        #endif
         downloadCountEvent.wait();
         updateNeighborListSize();
     }


### PR DESCRIPTION
The Apple Metal/MoltenCL backend has strange behavior regarding OpenCL events, causing them to infect any nearby commands. We explicitly flush whenever touching an event, ensuring a smooth command stream.

Refs: #3937