### PR TITLE
addMembrane() works with CustomNonbondedForce

### DIFF
--- a/wrappers/python/openmm/app/modeller.py
+++ b/wrappers/python/openmm/app/modeller.py
@@ -6,7 +6,7 @@ Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2012-2022 Stanford University and the Authors.
+Portions copyright (c) 2012-2023 Stanford University and the Authors.
 Authors: Peter Eastman
 Contributors: 
 
@@ -1470,6 +1470,12 @@ class Modeller(object):
                     for j in scaledProteinCells.neighbors(scaledProteinPos[i]):
                         if j < i:
                             f1.addException(i+numMembraneParticles, j+numMembraneParticles, 0.0, 1.0, 0.0)
+            elif isinstance(f1, CustomNonbondedForce):
+                for i in range(numProteinParticles):
+                    f1.addParticle(f2.getParticleParameters(i))
+                    for j in scaledProteinCells.neighbors(scaledProteinPos[i]):
+                        if j < i:
+                            f1.addExclusion(i + numMembraneParticles, j + numMembraneParticles)
         if nonbonded is None:
             raise ValueError('The ForceField does not specify a NonbondedForce')
         mergedPositions = membranePos+scaledProteinPos


### PR DESCRIPTION
Fixes #4023.  If the force field passed to `addMembrane()` used a CustomNonbondedForce (for example, CHARMM36), it would throw an exception.  This fixes it.