### PR TITLE
Add link to cookbook and tutorials in docs

### DIFF
--- a/docs-source/api-c++/conf.py
+++ b/docs-source/api-c++/conf.py
@@ -61,6 +61,11 @@ html_theme_options = {
             "relative": True,
         },
         {
+            "title": "Cookbook & Tutorials",
+            "uri": "https://openmm.github.io/openmm-cookbook/",
+            "relative": False,
+        },
+        {
             "title": "GitHub",
             "uri": "https://github.com/openmm",
             "relative": False,

--- a/docs-source/api-python/conf.py
+++ b/docs-source/api-python/conf.py
@@ -65,6 +65,11 @@ html_theme_options = {
             "relative": True,
         },
         {
+            "title": "Cookbook & Tutorials",
+            "uri": "https://openmm.github.io/openmm-cookbook/",
+            "relative": False,
+        },
+        {
             "title": "GitHub",
             "uri": "https://github.com/openmm",
             "relative": False,

--- a/docs-source/developerguide/conf.py
+++ b/docs-source/developerguide/conf.py
@@ -134,6 +134,11 @@ html_theme_options = {
             "relative": True,
         },
         {
+            "title": "Cookbook & Tutorials",
+            "uri": "https://openmm.github.io/openmm-cookbook/",
+            "relative": False,
+        },
+        {
             "title": "GitHub",
             "uri": "https://github.com/openmm",
             "relative": False,

--- a/docs-source/usersguide/conf.py
+++ b/docs-source/usersguide/conf.py
@@ -142,6 +142,11 @@ html_theme_options = {
             "relative": True,
         },
         {
+            "title": "Cookbook & Tutorials",
+            "uri": "https://openmm.github.io/openmm-cookbook/",
+            "relative": False,
+        },
+        {
             "title": "GitHub",
             "uri": "https://github.com/openmm",
             "relative": False,


### PR DESCRIPTION
This PR adds a link to the cookbook and tutorials page from the side panel navigation links of the OpenMM documentation.