### PR TITLE
Optimizations to reporters

### DIFF
--- a/wrappers/python/openmm/app/dcdfile.py
+++ b/wrappers/python/openmm/app/dcdfile.py
@@ -121,9 +121,10 @@ class DCDFile(object):
             raise ValueError('The number of positions must match the number of atoms')
         if is_quantity(positions):
             positions = positions.value_in_unit(nanometers)
-        if any(math.isnan(norm(pos)) for pos in positions):
+        import numpy as np
+        if np.isnan(positions).any():
             raise ValueError('Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
-        if any(math.isinf(norm(pos)) for pos in positions):
+        if np.isinf(positions).any():
             raise ValueError('Particle position is infinite.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
         file = self._file
 

--- a/wrappers/python/openmm/app/dcdreporter.py
+++ b/wrappers/python/openmm/app/dcdreporter.py
@@ -104,7 +104,7 @@ class DCDReporter(object):
                 self._out, simulation.topology, simulation.integrator.getStepSize(),
                 simulation.currentStep, self._reportInterval, self._append
             )
-        self._dcd.writeModel(state.getPositions(), periodicBoxVectors=state.getPeriodicBoxVectors())
+        self._dcd.writeModel(state.getPositions(asNumpy=True), periodicBoxVectors=state.getPeriodicBoxVectors())
 
     def __del__(self):
         self._out.close()

--- a/wrappers/python/openmm/app/pdbfile.py
+++ b/wrappers/python/openmm/app/pdbfile.py
@@ -343,9 +343,10 @@ class PDBFile(object):
             raise ValueError('The number of positions must match the number of atoms')
         if is_quantity(positions):
             positions = positions.value_in_unit(angstroms)
-        if any(math.isnan(norm(pos)) for pos in positions):
+        import numpy as np
+        if np.isnan(positions).any():
             raise ValueError('Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
-        if any(math.isinf(norm(pos)) for pos in positions):
+        if np.isinf(positions).any():
             raise ValueError('Particle position is infinite.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
         nonHeterogens = PDBFile._standardResidues[:]
         nonHeterogens.remove('HOH')

--- a/wrappers/python/openmm/app/pdbreporter.py
+++ b/wrappers/python/openmm/app/pdbreporter.py
@@ -104,12 +104,12 @@ class PDBReporter(object):
             topology = self._subsetTopology
 
             #PDBFile will convert to angstroms so do it here first instead
-            positions = state.getPositions().value_in_unit(angstroms) 
+            positions = state.getPositions(asNumpy=True).value_in_unit(angstroms)
             positions = [positions[i] for i in self._atomSubset]
 
         else:
             topology = simulation.topology
-            positions = state.getPositions()
+            positions = state.getPositions(asNumpy=True)
 
         if self._nextModel == 0:
             PDBFile.writeHeader(topology, self._out)
@@ -202,12 +202,12 @@ class PDBxReporter(PDBReporter):
             topology = self._subsetTopology
 
             #PDBFile will convert to angstroms so do it here first instead
-            positions = state.getPositions().value_in_unit(angstroms) 
+            positions = state.getPositions(asNumpy=True).value_in_unit(angstroms)
             positions = [positions[i] for i in self._atomSubset]
 
         else:
             topology = simulation.topology
-            positions = state.getPositions()
+            positions = state.getPositions(asNumpy=True)
 
         if self._nextModel == 0:
             PDBxFile.writeHeader(topology, self._out)

--- a/wrappers/python/openmm/app/pdbxfile.py
+++ b/wrappers/python/openmm/app/pdbxfile.py
@@ -418,9 +418,10 @@ class PDBxFile(object):
             raise ValueError('The number of positions must match the number of atoms')
         if is_quantity(positions):
             positions = positions.value_in_unit(angstroms)
-        if any(math.isnan(norm(pos)) for pos in positions):
+        import numpy as np
+        if np.isnan(positions).any():
             raise ValueError('Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
-        if any(math.isinf(norm(pos)) for pos in positions):
+        if np.isinf(positions).any():
             raise ValueError('Particle position is infinite.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
         nonHeterogens = PDBFile._standardResidues[:]
         nonHeterogens.remove('HOH')

--- a/wrappers/python/openmm/app/xtcfile.py
+++ b/wrappers/python/openmm/app/xtcfile.py
@@ -9,11 +9,9 @@ from openmm.app.internal.xtc_utils import (
     get_xtc_nframes,
     get_xtc_natoms,
 )
-import numpy as np
 import os
 from openmm import Vec3
 from openmm.unit import nanometers, picoseconds, is_quantity, norm
-import math
 import tempfile
 import shutil
 

--- a/wrappers/python/openmm/app/xtcfile.py
+++ b/wrappers/python/openmm/app/xtcfile.py
@@ -92,11 +92,12 @@ class XTCFile(object):
             raise ValueError("The number of positions must match the number of atoms")
         if is_quantity(positions):
             positions = positions.value_in_unit(nanometers)
-        if any(math.isnan(norm(pos)) for pos in positions):
+        import numpy as np
+        if np.isnan(positions).any():
             raise ValueError(
                 "Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan"
             )
-        if any(math.isinf(norm(pos)) for pos in positions):
+        if np.isinf(positions).any():
             raise ValueError(
                 "Particle position is infinite.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan"
             )

--- a/wrappers/python/openmm/app/xtcreporter.py
+++ b/wrappers/python/openmm/app/xtcreporter.py
@@ -71,5 +71,5 @@ class XTCReporter(object):
                 self._append,
             )
         self._xtc.writeModel(
-            state.getPositions(), periodicBoxVectors=state.getPeriodicBoxVectors()
+            state.getPositions(asNumpy=True), periodicBoxVectors=state.getPeriodicBoxVectors()
         )


### PR DESCRIPTION
It turned out that the reporters for writing trajectories in OpenMM had much higher overhead than was really necessary.  See https://github.com/mdtraj/mdtraj/issues/1840, which found that the new XTCReporter is many times slower than the corresponding one in MDTraj.

The first major source of overhead was that they retrieved the positions from the State by calling `getPositions()`, which involves constructing a Vec3 object for every particle, rather than `getPositions(asNumpy=True)`, which just requires a simple memcpy.  It was especially bad for XTCReporter, which then internally coverts it to a Numpy array anyway.

To test this, I ran the simulatePdb.py example, which simulates a fairly small system, while having it write a frame every 10 steps in a few different formats.  That's much more often than people would typically want, of course, but it's useful to emphasize the cost of the reporter.  Here are the total times in seconds for 10,000 steps.

No reporter: 13.6
PDB: 68.5
DCD: 41.7
XTC: 50.7

Here are the times after adding `asNumpy=True`.

PDB: 62.9
DCD: 39.2
XTC: 31.7

It's only a small speedup for PDB and DCD, but a much larger speedup for XTC, presumably because it avoids the extra conversion.

The next bottleneck came from these lines:

https://github.com/openmm/openmm/blob/127a373381a35ca6abc7a4966795bb7b4a87ae37/wrappers/python/openmm/app/xtcfile.py#L95-L102

That's a very inefficient way of doing the error check.  I replaced them with calls to `np.isnan(positions)` and `np.isinf(positions)`.  Here are the times after doing that.

PDB: 43.1
DCD: 19.3
XTC: 22.5

The result is a moderate speedup to PDB, and quite large speedups to DCD and XTC.