### PR TITLE
Remove support for Gromacs implicit solvent

### DIFF
--- a/devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
@@ -16,4 +16,4 @@ dependencies:
 - pytest
 - pytest-xdist
 - pytest-timeout
-- gromacs 2018.*
+- gromacs

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
@@ -19,4 +19,4 @@ dependencies:
 - pytest
 - pytest-xdist
 - pytest-timeout
-- gromacs 2018.*
+- gromacs

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
@@ -19,4 +19,4 @@ dependencies:
 - pytest
 - pytest-xdist
 - pytest-timeout
-- gromacs 2018.*
+- gromacs

--- a/wrappers/python/openmm/app/gromacstopfile.py
+++ b/wrappers/python/openmm/app/gromacstopfile.py
@@ -290,8 +290,6 @@ class GromacsTopFile(object):
                 self._processAngleType(line)
             elif self._currentCategory == 'dihedraltypes':
                 self._processDihedralType(line)
-            elif self._currentCategory == 'implicit_genborn_params':
-                self._processImplicitType(line)
             elif self._currentCategory == 'pairtypes':
                 self._processPairType(line)
             elif self._currentCategory == 'cmaptypes':
@@ -488,13 +486,6 @@ class GromacsTopFile(object):
         else:
             self._dihedralTypes[key] = [fields]
 
-    def _processImplicitType(self, line):
-        """Process a line in the [ implicit_genborn_params ] category."""
-        fields = line.split()
-        if len(fields) < 6:
-            raise ValueError('Too few fields in [ implicit_genborn_params ] line: '+line)
-        self._implicitTypes[fields[0]] = fields
-
     def _processPairType(self, line):
         """Process a line in the [ pairtypes ] category."""
         fields = line.split()
@@ -586,7 +577,6 @@ class GromacsTopFile(object):
         self._bondTypes= {}
         self._angleTypes = {}
         self._dihedralTypes = {}
-        self._implicitTypes = {}
         self._pairTypes = {}
         self._cmapTypes = {}
         self._nonbondTypes = {}
@@ -661,9 +651,8 @@ class GromacsTopFile(object):
                 for fields in moleculeType.bonds:
                     top.addBond(atoms[int(fields[0])-1], atoms[int(fields[1])-1])
 
-    def createSystem(self, nonbondedMethod=ff.NoCutoff, nonbondedCutoff=1.0*unit.nanometer,
-                     constraints=None, rigidWater=True, implicitSolvent=None, soluteDielectric=1.0, solventDielectric=78.5,
-                     ewaldErrorTolerance=0.0005, removeCMMotion=True, hydrogenMass=None, switchDistance=None):
+    def createSystem(self, nonbondedMethod=ff.NoCutoff, nonbondedCutoff=1.0*unit.nanometer, constraints=None,
+                     rigidWater=True, ewaldErrorTolerance=0.0005, removeCMMotion=True, hydrogenMass=None, switchDistance=None):
         """Construct an OpenMM System representing the topology described by this
         top file.
 
@@ -682,16 +671,6 @@ class GromacsTopFile(object):
         rigidWater : boolean=True
             If true, water molecules will be fully rigid regardless of the value
             passed for the constraints argument
-        implicitSolvent : object=None
-            If not None, the implicit solvent model to use.  The only allowed
-            value is OBC2.  This option is deprecated, since Gromacs 2019 and later
-            no longer support implicit solvent.  It will be removed in a future
-            release.
-        soluteDielectric : float=1.0
-            The solute dielectric constant to use in the implicit solvent model.
-        solventDielectric : float=78.5
-            The solvent dielectric constant to use in the implicit solvent
-            model.
         ewaldErrorTolerance : float=0.0005
             The error tolerance to use if nonbondedMethod is Ewald, PME or LJPME.
         removeCMMotion : boolean=True
@@ -741,14 +720,6 @@ class GromacsTopFile(object):
             lj.addPerParticleParameter('C')
             lj.addPerParticleParameter('A')
             sys.addForce(lj)
-        if implicitSolvent is OBC2:
-            gb = mm.GBSAOBCForce()
-            gb.setSoluteDielectric(soluteDielectric)
-            gb.setSolventDielectric(solventDielectric)
-            sys.addForce(gb)
-            nb.setReactionFieldDielectric(1.0)
-        elif implicitSolvent is not None:
-            raise ValueError('Illegal value for implicitSolvent')
         bonds = {}
         angles = {}
         periodic = None
@@ -1038,11 +1009,6 @@ class GromacsTopFile(object):
                             epsilon = float(params[7])
                             lj.addParticle([math.sqrt(4*epsilon*sigma**6), math.sqrt(4*epsilon*sigma**12)])
 
-                    if implicitSolvent is OBC2:
-                        if fields[1] not in self._implicitTypes:
-                            raise ValueError('No implicit solvent parameters specified for atom type: '+fields[1])
-                        gbparams = self._implicitTypes[fields[1]]
-                        gb.addParticle(q, float(gbparams[4]), float(gbparams[5]))
                 for fields in moleculeType.bonds:
                     atoms = [int(x)-1 for x in fields[:2]]
                     bondIndices.append((baseAtomIndex+atoms[0], baseAtomIndex+atoms[1]))


### PR DESCRIPTION
Fixes #3006.

Gromacs 2019 removed all support for implicit solvent, and apparently it had been broken for years before that.  We continued to support implicit solvent when reading Gromacs .top files, but it only worked if you had an increasingly obsolete version of Gromacs installed.  In OpenMM 7.7 we marked it as deprecated.  This goes the rest of the way and completely removes support for Gromacs files with implicit solvent.