### PR TITLE
Decreased default epsilon for AmoebaMultipoleForce

### DIFF
--- a/plugins/amoeba/openmmapi/src/AmoebaMultipoleForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaMultipoleForce.cpp
@@ -41,7 +41,7 @@ using std::string;
 using std::vector;
 
 AmoebaMultipoleForce::AmoebaMultipoleForce() : nonbondedMethod(NoCutoff), polarizationType(Mutual), pmeBSplineOrder(5), cutoffDistance(1.0), ewaldErrorTol(1e-4), mutualInducedMaxIterations(60),
-                                               mutualInducedTargetEpsilon(1.0e-02), scalingDistanceCutoff(100.0), electricConstant(ONE_4PI_EPS0), alpha(0.0), nx(0), ny(0), nz(0) {
+                                               mutualInducedTargetEpsilon(1e-5), scalingDistanceCutoff(100.0), electricConstant(ONE_4PI_EPS0), alpha(0.0), nx(0), ny(0), nz(0) {
     extrapolationCoefficients.push_back(-0.154);
     extrapolationCoefficients.push_back(0.017);
     extrapolationCoefficients.push_back(0.658);


### PR DESCRIPTION
The default value was really too large.  Using it would lead to unacceptable energy drift.  We were relying on people to manually specify a more appropriate value.  I decreased it from 1e-2 to 1e-5, which is a much more reasonable value.