### PR TITLE
Fixed numeric overflow in computing interaction groups

### DIFF
--- a/platforms/common/src/kernels/customNonbondedGroups.cc
+++ b/platforms/common/src/kernels/customNonbondedGroups.cc
@@ -50,8 +50,9 @@ KERNEL void computeInteractionGroups(
     LOCAL AtomData localData[LOCAL_MEMORY_SIZE];
     LOCAL int reductionBuffer[LOCAL_MEMORY_SIZE];
 
-    const unsigned int startTile = (useNeighborList ? warp*numGroupTiles[0]/totalWarps : FIRST_TILE+warp*(LAST_TILE-FIRST_TILE)/totalWarps);
-    const unsigned int endTile = (useNeighborList ? (warp+1)*numGroupTiles[0]/totalWarps : FIRST_TILE+(warp+1)*(LAST_TILE-FIRST_TILE)/totalWarps);
+    mm_ulong wl = warp;
+    const unsigned int startTile = (unsigned int) (useNeighborList ? wl*numGroupTiles[0]/totalWarps : FIRST_TILE+wl*(LAST_TILE-FIRST_TILE)/totalWarps);
+    const unsigned int endTile = (unsigned int) (useNeighborList ? (wl+1)*numGroupTiles[0]/totalWarps : FIRST_TILE+(wl+1)*(LAST_TILE-FIRST_TILE)/totalWarps);
     for (int tile = startTile; tile < endTile; tile++) {
         const int4 atomData = groupData[TILE_SIZE*tile+tgx];
         const int atom1 = atomData.x;
@@ -155,8 +156,8 @@ KERNEL void buildNeighborList(GLOBAL int* RESTRICT rebuildNeighborList, GLOBAL i
     LOCAL volatile int tileIndex[WARPS_IN_BLOCK];
     LOCAL int reductionBuffer[LOCAL_MEMORY_SIZE];
 
-    const unsigned int startTile = warp*NUM_TILES/totalWarps;
-    const unsigned int endTile = (warp+1)*NUM_TILES/totalWarps;
+    const unsigned int startTile = (unsigned int) (warp*(mm_ulong)NUM_TILES/totalWarps);
+    const unsigned int endTile = (unsigned int) ((warp+1)*(mm_ulong)NUM_TILES/totalWarps);
     for (int tile = startTile; tile < endTile; tile++) {
         const int4 atomData = groupData[TILE_SIZE*tile+tgx];
         const int atom1 = atomData.x;


### PR DESCRIPTION
Fixes #4127.

The error was caused by a combination of two factors:

1. The system had a CustomNonbondedForce that used very large interaction groups.  In the issue that was reported, the interaction groups contained nearly 3.5 billion interactions.
2. You were running on a GPU with a very large number of SMs.  It happened on RTX 3090 (82 SMs) and H100 (114 SMs), but not on RTX 3080 (68 SMs) or RTX 4080 (76 SMs).

The combination of those two factors led to a number that exceeded the range of a 32 bit integer, leading to some interactions being included more than once.