### PR TITLE
Add OpenCLPlatformIndex to benchmark.py

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -352,6 +352,8 @@ def runOneTest(testName, options):
         properties['DeviceIndex'] = options.device
         if ',' in options.device or ' ' in options.device:
             initialSteps = 250
+    if options.opencl_platform is not None and 'OpenCLPlatformIndex' in platform.getPropertyNames():
+        properties['OpenCLPlatformIndex'] = options.opencl_platform
     if (options.precision is not None) and ('Precision' in platform.getPropertyNames()):
         properties['Precision'] = options.precision
 
@@ -477,6 +479,7 @@ parser.add_argument('--polarization', default='mutual', dest='polarization', cho
 parser.add_argument('--mutual-epsilon', default=1e-5, dest='epsilon', type=float, help='mutual induced epsilon for AMOEBA [default: 1e-5]')
 parser.add_argument('--bond-constraints', default='hbonds', dest='bond_constraints', help=f'hbonds: constrain bonds to hydrogen, use 1.5*amu H mass; allbonds: constrain all bonds, use 4*amu H mass, and use larger timestep. This option is ignored for AMOEBA: {BOND_CONSTRAINTS} [default: hbonds]')
 parser.add_argument('--device', default=None, dest='device', help='device index for CUDA or OpenCL')
+parser.add_argument('--opencl-platform', default=None, dest='opencl_platform', help='platform index for OpenCL')
 parser.add_argument('--precision', default='single', dest='precision', help=f'precision modes for CUDA or OpenCL: {PRECISIONS} [default: single]')
 parser.add_argument('--style', default='simple', dest='style', choices=STYLES, help=f'output style: {STYLES} [default: simple]')
 parser.add_argument('--outfile', default=None, dest='outfile', help='output filename for benchmark logging (must end with .yaml or .json)')


### PR DESCRIPTION
Fix specifying a device will fail to run when multiple OpenCL platforms are available. Specifying `--verbose` prints the following exception: `Specified DeviceIndex but not OpenCLPlatformIndex. When multiple platforms are available, a platform index is needed to specify a device.`