### PR TITLE
Fixed DOF calculation for NoseHooverIntegrator

### DIFF
--- a/plugins/drude/tests/TestDrudeNoseHoover.h
+++ b/plugins/drude/tests/TestDrudeNoseHoover.h
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019-2022 Stanford University and the Authors.      *
+ * Portions copyright (c) 2019-2023 Stanford University and the Authors.      *
  * Authors: Andreas Krämer and Andrew C. Simmonett                            *
  * Contributors: Peter Eastman                                                *
  *                                                                            *
@@ -115,9 +115,8 @@ void testWaterBox() {
     build_waterbox(system, gridSize, polarizability, positions);
 
     const int numMolecules = gridSize*gridSize*gridSize;
-    int numStandardDof = 3*3*numMolecules - system.getNumConstraints();
+    int numStandardDof = 3*3*numMolecules - system.getNumConstraints() - 3;
     int numDrudeDof = 3*numMolecules;
-    int numDof = numStandardDof+numDrudeDof;
     const double temperature = 300.0;
     const double temperatureDrude = 10.0;
 


### PR DESCRIPTION
Fixes #4109.  When using Nose-Hoover for Drude particles, it would fail to subtract 3 from the degrees of freedom for a CMMotionRemover.  This caused the temperature to be very slightly too high.

NoseHooverIntegrator lets you use different thermostats for different parts of the system.  That creates an ambiguity for which one to subtract 3 from.  Or should it be split among them?  It probably doesn't make much difference.  The effect should be tiny, and I don't know if anyone even uses that feature much.  I chose the simple answer of subtracting them from the largest subset.

cc @Olllom @andysim