### PR TITLE
Report status during minimization

### DIFF
--- a/docs-source/api-c++/extras.rst
+++ b/docs-source/api-c++/extras.rst
@@ -62,6 +62,7 @@ that they aren't important!
     :maxdepth: 2
 
     generated/LocalEnergyMinimizer
+    generated/MinimizationReporter
     generated/NoseHooverChain
     generated/OpenMMException
     generated/Vec3

--- a/openmmapi/include/openmm/LocalEnergyMinimizer.h
+++ b/openmmapi/include/openmm/LocalEnergyMinimizer.h
@@ -76,12 +76,13 @@ public:
      * objective function with respect to them, and a set of useful statistics.  In particular,
      * args contains these values:
      * 
-     * <ul>
-     * <li>"system energy": the current potential energy of the system</li>
-     * <li>"restraint energy": the energy of the harmonic restraints</li>
-     * <li>"restraint strength": the force constant of the restraints (in kJ/mol/nm^2)</li>
-     * <li>"max constraint error": the maximum relative error in the length of any constraint</li>
-     * </ul>
+     * "system energy": the current potential energy of the system
+     * 
+     * "restraint energy": the energy of the harmonic restraints
+     * 
+     * "restraint strength": the force constant of the restraints (in kJ/mol/nm^2)
+     * 
+     * "max constraint error": the maximum relative error in the length of any constraint
      * 
      * If this function throws an exception, it will cause the L-BFGS optimizer to immediately
      * exit.  If all constrained distances are sufficiently close to their target values,

--- a/openmmapi/include/openmm/LocalEnergyMinimizer.h
+++ b/openmmapi/include/openmm/LocalEnergyMinimizer.h
@@ -84,7 +84,7 @@ public:
      * 
      * "max constraint error": the maximum relative error in the length of any constraint
      * 
-     * If this function throws an exception, it will cause the L-BFGS optimizer to immediately
+     * If this function returns true, it will cause the L-BFGS optimizer to immediately
      * exit.  If all constrained distances are sufficiently close to their target values,
      * minimize() will return.  If any constraint error is unacceptably large, it will instead
      * cause the minimizer to immediately increase the strength of the harmonic restraints and
@@ -99,8 +99,10 @@ public:
      *                   restraint energy) with respect to the particle coordinates, in flattened
      *                   order
      * @param args       additional statistics described above about the current state of minimization
+     * @return whether to immediately stop minimization
      */
-    virtual void report(int iteration, const std::vector<double>& x, const std::vector<double>& grad, std::map<std::string, double>& args) {
+    virtual bool report(int iteration, const std::vector<double>& x, const std::vector<double>& grad, std::map<std::string, double>& args) {
+        return false;
     }
 };
 

--- a/openmmapi/include/openmm/LocalEnergyMinimizer.h
+++ b/openmmapi/include/openmm/LocalEnergyMinimizer.h
@@ -33,8 +33,75 @@
  * -------------------------------------------------------------------------- */
 
 #include "Context.h"
+#include <map>
+#include <string>
+#include <vector>
 
 namespace OpenMM {
+
+/**
+ * A MinimizationReporter can be passed to LocalEnergyMinimizer::minimize() to provide
+ * periodic information on the progress of minimization, and to give you the chance to
+ * stop minimization early.  Define a subclass that overrides report() and implement it
+ * to take whatever action you want.
+ * 
+ * To correctly interpret the information passed to the reporter, you need to know a bit
+ * about how the minimizer works.  The L-BFGS algorithm used by the minimizer does not
+ * support constraints.  The minimizer therefore replaces all constraints with harmonic
+ * restraints, then performs unconstrained minimization of a combined objective function
+ * that is the sum of the system's potential energy and the restraint energy.  Once
+ * minimization completes, it checks whether all constraints are satisfied to an acceptable
+ * tolerance.  It not, it increases the strength of the harmonic restraints and performs
+ * additional minimization.  If the error in constrained distances is especially large,
+ * it may choose to throw out all work that has been done so far and start over with
+ * stronger restraints.  This has several important consequences.
+ * 
+ * <ul>
+ * <li>The objective function being minimized not actually the same as the potential energy.</li>
+ * <li>The objective function and the potential energy can both increase between iterations.</li>
+ * <li>The total number of iterations performed could be larger than the number specified
+ *     by the maxIterations argument, if that many iterations leaves unacceptable constraint errors.</li>
+ * <li>All work is provisional.  It is possible for the minimizer to throw it out and start over.</li>
+ * </ul>
+ */
+class OPENMM_EXPORT MinimizationReporter {
+public:
+    MinimizationReporter() {
+    }
+    virtual ~MinimizationReporter() {
+    }
+    /**
+     * This is called after each iteration to provide information about the current status
+     * of minimization.  It receives the current particle coordinates, the gradient of the
+     * objective function with respect to them, and a set of useful statistics.  In particular,
+     * args contains these values:
+     * 
+     * <ul>
+     * <li>"system energy": the current potential energy of the system</li>
+     * <li>"restraint energy": the energy of the harmonic restraints</li>
+     * <li>"restraint strength": the force constant of the restraints (in kJ/mol/nm^2)</li>
+     * <li>"max constraint error": the maximum relative error in the length of any constraint</li>
+     * </ul>
+     * 
+     * If this function throws an exception, it will cause the L-BFGS optimizer to immediately
+     * exit.  If all constrained distances are sufficiently close to their target values,
+     * minimize() will return.  If any constraint error is unacceptably large, it will instead
+     * cause the minimizer to immediately increase the strength of the harmonic restraints and
+     * perform additional optimization.
+     * 
+     * @param iteration  the index of the current iteration.  This refers to the current call
+     *                   to the L-BFGS optimizer.  Each time the minimizer increases the restraint
+     *                   strength, the iteration index is reset to 0.
+     * @param x          the current particle positions in flattened order: the three coordinates
+     *                   of the first particle, then the three coordinates of the second particle, etc.
+     * @param grad       the current gradient of the objective function (potential energy plus
+     *                   restraint energy) with respect to the particle coordinates, in flattened
+     *                   order
+     * @param args       additional statistics described above about the current state of minimization
+     */
+    virtual void report(int iteration, const std::vector<double>& x, const std::vector<double>& grad, std::map<std::string, double>& args) {
+    }
+};
 
 /**
  * Given a Context, this class searches for a new set of particle positions that represent
@@ -62,8 +129,10 @@ public:
      * @param maxIterations  the maximum number of iterations to perform.  If this is 0, minimation is continued
      *                       until the results converge without regard to how many iterations it takes.  The
      *                       default value is 0.
+     * @param reporter       an optional MinimizationReporter to invoke after each iteration.  This can be used
+     *                       to monitor the progress of minimization or to stop minimization early.
      */
-    static void minimize(Context& context, double tolerance = 10, int maxIterations = 0);
+    static void minimize(Context& context, double tolerance = 10, int maxIterations = 0, MinimizationReporter* reporter = NULL);
 };
 
 } // namespace OpenMM

--- a/openmmapi/src/LocalEnergyMinimizer.cpp
+++ b/openmmapi/src/LocalEnergyMinimizer.cpp
@@ -46,10 +46,12 @@ using namespace std;
 struct MinimizerData {
     Context& context;
     double k;
+    MinimizationReporter* reporter;
     bool checkLargeForces;
     VerletIntegrator cpuIntegrator;
     Context* cpuContext;
-    MinimizerData(Context& context, double k) : context(context), k(k), cpuIntegrator(1.0), cpuContext(NULL) {
+    MinimizerData(Context& context, double k, MinimizationReporter* reporter) :
+            context(context), k(k), reporter(reporter), cpuIntegrator(1.0), cpuContext(NULL) {
         string platformName = context.getPlatform().getName();
         checkLargeForces = (platformName == "CUDA" || platformName == "OpenCL" || platformName == "HIP" || platformName == "Metal");
     }
@@ -151,7 +153,55 @@ static lbfgsfloatval_t evaluate(void *instance, const lbfgsfloatval_t *x, lbfgsf
     return energy;
 }
 
-void LocalEnergyMinimizer::minimize(Context& context, double tolerance, int maxIterations) {
+static int report(void *instance, const lbfgsfloatval_t *x, const lbfgsfloatval_t *g, const lbfgsfloatval_t fx,
+        const lbfgsfloatval_t xnorm, const lbfgsfloatval_t gnorm, const lbfgsfloatval_t step, int n, int iteration, int ls) {
+    // Copy over the positions and gradients.
+
+    vector<double> xout(n), gradout(n);
+    for (int i = 0; i < n; i++) {
+        xout[i] = x[i];
+        gradout[i] = g[i];
+    }
+
+    // Compute the other arguments passed to the reporter.
+
+    MinimizerData* data = reinterpret_cast<MinimizerData*>(instance);
+    Context& context = data->context;
+    const System& system = context.getSystem();
+    double restraintEnergy = 0.0, maxError = 0.0;
+    double k = data->k;
+    for (int i = 0; i < system.getNumConstraints(); i++) {
+        int p1, p2;
+        double distance;
+        system.getConstraintParameters(i, p1, p2, distance);
+        Vec3 delta(x[3*p1]-x[3*p2], x[3*p1+1]-x[3*p2+1], x[3*p1+2]-x[3*p2+2]);
+        double r2 = delta.dot(delta);
+        double r = sqrt(r2);
+        double dr = r-distance;
+        restraintEnergy += 0.5*k*dr*dr;
+        maxError = max(maxError, fabs(dr)/distance);
+    }
+    map<string, double> args;
+    args["restraint energy"] = restraintEnergy;
+    args["system energy"] = fx-restraintEnergy;
+    args["restraint strength"] = k;
+    args["max constraint error"] = maxError;
+
+    // Invoke the reporter.
+
+    MinimizationReporter* reporter = reinterpret_cast<MinimizationReporter*>(data->reporter);
+    try {
+        reporter->report(iteration-1, xout, gradout, args);
+    }
+    catch (...) {
+        // The reporter threw an exception.  Signal the minimizer to stop.
+
+        return 1;
+    }
+    return 0;
+}
+
+void LocalEnergyMinimizer::minimize(Context& context, double tolerance, int maxIterations, MinimizationReporter* reporter) {
     const System& system = context.getSystem();
     int numParticles = system.getNumParticles();
     double constraintTol = context.getIntegrator().getConstraintTolerance();
@@ -192,12 +242,13 @@ void LocalEnergyMinimizer::minimize(Context& context, double tolerance, int maxI
         // Repeatedly minimize, steadily increasing the strength of the springs until all constraints are satisfied.
 
         double prevMaxError = 1e10;
-        MinimizerData data(context, k);
+        MinimizerData data(context, k, reporter);
         while (true) {
             // Perform the minimization.
 
             lbfgsfloatval_t fx;
-            lbfgs(numParticles*3, x, &fx, evaluate, NULL, &data, &param);
+            lbfgs_progress_t reportFn = (reporter == NULL ? NULL : report);
+            lbfgs(numParticles*3, x, &fx, evaluate, reportFn, &data, &param);
 
             // Check whether all constraints are satisfied.
 
@@ -210,7 +261,7 @@ void LocalEnergyMinimizer::minimize(Context& context, double tolerance, int maxI
                 system.getConstraintParameters(i, particle1, particle2, distance);
                 Vec3 delta = positions[particle2]-positions[particle1];
                 double r = sqrt(delta.dot(delta));
-                double error = fabs(r-distance);
+                double error = fabs(r-distance)/distance;
                 if (error > maxError)
                     maxError = error;
             }

--- a/openmmapi/src/LocalEnergyMinimizer.cpp
+++ b/openmmapi/src/LocalEnergyMinimizer.cpp
@@ -190,14 +190,8 @@ static int report(void *instance, const lbfgsfloatval_t *x, const lbfgsfloatval_
     // Invoke the reporter.
 
     MinimizationReporter* reporter = reinterpret_cast<MinimizationReporter*>(data->reporter);
-    try {
-        reporter->report(iteration-1, xout, gradout, args);
-    }
-    catch (...) {
-        // The reporter threw an exception.  Signal the minimizer to stop.
-
+    if (reporter->report(iteration-1, xout, gradout, args))
         return 1;
-    }
     return 0;
 }
 

--- a/tests/TestLocalEnergyMinimizer.h
+++ b/tests/TestLocalEnergyMinimizer.h
@@ -318,21 +318,22 @@ void testReporter() {
     public:
         int lastIter = 0;
         double lastK = 0, lastEnergy = 0;
-        bool threwException = false, success = true;
-        void report(int iteration, const vector<double>& x, const vector<double>& grad, map<string, double>& args) {
+        bool canceled = false, success = true;
+        bool report(int iteration, const vector<double>& x, const vector<double>& grad, map<string, double>& args) {
             double k = args["restraint strength"];
             if (iteration > 0)
                 success &= (iteration == lastIter+1 && k == lastK) | (iteration == 0 && k > lastK);
-            if (threwException)
+            if (canceled)
                 success &= (iteration == 0 && k > lastK);
             lastEnergy = args["system energy"];
             if (iteration > 300 && args["max constraint error"] > 1e-4) {
-                threwException = true;
-                throw OpenMMException("Stopping");
+                canceled = true;
+                return true;
             }
-            threwException = false;
+            canceled = false;
             lastIter = iteration;
             lastK = k;
+            return false;
         }
     };
 

--- a/tests/TestLocalEnergyMinimizer.h
+++ b/tests/TestLocalEnergyMinimizer.h
@@ -7,7 +7,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -32,6 +32,7 @@
 
 #include "openmm/internal/AssertionUtilities.h"
 #include "openmm/Context.h"
+#include "openmm/CustomExternalForce.h"
 #include "openmm/HarmonicBondForce.h"
 #include "openmm/LocalEnergyMinimizer.h"
 #include "openmm/NonbondedForce.h"
@@ -295,6 +296,53 @@ void testMasslessParticles() {
     ASSERT_EQUAL_TOL(1.05, sqrt(delta.dot(delta)), 1e-4);
 }
 
+void testReporter() {
+    const int numParticles = 30;
+    System system;
+    CustomExternalForce* force = new CustomExternalForce("sin(5*x)+cos(2*y)*(sin(3*z)+1.5)");
+    system.addForce(force);
+    vector<Vec3> positions;
+    for (int i = 0; i < numParticles; i++) {
+        system.addParticle(1.0);
+        force->addParticle(i);
+        positions.push_back(Vec3(0.5*i, 0.3*sin(i), 0.2*cos(i)));
+        if (i > 0)
+            system.addConstraint(i-1, i, 1.0);
+    }
+    VerletIntegrator integrator(0.01);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    context.applyConstraints(1e-5);
+
+    class Reporter : public MinimizationReporter {
+    public:
+        int lastIter = 0;
+        double lastK = 0, lastEnergy = 0;
+        bool threwException = false, success = true;
+        void report(int iteration, const vector<double>& x, const vector<double>& grad, map<string, double>& args) {
+            double k = args["restraint strength"];
+            if (iteration > 0)
+                success &= (iteration == lastIter+1 && k == lastK) | (iteration == 0 && k > lastK);
+            if (threwException)
+                success &= (iteration == 0 && k > lastK);
+            lastEnergy = args["system energy"];
+            if (iteration > 300 && args["max constraint error"] > 1e-4) {
+                threwException = true;
+                throw OpenMMException("Stopping");
+            }
+            threwException = false;
+            lastIter = iteration;
+            lastK = k;
+        }
+    };
+
+    Reporter reporter;
+    LocalEnergyMinimizer::minimize(context, 1.0, 0, &reporter);
+    ASSERT(reporter.success);
+    State state = context.getState(State::Energy);
+    ASSERT_EQUAL_TOL(state.getPotentialEnergy(), reporter.lastEnergy, 1e-5);
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -306,6 +354,7 @@ int main(int argc, char* argv[]) {
         testLargeForces();
         testForceGroups();
         testMasslessParticles();
+        testReporter();
         runPlatformTests();
     }
     catch(const exception& e) {

--- a/wrappers/python/openmm/app/simulation.py
+++ b/wrappers/python/openmm/app/simulation.py
@@ -123,7 +123,7 @@ class Simulation(object):
     def currentStep(self, step):
         self.context.setStepCount(step)
 
-    def minimizeEnergy(self, tolerance=10*unit.kilojoules_per_mole/unit.nanometer, maxIterations=0):
+    def minimizeEnergy(self, tolerance=10*unit.kilojoules_per_mole/unit.nanometer, maxIterations=0, reporter=None):
         """Perform a local energy minimization on the system.
 
         Parameters
@@ -136,8 +136,11 @@ class Simulation(object):
             The maximum number of iterations to perform.  If this is 0,
             minimization is continued until the results converge without regard
             to how many iterations it takes.
+        reporter : MinimizationReporter = None
+            an optional reporter to invoke after each iteration.  This can be used to monitor the progress
+            of minimization or to stop minimization early.
         """
-        mm.LocalEnergyMinimizer.minimize(self.context, tolerance, maxIterations)
+        mm.LocalEnergyMinimizer.minimize(self.context, tolerance, maxIterations, reporter)
 
     def step(self, steps):
         """Advance the simulation by integrating a specified number of time steps."""

--- a/wrappers/python/src/swig_doxygen/OpenMM.i
+++ b/wrappers/python/src/swig_doxygen/OpenMM.i
@@ -1,4 +1,4 @@
-%module openmm
+%module(directors="1") openmm
 %include "factory.i"
 
 %include "std_string.i"

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
@@ -43,17 +43,22 @@
     PyThreadState* _savePythonThreadState = (releaseGIL ? PyEval_SaveThread() : nullptr);
     try {
         $action
-    } catch (std::exception &e) {
+    }
+    catch (std::exception &e) {
         if (releaseGIL)
             PyEval_RestoreThread(_savePythonThreadState);
-        PyObject* mm = PyImport_AddModule("openmm");
-        PyObject* openmm_exception = PyObject_GetAttrString(mm, "OpenMMException");
-        PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
-        return NULL;
+        if (dynamic_cast<Swig::DirectorException*>(&e) != NULL) {
+            SWIG_fail;
+        }
+        else {
+            PyObject* mm = PyImport_AddModule("openmm");
+            PyObject* openmm_exception = PyObject_GetAttrString(mm, "OpenMMException");
+            PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
+            return NULL;
+        }
     }
     if (releaseGIL)
         PyEval_RestoreThread(_savePythonThreadState);
-    PyErr_Restore(NULL, NULL, NULL);
 }
 
 %exception OpenMM::Context::setVelocitiesToTemperature {

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
@@ -51,9 +51,9 @@
         PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
         return NULL;
     }
-    PyErr_Restore(NULL, NULL, NULL);
     if (releaseGIL)
         PyEval_RestoreThread(_savePythonThreadState);
+    PyErr_Restore(NULL, NULL, NULL);
 }
 
 %exception OpenMM::Context::setVelocitiesToTemperature {

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/exceptions.i
@@ -39,17 +39,21 @@
 }
 
 %exception OpenMM::LocalEnergyMinimizer::minimize {
-    PyThreadState* _savePythonThreadState = PyEval_SaveThread();
+    bool releaseGIL = (nobjs < 4 || swig_obj[3] == Py_None);
+    PyThreadState* _savePythonThreadState = (releaseGIL ? PyEval_SaveThread() : nullptr);
     try {
         $action
     } catch (std::exception &e) {
-        PyEval_RestoreThread(_savePythonThreadState);
+        if (releaseGIL)
+            PyEval_RestoreThread(_savePythonThreadState);
         PyObject* mm = PyImport_AddModule("openmm");
         PyObject* openmm_exception = PyObject_GetAttrString(mm, "OpenMMException");
         PyErr_SetString(openmm_exception, const_cast<char*>(e.what()));
         return NULL;
     }
-    PyEval_RestoreThread(_savePythonThreadState);
+    PyErr_Restore(NULL, NULL, NULL);
+    if (releaseGIL)
+        PyEval_RestoreThread(_savePythonThreadState);
 }
 
 %exception OpenMM::Context::setVelocitiesToTemperature {

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/features.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/features.i
@@ -9,3 +9,5 @@
 %include pythonprepend.i
 %include pythonappend.i
 %include typemaps.i
+
+%feature("director") OpenMM::MinimizationReporter;

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -215,9 +215,10 @@ class TestSimulation(unittest.TestCase):
                     self.error = True
                 self.lastIteration = iteration
                 if iteration == 10:
-                    raise ValueError('stop minimizing')
+                    return True
                 if iteration > 10:
                     self.error = True
+                return False
 
         reporter = Reporter()
         simulation.minimizeEnergy(reporter=reporter)

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -208,16 +208,20 @@ class TestSimulation(unittest.TestCase):
 
         class Reporter(MinimizationReporter):
             lastIteration = -1
+            error = False
 
             def report(self, iteration, x, grad, args):
-                assert iteration == self.lastIteration+1
+                if iteration != self.lastIteration+1:
+                    self.error = True
                 self.lastIteration = iteration
                 if iteration == 10:
                     raise ValueError('stop minimizing')
-                assert iteration < 11
+                if iteration > 10:
+                    self.error = True
 
         reporter = Reporter()
         simulation.minimizeEnergy(reporter=reporter)
+        assert not reporter.error
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements #1155.

This adds a virtual MinimizationReporter class.  You subclass it, implementing the `report()` method, and pass it to `minimize()`.  It gets called after each iteration.

The Python API was a little challenging.  This is the first time we've had an interface in which C++ code invokes Python code, instead of the other way around.  I ran into some SWIG issues (https://github.com/swig/swig/issues/2670 and https://github.com/swig/swig/issues/2671), but I think I have workarounds for them.