### PR TITLE
Add support for non-(amd64,Arm,PPC) using SIMD Everywhere

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -41,6 +41,7 @@ jobs:
       # Note: conda activate doesn't work here, because it creates a new shell!
       - script: |
           conda install cmake ^
+                        simde ^
                         cython ^
                         ninja ^
                         numpy ^

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - python-numpy
       - python-scipy
       - libfftw3-dev
+      - libsimde-dev
 
 env:
   global:
@@ -127,7 +128,7 @@ before_install:
   - mkdir -p $HOME/ccache && tar xf ccache-3.2.4-0.tar.bz2 -C $HOME/ccache
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew cask uninstall oclint;
-      brew install fftw;
+      brew install fftw simde;
       brew upgrade python;
       brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
       pip3 install virtualenv;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,7 @@ ENDIF(${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
 # The source is organized into subdirectories, but we handle them all from
 # this CMakeLists file rather than letting CMake visit them as SUBDIRS.
 SET(OPENMM_SOURCE_SUBDIRS . openmmapi olla libraries/jama libraries/quern libraries/lepton libraries/sfmt libraries/lbfgs libraries/hilbert libraries/csha1 libraries/pocketfft libraries/vkfft platforms/reference serialization libraries/irrxml)
-IF(X86 OR ARM)
-    SET(OPENMM_SOURCE_SUBDIRS ${OPENMM_SOURCE_SUBDIRS} libraries/vecmath)
-ENDIF()
+SET(OPENMM_SOURCE_SUBDIRS ${OPENMM_SOURCE_SUBDIRS} libraries/vecmath)
 IF(WIN32)
     SET(OPENMM_SOURCE_SUBDIRS ${OPENMM_SOURCE_SUBDIRS} libraries/pthreads)
 ELSE(WIN32)

--- a/devtools/ci/gh-actions/conda-envs/build-M1-arm64.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-M1-arm64.yml
@@ -12,6 +12,7 @@ dependencies:
 - swig
 - numpy
 - doxygen 1.9.1
+- simde
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-macos-latest.yml
@@ -12,6 +12,7 @@ dependencies:
 - swig
 - numpy
 - doxygen 1.8.14
+- simde
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
@@ -15,6 +15,7 @@ dependencies:
 - numpy
 - ocl-icd-system
 - doxygen 1.8.14
+- simde
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
@@ -15,6 +15,7 @@ dependencies:
 - numpy
 - ocl-icd-system
 - doxygen 1.8.14
+- simde
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
@@ -15,6 +15,7 @@ dependencies:
 - numpy
 - doxygen 1.8.14
 - khronos-opencl-icd-loader
+- simde
 # test
 - pytest
 - pytest-xdist

--- a/libraries/vecmath/include/sse_mathfun.h
+++ b/libraries/vecmath/include/sse_mathfun.h
@@ -29,7 +29,8 @@
   (this is the zlib license)
 */
 
-#include <xmmintrin.h>
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse.h>
 #include "openmm/internal/windowsExport.h"
 
 /* yes I know, the top of this file is quite ugly */
@@ -46,7 +47,7 @@
 typedef __m128 v4sf;  // vector of 4 float (sse1)
 
 #ifdef USE_SSE2
-# include <emmintrin.h>
+# include <simde/x86/sse2.h>
 typedef __m128i v4si; // vector of 4 int (sse2)
 #else
 typedef __m64 v2si;   // vector of 2 int (mmx)

--- a/openmmapi/include/openmm/internal/hardware.h
+++ b/openmmapi/include/openmm/internal/hardware.h
@@ -93,8 +93,7 @@ static int getNumProcessors() {
 #ifdef WIN32
 #define cpuid __cpuid
 #else
-#if !defined(__ANDROID__) && !defined(__PNACL__) && !defined(__PPC__) \
-    && !defined(__ARM__) && !defined(__ARM64__)
+#if defined(__x86_64__) || defined(__i386__)
     static void cpuid(int cpuInfo[4], int infoType) {
     #ifdef __LP64__
         __asm__ __volatile__ (

--- a/openmmapi/include/openmm/internal/vectorize_sse.h
+++ b/openmmapi/include/openmm/internal/vectorize_sse.h
@@ -32,11 +32,8 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#ifdef __AVX__
-#include <immintrin.h>
-#else
-#include <smmintrin.h>
-#endif
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/avx.h>
 
 #include "hardware.h"
 
@@ -101,7 +98,7 @@ public:
     void storeVec3(float* v) const {
         // This code could be called from objects compiled for better SIMD domains (e.g., AVX) so conditionally
         // compile in the most efficient variant of the instruction.
-#ifdef  __AVX__
+#if defined(SIMDE_X86_AVX_NATIVE) || !defined(SIMDE_X86_SSE2_NATIVE)
         _mm_maskstore_ps(v, _mm_setr_epi32(-1, -1, -1, 0), val);
 #else
         _mm_maskmoveu_si128 (_mm_castps_si128(val), _mm_setr_epi32(-1, -1, -1, 0), (char*)v);


### PR DESCRIPTION
Hello, this enables building and running openmm on riscv64 and other non-(amd64,arm,ppc) systems.

It uses the portable (and sometimes optimized) implementations of x86 intrinsics from https://github.com/simd-everywhere/simde

Once riscv64 hardware with support for version 1.0 of their vector extension becomes more widely available, then a proper riscv64 implementation could be written.

If you want to bundle the SIMDe library instead of making it an external dependency, then I'm happy to do so. Just let me know how you would like it: 1) single-file; 2) folder copied in; or 3) git sub module.