### PR TITLE
Update IntegrationUtilities.cpp to include <functional>

### DIFF
--- a/platforms/common/src/IntegrationUtilities.cpp
+++ b/platforms/common/src/IntegrationUtilities.cpp
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <functional>
 #include <map>
 #include <set>
 


### PR DESCRIPTION
Fixes #4213 

Including the `functional` header as per its standard location per: https://en.cppreference.com/w/cpp/utility/functional/binary_function