### PR TITLE
another attempted fix for MonteCarloBarostat

### DIFF
--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -1576,7 +1576,7 @@ public:
     void restoreCoordinates(ContextImpl& context);
 private:
     ComputeContext& cc;
-    bool hasInitializedKernels, rigidMolecules;
+    bool hasInitializedKernels, rigidMolecules, atomsWereReordered;
     int numMolecules;
     ComputeArray savedPositions, savedFloatForces, savedLongForces;
     ComputeArray moleculeAtoms;

--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -388,11 +388,9 @@ public:
         return atomIndex;
     }
     /**
-     * Set the host-side vector which contains the index of each atom.
+     * Set the vector which contains the index of each atom.
      */
-    void setAtomIndex(std::vector<int>& index){
-        atomIndex = index;
-    }
+    void setAtomIndex(std::vector<int>& index);
     /**
      * Get the array which contains the index of each atom.
      */

--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -388,6 +388,12 @@ public:
         return atomIndex;
     }
     /**
+     * Set the host-side vector which contains the index of each atom.
+     */
+    void setAtomIndex(std::vector<int>& index){
+        atomIndex = index;
+    }
+    /**
      * Get the array which contains the index of each atom.
      */
     virtual ArrayInterface& getAtomIndexArray() = 0;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -7720,6 +7720,7 @@ void CommonApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& context) 
     if (savedFloatForces.isInitialized())
         cc.getFloatForceBuffer().copyTo(savedFloatForces);
     lastPosCellOffsets = cc.getPosCellOffsets();
+    lastAtomOrder = cc.getAtomIndex();
 }
 
 void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ) {
@@ -7769,7 +7770,6 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
     kernel->setArg(2, (float) scaleZ);
     setPeriodicBoxArgs(cc, kernel, 4);
     kernel->execute(cc.getNumAtoms());
-    lastAtomOrder = cc.getAtomIndex();
 }
 
 void CommonApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& context) {
@@ -7779,4 +7779,5 @@ void CommonApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& contex
     cc.setPosCellOffsets(lastPosCellOffsets);
     if (savedFloatForces.isInitialized())
         savedFloatForces.copyTo(cc.getFloatForceBuffer());
+    cc.setAtomIndex(lastAtomOrder);
 }

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -7725,6 +7725,10 @@ void CommonApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& context) 
 
 void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ) {
     ContextSelector selector(cc);
+
+    // check if atoms were reordered from energy evaluation before scaling
+    atomsWereReordered = cc.getAtomsWereReordered();
+
     if (!hasInitializedKernels) {
         hasInitializedKernels = true;
 
@@ -7779,5 +7783,8 @@ void CommonApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& contex
     cc.setPosCellOffsets(lastPosCellOffsets);
     if (savedFloatForces.isInitialized())
         savedFloatForces.copyTo(cc.getFloatForceBuffer());
-    cc.setAtomIndex(lastAtomOrder);
+
+    // check if atoms were reordered from energy evaluation before or after scaling
+    if (atomsWereReordered || cc.getAtomsWereReordered())
+        cc.setAtomIndex(lastAtomOrder);
 }

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -57,6 +57,13 @@ void ComputeContext::addForce(ComputeForceInfo* force) {
     forces.push_back(force);
 }
 
+void ComputeContext::setAtomIndex(std::vector<int>& index){
+    atomIndex = index;
+    getAtomIndexArray().upload(atomIndex);
+    for (auto listener : reorderListeners)
+        listener->execute();
+}
+
 string ComputeContext::replaceStrings(const string& input, const std::map<std::string, std::string>& replacements) const {
     static set<char> symbolChars;
     if (symbolChars.size() == 0) {


### PR DESCRIPTION
This aims to fix #4117 

In #4117 the atomic indices can end up incorrectly reordered.
In this PR the atomIndex vector is saved before an attempted MC move and  restored after a rejected one.