### PR TITLE
Fix ReStructuredText formatting in docstring

### DIFF
--- a/wrappers/python/openmm/unit/quantity.py
+++ b/wrappers/python/openmm/unit/quantity.py
@@ -85,12 +85,15 @@ class Quantity(object):
     such as 'meters per second'.
 
     Supported value types include:
-      1 - numbers (float, int, long)
-      2 - lists of numbers, e.g. [1,2,3]
-      3 - tuples of numbers, e.g. (1,2,3)
-            Note - unit conversions will cause tuples to be converted to lists
-      4 - lists of tuples of numbers, lists of lists of ... etc. of numbers
-      5 - numpy.arrays
+    
+    1. numbers (float, int, long)
+    2. lists of numbers, e.g. [1,2,3]
+    3. tuples of numbers, e.g. (1,2,3)
+        
+       - Note: unit conversions will cause tuples to be converted to lists
+      
+    4. lists of tuples of numbers, lists of lists of ... etc. of numbers
+    5. numpy.arrays
     """
     __array_priority__ = 99
 


### PR DESCRIPTION
This PR should fix the docstring rendering of `Quantity`, which currently looks the following way: http://docs.openmm.org/latest/api-python/generated/openmm.unit.quantity.Quantity.html#openmm.unit.quantity.Quantity