### PR TITLE
Add support to "NHE" C-terminal caps

### DIFF
--- a/wrappers/python/openmm/app/data/pdbNames.xml
+++ b/wrappers/python/openmm/app/data/pdbNames.xml
@@ -237,7 +237,7 @@
   <Atom name="H2" alt1="2H" alt2="2HA" alt3="HT2" alt4="HH32" alt5="2HH3"/>
   <Atom name="H3" alt1="3H" alt2="3HA" alt3="HT3" alt4="HH33" alt5="3HH3"/>
  </Residue>
- <Residue name="NH2" type="Protein">
+ <Residue name="NH2" alt1="NHE" type="Protein">
   <Atom name="N" alt1="NT"/>
   <Atom name="HN1" alt1="1H" alt2="HT1" alt3="H1"/>
   <Atom name="HN2" alt1="2H" alt2="HT2" alt3="H2"/>


### PR DESCRIPTION
Addressing #4012:
"NHE" is the AMBER standard naming of NH2 termination according to their manual ([here](https://ambermd.org/doc12/Amber19.pdf) page 211 bottom). In OpenMM, although "NHE" shows up in the forcefield XML files (e.g., AMBER ff14SB)
https://github.com/openmm/openmm/blob/3dc2f12ff20efcb609dfa5508431065d2c98d028/wrappers/python/openmm/app/data/amber14/protein.ff14SB.xml#L1900 this end group cannot be recognized by `openmm.app.PDBFile` to create correct bond graphs. When calling `forcefield.createSystem`, there is such error message:
```
(openmm) $ python vacuum_relax.py 
Traceback (most recent call last):
  File ".../capped_version/vacuum_relax.py", line 5, in <module>
    sys = forcefield.createSystem(pdb.topology)
  File "${CONDA_PREFIX}/lib/python3.9/site-packages/openmm/app/forcefield.py", line 1218, in createSystem
    templateForResidue = self._matchAllResiduesToTemplates(data, topology, residueTemplates, ignoreExternalBonds)
  File "${CONDA_PREFIX}/lib/python3.9/site-packages/openmm/app/forcefield.py", line 1433, in _matchAllResiduesToTemplates
    raise ValueError('No template found for residue %d (%s).  %s  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#template' % (res.index+1, res.name, _findMatchErrors(self, res)))
ValueError: No template found for residue 17 (GLY).  The set of atoms matches GLY, but the bonds are different.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#template
```

Since it is actually the same group as the registered "NH2", I suggest inserting an alias to this line as a simple solution:
https://github.com/openmm/openmm/blob/3dc2f12ff20efcb609dfa5508431065d2c98d028/wrappers/python/openmm/app/data/pdbNames.xml#L240