### PR TITLE
Fixed error in barostats

### DIFF
--- a/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
@@ -111,7 +111,7 @@ void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context)
     context.getOwner().setPeriodicBoxVectors(Vec3(box[0][0]*lengthScale[0], box[0][1]*lengthScale[1], box[0][2]*lengthScale[2]),
                                              Vec3(box[1][0]*lengthScale[0], box[1][1]*lengthScale[1], box[1][2]*lengthScale[2]),
                                              Vec3(box[2][0]*lengthScale[0], box[2][1]*lengthScale[1], box[2][2]*lengthScale[2]));
-    
+
     // Compute the energy of the modified system.
     
     double finalEnergy = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
@@ -120,8 +120,8 @@ void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context)
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
         
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
         context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
     }
     else
         numAccepted[axis]++;

--- a/openmmapi/src/MonteCarloBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloBarostatImpl.cpp
@@ -90,8 +90,8 @@ void MonteCarloBarostatImpl::updateContextState(ContextImpl& context, bool& forc
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
 
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
         context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
     }
     else {
         numAccepted++;

--- a/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
@@ -115,8 +115,8 @@ void MonteCarloFlexibleBarostatImpl::updateContextState(ContextImpl& context, bo
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
 
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
         context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
     }
     else {
         numAccepted++;

--- a/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
@@ -121,8 +121,8 @@ void MonteCarloMembraneBarostatImpl::updateContextState(ContextImpl& context) {
     if (w > 0 && SimTKOpenMMUtilities::getUniformlyDistributedRandomNumber() > exp(-w/kT)) {
         // Reject the step.
         
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
         context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
     }
     else
         numAccepted[axis]++;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -7217,7 +7217,7 @@ void CommonIntegrateCustomStepKernel::execute(ContextImpl& context, CustomIntegr
             energy = savedEnergy[forceGroups];
         if (needsGlobals[step] && !deviceGlobalsAreCurrent) {
             // Upload the global values to the device.
-            
+
             globalValues.upload(localGlobalValues, true);
             deviceGlobalsAreCurrent = true;
         }
@@ -7781,13 +7781,13 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
     cc.getLongForceBuffer().copyTo(savedLongForces);
     if (savedFloatForces.isInitialized())
         cc.getFloatForceBuffer().copyTo(savedFloatForces);
+    lastPosCellOffsets = cc.getPosCellOffsets();
     kernel->setArg(0, (float) scaleX);
     kernel->setArg(1, (float) scaleY);
     kernel->setArg(2, (float) scaleZ);
     setPeriodicBoxArgs(cc, kernel, 4);
     kernel->execute(cc.getNumAtoms());
     lastAtomOrder = cc.getAtomIndex();
-    lastPosCellOffsets = cc.getPosCellOffsets();
 }
 
 void CommonApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& context) {


### PR DESCRIPTION
Fixes #4032.

This fixes an error that was introduced by #4034.  Due to a subtle interaction, rejecting a step could sometimes introduce small errors into positions.