### PR TITLE
Note that w_cross has units of inverse distance

### DIFF
--- a/openmmapi/include/openmm/VirtualSite.h
+++ b/openmmapi/include/openmm/VirtualSite.h
@@ -136,7 +136,9 @@ private:
  * r<sub>1</sub> + w<sub>12</sub>r<sub>12</sub> + w<sub>13</sub>r<sub>13</sub> + w<sub>cross</sub>(r<sub>12</sub> x r<sub>13</sub>)
  * 
  * The three weight factors are user-specified.  This allows the virtual site location
- * to be out of the plane of the three particles.
+ * to be out of the plane of the three particles. Note that while
+ * w<sub>12</sub> and w<sub>13</sub> are unitless and w<sub>cross</sub> has
+ * units of inverse distance.
  */
 class OPENMM_EXPORT OutOfPlaneSite : public VirtualSite {
 public:


### PR DESCRIPTION
https://github.com/openmm/openmm/issues/4262#issuecomment-1758274887

This is the smallest change that would prevent future users from catching the tripwire I've found myself on. I didn't update the user guide or other classes since I think that's somewhat more obvious - it's really this one weight in this one class that's not intuitive - but I can do that easily if we think that's useful.