### PR TITLE
Fix misleading documentation of `Topology.bonds`

### DIFF
--- a/wrappers/python/openmm/app/topology.py
+++ b/wrappers/python/openmm/app/topology.py
@@ -230,8 +230,8 @@ class Topology(object):
                     yield atom
 
     def bonds(self):
-        """Iterate over all Bonds in the Topology.
-        A Bond can be treated as tuple of two Atoms.
+        """Iterate over all bonds in the Topology.
+        Each one is represented by a Bond object, which is a named tuple of two atoms.
         """
         return iter(self._bonds)
 

--- a/wrappers/python/openmm/app/topology.py
+++ b/wrappers/python/openmm/app/topology.py
@@ -230,7 +230,9 @@ class Topology(object):
                     yield atom
 
     def bonds(self):
-        """Iterate over all bonds (each represented as a tuple of two Atoms) in the Topology."""
+        """Iterate over all Bonds in the Topology.
+        A Bond can be treated as tuple of two Atoms.
+        """
         return iter(self._bonds)
 
     def getPeriodicBoxVectors(self):


### PR DESCRIPTION
`Topology.bonds()` states that iterates over a tuple of `Atom` objects. While this is technically correct, as the `Bond` class is a named tuple, this also hides the fact, that `Bond` objects also provide the `order` and `type` attributes. Therefore, I propose to change the sentence, so that it uses the capitalized *Bonds* indicating that they are actually objects.