### PR TITLE
Disable M1 build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,15 +148,15 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=ON \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: MacOS M1 CPU arm64 Python 3.11
-            python-version: "3.11"
-            os: M1-arm64
-            OPENCL: false
-            cuda-version: ""
-            compilers: conda-forge
-            CMAKE_FLAGS: |
-              -DOPENMM_BUILD_OPENCL_LIB=ON \
-              -DOPENMM_BUILD_OPENCL_TESTS=OFF \
+          #- name: MacOS M1 CPU arm64 Python 3.11
+          #  python-version: "3.11"
+          #  os: M1-arm64
+          #  OPENCL: false
+          #  cuda-version: ""
+          #  compilers: conda-forge
+          #  CMAKE_FLAGS: |
+          #    -DOPENMM_BUILD_OPENCL_LIB=ON \
+          #    -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
 
     steps:


### PR DESCRIPTION
The runner hasn't worked in over a year, so I'm disabling the build.  @mikemhenry if you can get the runner working again we can reenable it.  Until then, all it does is guarantee that every build will be marked as having failed.