### PR TITLE
Removed use of obsolete method iteritems()

### DIFF
--- a/wrappers/python/openmm/app/gromacstopfile.py
+++ b/wrappers/python/openmm/app/gromacstopfile.py
@@ -562,7 +562,7 @@ class GromacsTopFile(object):
         self._defines['FLEXIBLE'] = True
         self._genpairs = True
         if defines is not None:
-            for define, value in defines.iteritems():
+            for define, value in defines.items():
                 self._defines[define] = value
 
         # Parse the file.


### PR DESCRIPTION
Fixes #4284.  The `iteritems()` method was changed to `items()` in Python 3.