### PR TITLE
writeFile() accepts a filename instead of a file object

### DIFF
--- a/wrappers/python/openmm/app/pdbfile.py
+++ b/wrappers/python/openmm/app/pdbfile.py
@@ -6,7 +6,7 @@ Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2012-2021 Stanford University and the Authors.
+Portions copyright (c) 2012-2023 Stanford University and the Authors.
 Authors: Peter Eastman
 Contributors:
 
@@ -277,8 +277,8 @@ class PDBFile(object):
             The Topology defining the model to write
         positions : list
             The list of atomic positions to write
-        file : file=stdout
-            A file to write to
+        file : string or file
+            the name of the file to write.  Alternatively you can pass an open file object.
         keepIds : bool=False
             If True, keep the residue and chain IDs specified in the Topology
             rather than generating new ones.  Warning: It is up to the caller to
@@ -287,9 +287,13 @@ class PDBFile(object):
         extraParticleIdentifier : string='EP'
             String to write in the element column of the ATOM records for atoms whose element is None (extra particles)
         """
-        PDBFile.writeHeader(topology, file)
-        PDBFile.writeModel(topology, positions, file, keepIds=keepIds, extraParticleIdentifier=extraParticleIdentifier)
-        PDBFile.writeFooter(topology, file)
+        if isinstance(file, str):
+            with open(file, 'w') as output:
+                PDBFile.writeFile(topology, positions, output, keepIds, extraParticleIdentifier)
+        else:
+            PDBFile.writeHeader(topology, file)
+            PDBFile.writeModel(topology, positions, file, keepIds=keepIds, extraParticleIdentifier=extraParticleIdentifier)
+            PDBFile.writeFooter(topology, file)
 
     @staticmethod
     def writeHeader(topology, file=sys.stdout):

--- a/wrappers/python/openmm/app/pdbxfile.py
+++ b/wrappers/python/openmm/app/pdbxfile.py
@@ -6,7 +6,7 @@ Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2015-2020 Stanford University and the Authors.
+Portions copyright (c) 2015-2023 Stanford University and the Authors.
 Authors: Peter Eastman
 Contributors: Jason Swails
 
@@ -266,8 +266,8 @@ class PDBxFile(object):
             The Topology defining the model to write
         positions : list
             The list of atomic positions to write
-        file : file=stdout
-            A file to write to
+        file : string or file
+            the name of the file to write.  Alternatively you can pass an open file object.
         keepIds : bool=False
             If True, keep the residue and chain IDs specified in the Topology
             rather than generating new ones.  Warning: It is up to the caller to
@@ -276,8 +276,12 @@ class PDBxFile(object):
         entry : str=None
             The entry ID to assign to the CIF file
         """
-        PDBxFile.writeHeader(topology, file, entry, keepIds)
-        PDBxFile.writeModel(topology, positions, file, keepIds=keepIds)
+        if isinstance(file, str):
+            with open(file, 'w') as output:
+                PDBxFile.writeFile(topology, positions, output, keepIds, entry)
+        else:
+            PDBxFile.writeHeader(topology, file, entry, keepIds)
+            PDBxFile.writeModel(topology, positions, file, keepIds=keepIds)
 
     @staticmethod
     def writeHeader(topology, file=sys.stdout, entry=None, keepIds=False):

--- a/wrappers/python/tests/TestPdbxFile.py
+++ b/wrappers/python/tests/TestPdbxFile.py
@@ -1,13 +1,11 @@
+import tempfile
 import unittest
 from openmm.app import *
 from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
 import os
-if sys.version_info >= (3, 0):
-    from io import StringIO
-else:
-    from cStringIO import StringIO
+from io import StringIO
 
 class TestPdbxFile(unittest.TestCase):
     """Test the PDBx/mmCIF file parser"""
@@ -16,22 +14,13 @@ class TestPdbxFile(unittest.TestCase):
         """Test conversion from PDB to PDBx"""
 
         mol = PDBFile('systems/ala_ala_ala.pdb')
-
-        # Write to 'file'
-        output = StringIO()
-        PDBxFile.writeFile(mol.topology, mol.positions, output,
-                           keepIds=True)
-
-        # Read from 'file'
-        input = StringIO(output.getvalue())
-        try:
-            pdbx = PDBxFile(input)
-        except Exception:
-            self.fail('Parser failed to read PDBx/mmCIF file')
-
-        # Close file handles
-        output.close()
-        input.close()
+        with tempfile.TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, 'temp.pdbx')
+            PDBxFile.writeFile(mol.topology, mol.positions, filename, keepIds=True)
+            try:
+                pdbx = PDBxFile(filename)
+            except Exception:
+                self.fail('Parser failed to read PDBx/mmCIF file')
 
 
     def test_Triclinic(self):


### PR DESCRIPTION
This is a minor simplification to the API for writing PDB and PDBx/mmCIF files.  Instead of having to write

```python
with open(filename, 'w') as output:
    PDBFile.writeFile(topology, positions, output)
```

it now will also accept

```python
PDBFile.writeFile(topology, positions, filename)
```