### PR TITLE
Don't add extra bond between water hydrogens

### DIFF
--- a/wrappers/python/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/openmm/app/amberprmtopfile.py
@@ -160,7 +160,13 @@ class AmberPrmtopFile(object):
 
         atoms = list(top.atoms())
         for bond in prmtop.getBondsWithH():
-            top.addBond(atoms[bond[0]], atoms[bond[1]])
+            a1 = atoms[bond[0]]
+            a2 = atoms[bond[1]]
+            if a1.residue.name == 'HOH' and a1.element == elem.hydrogen and a2.element == elem.hydrogen:
+                # Don't add the "bond" Amber lists between the two hydrogens of a water molecule.
+                pass
+            else:
+                top.addBond(a1, a2)
         for bond in prmtop.getBondsNoH():
             top.addBond(atoms[bond[0]], atoms[bond[1]])
 

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -439,7 +439,6 @@ class TestForceField(unittest.TestCase):
    <Atom name="H2" type="tip3p-H" charge="0.417"/>
    <Bond from="0" to="1"/>
    <Bond from="0" to="2"/>
-   <Bond from="1" to="2"/>
   </Residue>
   <Residue name="HOH2">
    <Atom name="O" type="tip3p-O" charge="0.834"/>
@@ -447,7 +446,6 @@ class TestForceField(unittest.TestCase):
    <Atom name="H2" type="tip3p-H" charge="-0.417"/>
    <Bond from="0" to="1"/>
    <Bond from="0" to="2"/>
-   <Bond from="1" to="2"/>
   </Residue>
  </Residues>
  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5">


### PR DESCRIPTION
Fixes #4212.

Amber files list an extra "bond" between the hydrogens of a water molecule, which was incorrectly included in the Topology built from a prmtop file.  A Topology should only include actual chemical bonds.