### PR TITLE
Use more efficient version of updateContextState()

### DIFF
--- a/openmmapi/include/openmm/internal/GayBerneForceImpl.h
+++ b/openmmapi/include/openmm/internal/GayBerneForceImpl.h
@@ -55,7 +55,7 @@ public:
     const GayBerneForce& getOwner() const {
         return owner;
     }
-    void updateContextState(ContextImpl& context) {
+    void updateContextState(ContextImpl& context, bool& forcesInvalid) {
         // This force field doesn't update the state directly.
     }
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups);

--- a/openmmapi/include/openmm/internal/MonteCarloAnisotropicBarostatImpl.h
+++ b/openmmapi/include/openmm/internal/MonteCarloAnisotropicBarostatImpl.h
@@ -50,7 +50,7 @@ public:
     const MonteCarloAnisotropicBarostat& getOwner() const {
         return owner;
     }
-    void updateContextState(ContextImpl& context);
+    void updateContextState(ContextImpl& context, bool& forcesInvalid);
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
         // This force doesn't apply forces to particles.
         return 0.0;

--- a/openmmapi/include/openmm/internal/MonteCarloMembraneBarostatImpl.h
+++ b/openmmapi/include/openmm/internal/MonteCarloMembraneBarostatImpl.h
@@ -50,7 +50,7 @@ public:
     const MonteCarloMembraneBarostat& getOwner() const {
         return owner;
     }
-    void updateContextState(ContextImpl& context);
+    void updateContextState(ContextImpl& context, bool& forcesInvalid);
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
         // This force doesn't apply forces to particles.
         return 0.0;

--- a/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
@@ -62,7 +62,7 @@ void MonteCarloAnisotropicBarostatImpl::initialize(ContextImpl& context) {
     SimTKOpenMMUtilities::setRandomNumberSeed(owner.getRandomNumberSeed());
 }
 
-void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context) {
+void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context, bool& forcesInvalid) {
     if (++step < owner.getFrequency() || owner.getFrequency() == 0)
         return;
     if (!owner.getScaleX() && !owner.getScaleY() && !owner.getScaleZ())
@@ -123,8 +123,10 @@ void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context)
         context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
         kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
     }
-    else
+    else {
         numAccepted[axis]++;
+        forcesInvalid = true;
+    }
     numAttempted[axis]++;
     if (numAttempted[axis] >= 10) {
         if (numAccepted[axis] < 0.25*numAttempted[axis]) {

--- a/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
@@ -62,7 +62,7 @@ void MonteCarloMembraneBarostatImpl::initialize(ContextImpl& context) {
     SimTKOpenMMUtilities::setRandomNumberSeed(owner.getRandomNumberSeed());
 }
 
-void MonteCarloMembraneBarostatImpl::updateContextState(ContextImpl& context) {
+void MonteCarloMembraneBarostatImpl::updateContextState(ContextImpl& context, bool& forcesInvalid) {
     if (++step < owner.getFrequency() || owner.getFrequency() == 0)
         return;
     step = 0;
@@ -124,8 +124,10 @@ void MonteCarloMembraneBarostatImpl::updateContextState(ContextImpl& context) {
         context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
         kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
     }
-    else
+    else {
         numAccepted[axis]++;
+        forcesInvalid = true;
+    }
     numAttempted[axis]++;
     if (numAttempted[axis] >= 10) {
         if (numAccepted[axis] < 0.25*numAttempted[axis]) {

--- a/plugins/rpmd/openmmapi/include/openmm/internal/RPMDMonteCarloBarostatImpl.h
+++ b/plugins/rpmd/openmmapi/include/openmm/internal/RPMDMonteCarloBarostatImpl.h
@@ -54,7 +54,7 @@ public:
         return owner;
     }
     void updateRPMDState(ContextImpl& context);
-    void updateContextState(ContextImpl& context) {
+    void updateContextState(ContextImpl& context, bool& forcesInvalid) {
         // This is unused, since the updating is done in updateRPMDState().
     }
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {


### PR DESCRIPTION
A few forces were still overriding the old version of `updateContextState()`, which assumes forces always get invalidated.  In certain cases, this could lead to CustomIntegrators having to compute forces more often than necessary.