### PR TITLE
Fixed uninitialized memory error

### DIFF
--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -1308,7 +1308,7 @@ class CommonIntegrateCustomStepKernel : public IntegrateCustomStepKernel {
 public:
     enum GlobalTargetType {DT, VARIABLE, PARAMETER};
     CommonIntegrateCustomStepKernel(std::string name, const Platform& platform, ComputeContext& cc) : IntegrateCustomStepKernel(name, platform), cc(cc),
-            hasInitializedKernels(false), needsEnergyParamDerivs(false) {
+            hasInitializedKernels(false), deviceGlobalsAreCurrent(false), needsEnergyParamDerivs(false) {
     }
     /**
      * Initialize the kernel.


### PR DESCRIPTION
Fixes #4038.

CustomIntegrator needs to keep the values of global variables synchronized between the CPU and GPU.  To do that, it has a boolean flag that tracks whether the values on the GPU are currently valid.  That flag wasn't being initialized, which could sometimes lead to the initial value of a global variable not getting uploaded to the GPU.  It wouldn't get set correctly until the first time an integration step set it.