### PR TITLE
[macOS GPU Support] Tune dispatching of persistent threads for Apple silicon GPUs

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -218,6 +218,9 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
       
         if (vendor.size() >= 5 && vendor.substr(0, 5) == "Apple") {
             simdWidth = 32;
+
+            // 768 threads per GPU core.
+            numThreadBlocksPerComputeUnit = 12;
         }
         else if (vendor.size() >= 6 && vendor.substr(0, 6) == "NVIDIA") {
             compilationDefines["WARPS_ARE_ATOMIC"] = "";

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -65,8 +65,14 @@ OpenCLNonbondedUtilities::OpenCLNonbondedUtilities(OpenCLContext& context) : con
         forceThreadBlockSize = 1;
     }
     else if (context.getSIMDWidth() == 32) {
-            numForceThreadBlocks = 4*context.getDevice().getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
-            forceThreadBlockSize = 256;
+        int blocksPerComputeUnit = 4;
+        std::string vendor = context.getDevice().getInfo<CL_DEVICE_VENDOR>();
+        if (vendor.size() >= 5 && vendor.substr(0, 5) == "Apple") {
+            // 1536 threads per GPU core.
+            blocksPerComputeUnit = 6;
+        }
+        numForceThreadBlocks = blocksPerComputeUnit*context.getDevice().getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
+        forceThreadBlockSize = 256;
     }
     else {
         numForceThreadBlocks = context.getNumThreadBlocks();


### PR DESCRIPTION
Apple GPUs generally work well when you have an even division of their maximum thread count (3072). That is, 768 (1/4) or 1536 (1/2). Something odd like 768+32 or 1536-32 will surely harm performance. Going all the way to 3072 was also bad in [metal-benchmarks](https://github.com/philipturner/metal-benchmarks), where I never exceeded 2816 (92% occupancy). This observation may not apply to other use cases; metal-benchmarks used some very peculiar GPU kernels. For the lower bound, Apple designed their GPU so that 768 threads is a magic number. Going lower will not allocate more registers per thread, going higher will not improve ALU utilization unless arithmetic intensity is low.

Expanding the threadgroup size seems to harm performance on GBSA. However, our benchmark uses only 2489 atoms - too few to saturate the GPU. In this case, decreasing threads to something absurd like 192 causes the best performance. On the 14c M1 Pro, this number creates 2688 threads total across the entire GPU, 0.93 atoms per thread. 768 would create 10752, 0.23 atoms per thread. It is obvious that the latter would harm performance for such small simulations. `O(n)` kernels are designed to have >10.00 atoms per thread. This may not apply to `O(n^2)` kernels, or perhaps it does apply and is affected even more strongly.

We have yet to prove that 192 was faster because of "conflicting kernels". This hypothesis (1) states that one kernel runs fastest at 192 <i>regardless of simulation size</i>, another fastest at 768 <i>regardless of simulation size</i>. For small simulations, the first dominates; for larger simulations, the second dominates. Proving the hypothesis would require extensive profiling at the per-kernel granularity. I hypothesize (2) that the actual cause is something simpler - excessively small simulations require excessively few threads. A third hypothesis (3) is, the GBSA algorithm itself is at fault. That is mutually exclusive to hypothesis 2. We can test GBSA with 248,900 atoms instead of 2,489, proving either (2) or (3) wrong.

RDNA experienced similar behavior with smaller simulations, needing to adjust threads for force kernels to improve performance there. This indicates that the problem may apply to more than M1. Therefore, a separate PR should implement a comprehensive solution to that problem, for all hardware vendors. That is not the purpose of the current PR.

This PR implements the second component of #3914, but revises 768 -> 1536 threads/core. Subsequent benchmarks showed `findBlocksWithInteractions` runs faster with 1536 threads, assuming the optimization from #3924 is implemented. Furthermore, upon re-examing the Google Sheet attached to #3914, I noticed that 1536 was slightly better than 768 across the board, except for the smallest simulation. Reproducible benchmark [here](https://github.com/philipturner/openmm-benchmarks/blob/1da6c9f90980ad085cae11e8f5d4c716481b606b/FindInteractingBlocks/kernels.metal#L15).