### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/wrappers/python/openmm/app/gromacstopfile.py
+++ b/wrappers/python/openmm/app/gromacstopfile.py
@@ -42,7 +42,7 @@ import openmm as mm
 import math
 import os
 import re
-import distutils.spawn
+import shutil
 from collections import OrderedDict, defaultdict
 from itertools import combinations, combinations_with_replacement
 from copy import deepcopy
@@ -1327,11 +1327,11 @@ def _defaultGromacsIncludeDir():
     if 'GMXBIN' in os.environ:
         return os.path.abspath(os.path.join(os.environ['GMXBIN'], '..', 'share', 'gromacs', 'top'))
 
-    pdb2gmx_path = distutils.spawn.find_executable('pdb2gmx')
+    pdb2gmx_path = shutil.which('pdb2gmx')
     if pdb2gmx_path is not None:
         return os.path.abspath(os.path.join(os.path.dirname(pdb2gmx_path), '..', 'share', 'gromacs', 'top'))
     else:
-        gmx_path = distutils.spawn.find_executable('gmx')
+        gmx_path = shutil.which('gmx')
         if gmx_path is not None:
             return os.path.abspath(os.path.join(os.path.dirname(gmx_path), '..', 'share', 'gromacs', 'top'))
 

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -7,7 +7,7 @@ import os
 import sys
 import platform
 import numpy
-from distutils.core import setup
+from setuptools import setup
 from Cython.Build import cythonize
 
 MAJOR_VERSION_NUM='@OPENMM_MAJOR_VERSION@'
@@ -125,7 +125,7 @@ if not release:
 def buildKeywordDictionary(major_version_num=MAJOR_VERSION_NUM,
                            minor_version_num=MINOR_VERSION_NUM,
                            build_info=BUILD_INFO):
-    from distutils.core import Extension
+    from setuptools import Extension
     setupKeywords = {}
     setupKeywords["name"]              = "OpenMM"
     setupKeywords["version"]           = "%s.%s.%s" % (major_version_num,


### PR DESCRIPTION
Distutils has been deprecated in favor of setuptools for quite a while.  Python 3.12 removes it altogether.  This switches the imports, which I think is the only change necessary.