### PR TITLE
Remove OpenCL cl_khr_fp64 pragma no longer required in OpenCL 1.2

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -603,8 +603,6 @@ cl::Program OpenCLContext::createProgram(const string source, const map<string, 
     }
     if (!compilationDefines.empty())
         src << endl;
-    if (supportsDoublePrecision)
-        src << "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n";
     if (useDoublePrecision) {
         src << "typedef double real;\n";
         src << "typedef double2 real2;\n";


### PR DESCRIPTION
Closes #2986