### PR TITLE
Avoid deprecation warnings in vkFFT

### DIFF
--- a/platforms/opencl/include/OpenCLFFT3D.h
+++ b/platforms/opencl/include/OpenCLFFT3D.h
@@ -31,6 +31,7 @@
 
 #ifdef USE_VKFFT
 #define VKFFT_BACKEND 3
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include "vkFFT.h"
 #endif
 #include "OpenCLArray.h"


### PR DESCRIPTION
The latest version of macOS deprecated the `sprintf()` function.  We don't use `sprintf()` anywhere, but vkFFT does.  This leads to huge volumes of deprecation warnings when compiling.  I added a pragma to remove the warnings.