### PR TITLE
Ignore changes to force group after context creation

### DIFF
--- a/openmmapi/include/openmm/internal/ForceImpl.h
+++ b/openmmapi/include/openmm/internal/ForceImpl.h
@@ -119,6 +119,7 @@ protected:
     ContextImpl& getContextImpl(Context& context) const {
         return context.getImpl();
     }
+    int forceGroup;
 };
 
 } // namespace OpenMM

--- a/openmmapi/include/openmm/internal/NonbondedForceImpl.h
+++ b/openmmapi/include/openmm/internal/NonbondedForceImpl.h
@@ -86,6 +86,8 @@ private:
     static double evalIntegral(double r, double rs, double rc, double sigma);
     const NonbondedForce& owner;
     Kernel kernel;
+    int recipForceGroup;
+    bool includeDirectSpace;
 };
 
 } // namespace OpenMM

--- a/openmmapi/src/CMAPTorsionForceImpl.cpp
+++ b/openmmapi/src/CMAPTorsionForceImpl.cpp
@@ -43,6 +43,7 @@ using namespace OpenMM;
 using namespace std;
 
 CMAPTorsionForceImpl::CMAPTorsionForceImpl(const CMAPTorsionForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CMAPTorsionForceImpl::~CMAPTorsionForceImpl() {
@@ -73,7 +74,7 @@ void CMAPTorsionForceImpl::initialize(ContextImpl& context) {
 }
 
 double CMAPTorsionForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCMAPTorsionForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomAngleForceImpl.cpp
+++ b/openmmapi/src/CustomAngleForceImpl.cpp
@@ -44,6 +44,7 @@ using std::string;
 using std::stringstream;
 
 CustomAngleForceImpl::CustomAngleForceImpl(const CustomAngleForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomAngleForceImpl::~CustomAngleForceImpl() {
@@ -78,7 +79,7 @@ void CustomAngleForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomAngleForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomAngleForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomBondForceImpl.cpp
+++ b/openmmapi/src/CustomBondForceImpl.cpp
@@ -44,6 +44,7 @@ using std::string;
 using std::stringstream;
 
 CustomBondForceImpl::CustomBondForceImpl(const CustomBondForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomBondForceImpl::~CustomBondForceImpl() {
@@ -79,7 +80,7 @@ void CustomBondForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomBondForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomBondForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomCVForceImpl.cpp
+++ b/openmmapi/src/CustomCVForceImpl.cpp
@@ -42,6 +42,7 @@ using namespace std;
 
 CustomCVForceImpl::CustomCVForceImpl(const CustomCVForce& owner) : owner(owner), innerIntegrator(1.0),
         innerContext(NULL) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomCVForceImpl::~CustomCVForceImpl() {
@@ -80,7 +81,7 @@ void CustomCVForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomCVForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomCVForceKernel>().execute(context, getContextImpl(*innerContext), includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomCentroidBondForceImpl.cpp
+++ b/openmmapi/src/CustomCentroidBondForceImpl.cpp
@@ -68,6 +68,7 @@ public:
 };
 
 CustomCentroidBondForceImpl::CustomCentroidBondForceImpl(const CustomCentroidBondForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomCentroidBondForceImpl::~CustomCentroidBondForceImpl() {
@@ -120,7 +121,7 @@ void CustomCentroidBondForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomCentroidBondForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomCentroidBondForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomCompoundBondForceImpl.cpp
+++ b/openmmapi/src/CustomCompoundBondForceImpl.cpp
@@ -72,6 +72,7 @@ public:
 };
 
 CustomCompoundBondForceImpl::CustomCompoundBondForceImpl(const CustomCompoundBondForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomCompoundBondForceImpl::~CustomCompoundBondForceImpl() {
@@ -106,7 +107,7 @@ void CustomCompoundBondForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomCompoundBondForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomCompoundBondForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomExternalForceImpl.cpp
+++ b/openmmapi/src/CustomExternalForceImpl.cpp
@@ -44,6 +44,7 @@ using std::string;
 using std::stringstream;
 
 CustomExternalForceImpl::CustomExternalForceImpl(const CustomExternalForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomExternalForceImpl::~CustomExternalForceImpl() {
@@ -77,7 +78,7 @@ void CustomExternalForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomExternalForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomExternalForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomGBForceImpl.cpp
+++ b/openmmapi/src/CustomGBForceImpl.cpp
@@ -45,6 +45,7 @@ using std::string;
 using std::stringstream;
 
 CustomGBForceImpl::CustomGBForceImpl(const CustomGBForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomGBForceImpl::~CustomGBForceImpl() {
@@ -107,7 +108,7 @@ void CustomGBForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomGBForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomGBForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomHbondForceImpl.cpp
+++ b/openmmapi/src/CustomHbondForceImpl.cpp
@@ -73,6 +73,7 @@ public:
 };
 
 CustomHbondForceImpl::CustomHbondForceImpl(const CustomHbondForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomHbondForceImpl::~CustomHbondForceImpl() {
@@ -180,7 +181,7 @@ void CustomHbondForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomHbondForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomHbondForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomManyParticleForceImpl.cpp
+++ b/openmmapi/src/CustomManyParticleForceImpl.cpp
@@ -73,6 +73,7 @@ public:
 };
 
 CustomManyParticleForceImpl::CustomManyParticleForceImpl(const CustomManyParticleForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomManyParticleForceImpl::~CustomManyParticleForceImpl() {
@@ -136,7 +137,7 @@ void CustomManyParticleForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomManyParticleForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomManyParticleForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomNonbondedForceImpl.cpp
+++ b/openmmapi/src/CustomNonbondedForceImpl.cpp
@@ -51,6 +51,7 @@ using namespace OpenMM;
 using namespace std;
 
 CustomNonbondedForceImpl::CustomNonbondedForceImpl(const CustomNonbondedForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomNonbondedForceImpl::~CustomNonbondedForceImpl() {
@@ -139,7 +140,7 @@ void CustomNonbondedForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomNonbondedForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomNonbondedForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/CustomTorsionForceImpl.cpp
+++ b/openmmapi/src/CustomTorsionForceImpl.cpp
@@ -44,6 +44,7 @@ using std::string;
 using std::stringstream;
 
 CustomTorsionForceImpl::CustomTorsionForceImpl(const CustomTorsionForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 CustomTorsionForceImpl::~CustomTorsionForceImpl() {
@@ -79,7 +80,7 @@ void CustomTorsionForceImpl::initialize(ContextImpl& context) {
 }
 
 double CustomTorsionForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcCustomTorsionForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/GBSAOBCForceImpl.cpp
+++ b/openmmapi/src/GBSAOBCForceImpl.cpp
@@ -40,6 +40,7 @@ using namespace OpenMM;
 using std::vector;
 
 GBSAOBCForceImpl::GBSAOBCForceImpl(const GBSAOBCForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 void GBSAOBCForceImpl::initialize(ContextImpl& context) {
@@ -65,7 +66,7 @@ void GBSAOBCForceImpl::initialize(ContextImpl& context) {
 }
 
 double GBSAOBCForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcGBSAOBCForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/GayBerneForceImpl.cpp
+++ b/openmmapi/src/GayBerneForceImpl.cpp
@@ -41,6 +41,7 @@ using namespace OpenMM;
 using namespace std;
 
 GayBerneForceImpl::GayBerneForceImpl(const GayBerneForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 GayBerneForceImpl::~GayBerneForceImpl() {
@@ -122,7 +123,7 @@ void GayBerneForceImpl::initialize(ContextImpl& context) {
 }
 
 double GayBerneForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcGayBerneForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/HarmonicAngleForceImpl.cpp
+++ b/openmmapi/src/HarmonicAngleForceImpl.cpp
@@ -43,6 +43,7 @@ using namespace OpenMM;
 using namespace std;
 
 HarmonicAngleForceImpl::HarmonicAngleForceImpl(const HarmonicAngleForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 HarmonicAngleForceImpl::~HarmonicAngleForceImpl() {
@@ -70,7 +71,7 @@ void HarmonicAngleForceImpl::initialize(ContextImpl& context) {
 }
 
 double HarmonicAngleForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcHarmonicAngleForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/HarmonicBondForceImpl.cpp
+++ b/openmmapi/src/HarmonicBondForceImpl.cpp
@@ -39,6 +39,7 @@ using namespace OpenMM;
 using namespace std;
 
 HarmonicBondForceImpl::HarmonicBondForceImpl(const HarmonicBondForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 HarmonicBondForceImpl::~HarmonicBondForceImpl() {
@@ -66,7 +67,7 @@ void HarmonicBondForceImpl::initialize(ContextImpl& context) {
 }
 
 double HarmonicBondForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcHarmonicBondForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/PeriodicTorsionForceImpl.cpp
+++ b/openmmapi/src/PeriodicTorsionForceImpl.cpp
@@ -39,6 +39,7 @@ using namespace OpenMM;
 using namespace std;
 
 PeriodicTorsionForceImpl::PeriodicTorsionForceImpl(const PeriodicTorsionForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 PeriodicTorsionForceImpl::~PeriodicTorsionForceImpl() {
@@ -66,7 +67,7 @@ void PeriodicTorsionForceImpl::initialize(ContextImpl& context) {
 }
 
 double PeriodicTorsionForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcPeriodicTorsionForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/RBTorsionForceImpl.cpp
+++ b/openmmapi/src/RBTorsionForceImpl.cpp
@@ -39,6 +39,7 @@ using namespace OpenMM;
 using namespace std;
 
 RBTorsionForceImpl::RBTorsionForceImpl(const RBTorsionForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 RBTorsionForceImpl::~RBTorsionForceImpl() {
@@ -64,7 +65,7 @@ void RBTorsionForceImpl::initialize(ContextImpl& context) {
 }
 
 double RBTorsionForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcRBTorsionForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }

--- a/openmmapi/src/RMSDForceImpl.cpp
+++ b/openmmapi/src/RMSDForceImpl.cpp
@@ -40,6 +40,7 @@ using namespace OpenMM;
 using namespace std;
 
 RMSDForceImpl::RMSDForceImpl(const RMSDForce& owner) : owner(owner) {
+    forceGroup = owner.getForceGroup();
 }
 
 RMSDForceImpl::~RMSDForceImpl() {
@@ -73,7 +74,7 @@ void RMSDForceImpl::initialize(ContextImpl& context) {
 }
 
 double RMSDForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
-    if ((groups&(1<<owner.getForceGroup())) != 0)
+    if ((groups&(1<<forceGroup)) != 0)
         return kernel.getAs<CalcRMSDForceKernel>().execute(context, includeForces, includeEnergy);
     return 0.0;
 }


### PR DESCRIPTION
Fixes #3427.  Once you create a Context, any changes to the System or the Forces it contains should be ignored.  In the case of force groups, they sometimes weren't.