### PR TITLE
Improved load balancing between GPUs

### DIFF
--- a/platforms/cuda/include/CudaParallelKernels.h
+++ b/platforms/cuda/include/CudaParallelKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -84,6 +84,7 @@ private:
     std::vector<Kernel> kernels;
     std::vector<long long> completionTimes;
     std::vector<double> contextNonbondedFractions;
+    bool loadBalance;
     int2* interactionCounts;
     CudaArray contextForces;
     void* pinnedPositionBuffer;


### PR DESCRIPTION
This PR makes two changes to load balancing.

1. It initializes the fractions in a way that more evenly distributes the work from the beginning.
2. Previously it only did load balancing during the first 200 steps.  That generally worked, but it was noisy.  Different runs would end up with slightly different distributions of work between the GPUs, which led to performance variations.  This changes it to continue doing load balancing after the first 200 steps, but only every 30 steps to keep the overhead minimal.

I ran a few benchmarks on four A100s.  I repeated each one three times to show the variation between runs.  Here are the speeds for the old version.

|Test|Run 1|Run 2|Run 3|
|---|---|---|---|
apoa1rf|757.216|757.864|767.391
apoa1pme|635.692|688.033|683.12
amber20-cellulose|234.363|236.996|246.975

And for the new version.

|Test|Run 1|Run 2|Run 3|
|---|---|---|---|
apoa1rf|798.808|798.139|799.509
apoa1pme|682.738|685.47|685.628
amber20-cellulose|243.48|242.876|243.31

It's slightly faster on average, and the variation between runs is much smaller.