### PR TITLE
Recognize Metal platform

### DIFF
--- a/openmmapi/src/LocalEnergyMinimizer.cpp
+++ b/openmmapi/src/LocalEnergyMinimizer.cpp
@@ -51,7 +51,7 @@ struct MinimizerData {
     Context* cpuContext;
     MinimizerData(Context& context, double k) : context(context), k(k), cpuIntegrator(1.0), cpuContext(NULL) {
         string platformName = context.getPlatform().getName();
-        checkLargeForces = (platformName == "CUDA" || platformName == "OpenCL" || platformName == "HIP");
+        checkLargeForces = (platformName == "CUDA" || platformName == "OpenCL" || platformName == "HIP" || platformName == "Metal");
     }
     ~MinimizerData() {
         if (cpuContext != NULL)


### PR DESCRIPTION
I originally made this a draft because I'm not entirely sure whether it's a good idea long-term. It solves a symptom of the problem: the current source line prevents people from using custom platforms with OpenMM.

#### Personal Motivation

I recently said I would give up making a Metal backend and emulating FP64. Therefore, I spent a significant amount of time building a header, which exposes the Metal Standard Library to OpenCL. <b>Then GPT-4 happened.</b> I want to explain what’s changed and how that relates to this PR.

I learned the reason for the surge in interest around ML potentials: quality approaching DFT, but O(n) scaling. Apple MPSGraph could execute ML potentials trained from DFT simulations, with much higher performance than PyTorch. Simultaneously, the new generative AI models could make porting massive code bases time-efficient. It may be feasible to transpile the entire OpenMM backend from OpenCL to Metal, and OpenMM-Torch to MPSGraph.

<b>Since I have not yet embarked on such an effort, it is still highly speculative.</b> A better change would be: fix the relevant source line, in a way that enables my use case, without hard-coding strings for speculative backend names.