### PR TITLE
Improved sorting of blocks when building neighbor list

### DIFF
--- a/platforms/cuda/include/CudaNonbondedUtilities.h
+++ b/platforms/cuda/include/CudaNonbondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2022 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -338,6 +338,7 @@ private:
     CudaArray sortedBlocks;
     CudaArray sortedBlockCenter;
     CudaArray sortedBlockBoundingBox;
+    CudaArray blockSizeRange;
     CudaArray largeBlockCenter;
     CudaArray largeBlockBoundingBox;
     CudaArray oldPositions;
@@ -345,7 +346,7 @@ private:
     CudaSort* blockSorter;
     CUevent downloadCountEvent;
     unsigned int* pinnedCountBuffer;
-    std::vector<void*> forceArgs, findBlockBoundsArgs, sortBoxDataArgs, findInteractingBlocksArgs;
+    std::vector<void*> forceArgs, findBlockBoundsArgs, computeSortKeysArgs, sortBoxDataArgs, findInteractingBlocksArgs;
     std::vector<std::vector<int> > atomExclusions;
     std::vector<ParameterInfo> parameters;
     std::vector<ParameterInfo> arguments;
@@ -354,7 +355,7 @@ private:
     std::map<int, std::string> groupKernelSource;
     double lastCutoff;
     bool useCutoff, usePeriodic, anyExclusions, usePadding, useNeighborList, forceRebuildNeighborList, canUsePairList, useLargeBlocks;
-    int startTileIndex, startBlockIndex, numBlocks, maxExclusions, numForceThreadBlocks, forceThreadBlockSize, numAtoms, groupFlags;
+    int startTileIndex, startBlockIndex, numBlocks, maxExclusions, numForceThreadBlocks, forceThreadBlockSize, numAtoms, groupFlags, numBlockSizes;
     unsigned int maxTiles, maxSinglePairs, tilesAfterReorder;
     long long numTiles;
     std::string kernelSource;
@@ -371,6 +372,7 @@ public:
     std::string source;
     CUfunction forceKernel, energyKernel, forceEnergyKernel;
     CUfunction findBlockBoundsKernel;
+    CUfunction computeSortKeysKernel;
     CUfunction sortBoxDataKernel;
     CUfunction findInteractingBlocksKernel;
     CUfunction findInteractionsWithinBlocksKernel;

--- a/platforms/cuda/src/CudaNonbondedUtilities.cpp
+++ b/platforms/cuda/src/CudaNonbondedUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2022 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -49,18 +49,15 @@ using namespace std;
 
 class CudaNonbondedUtilities::BlockSortTrait : public CudaSort::SortTrait {
 public:
-    BlockSortTrait(bool useDouble) : useDouble(useDouble) {
-    }
-    int getDataSize() const {return useDouble ? sizeof(double2) : sizeof(float2);}
-    int getKeySize() const {return useDouble ? sizeof(double) : sizeof(float);}
-    const char* getDataType() const {return "real2";}
-    const char* getKeyType() const {return "real";}
-    const char* getMinKey() const {return "-3.40282e+38f";}
-    const char* getMaxKey() const {return "3.40282e+38f";}
-    const char* getMaxValue() const {return "make_real2(3.40282e+38f, 3.40282e+38f)";}
-    const char* getSortKey() const {return "value.x";}
-private:
-    bool useDouble;
+    BlockSortTrait() {}
+    int getDataSize() const {return sizeof(int);}
+    int getKeySize() const {return sizeof(int);}
+    const char* getDataType() const {return "unsigned int";}
+    const char* getKeyType() const {return "unsigned int";}
+    const char* getMinKey() const {return "0";}
+    const char* getMaxKey() const {return "0xFFFFFFFFu";}
+    const char* getMaxValue() const {return "0xFFFFFFFFu";}
+    const char* getSortKey() const {return "value";}
 };
 
 CudaNonbondedUtilities::CudaNonbondedUtilities(CudaContext& context) : context(context), useCutoff(false), usePeriodic(false), useNeighborList(false), anyExclusions(false), usePadding(true),
@@ -282,14 +279,16 @@ void CudaNonbondedUtilities::initialize(const System& system) {
         int elementSize = (context.getUseDoublePrecision() ? sizeof(double) : sizeof(float));
         blockCenter.initialize(context, numAtomBlocks, 4*elementSize, "blockCenter");
         blockBoundingBox.initialize(context, numAtomBlocks, 4*elementSize, "blockBoundingBox");
-        sortedBlocks.initialize(context, numAtomBlocks, 2*elementSize, "sortedBlocks");
+        sortedBlocks.initialize<unsigned int>(context, numAtomBlocks, "sortedBlocks");
         sortedBlockCenter.initialize(context, numAtomBlocks+1, 4*elementSize, "sortedBlockCenter");
         sortedBlockBoundingBox.initialize(context, numAtomBlocks+1, 4*elementSize, "sortedBlockBoundingBox");
+        numBlockSizes = min((context.getNumAtomBlocks()+63)/64, context.getNumThreadBlocks());
+        blockSizeRange.initialize(context, numBlockSizes, 2*elementSize, "blockSizeRange");
         largeBlockCenter.initialize(context, numAtomBlocks, 4*elementSize, "largeBlockCenter");
         largeBlockBoundingBox.initialize(context, numAtomBlocks, 4*elementSize, "largeBlockBoundingBox");
         oldPositions.initialize(context, numAtoms, 4*elementSize, "oldPositions");
         rebuildNeighborList.initialize<int>(context, 1, "rebuildNeighborList");
-        blockSorter = new CudaSort(context, new BlockSortTrait(context.getUseDoublePrecision()), numAtomBlocks, false);
+        blockSorter = new CudaSort(context, new BlockSortTrait(), numAtomBlocks, false);
         vector<unsigned int> count(2, 0);
         interactionCount.upload(count);
         rebuildNeighborList.upload(&count[0]);
@@ -336,7 +335,11 @@ void CudaNonbondedUtilities::initialize(const System& system) {
         findBlockBoundsArgs.push_back(&blockCenter.getDevicePointer());
         findBlockBoundsArgs.push_back(&blockBoundingBox.getDevicePointer());
         findBlockBoundsArgs.push_back(&rebuildNeighborList.getDevicePointer());
-        findBlockBoundsArgs.push_back(&sortedBlocks.getDevicePointer());
+        findBlockBoundsArgs.push_back(&blockSizeRange.getDevicePointer());
+        computeSortKeysArgs.push_back(&blockBoundingBox.getDevicePointer());
+        computeSortKeysArgs.push_back(&sortedBlocks.getDevicePointer());
+        computeSortKeysArgs.push_back(&blockSizeRange.getDevicePointer());
+        computeSortKeysArgs.push_back(&numBlockSizes);
         sortBoxDataArgs.push_back(&sortedBlocks.getDevicePointer());
         sortBoxDataArgs.push_back(&blockCenter.getDevicePointer());
         sortBoxDataArgs.push_back(&blockBoundingBox.getDevicePointer());
@@ -417,9 +420,9 @@ void CudaNonbondedUtilities::prepareInteractions(int forceGroups) {
 
     if (lastCutoff != kernels.cutoffDistance)
         forceRebuildNeighborList = true;
-    context.executeKernel(kernels.findBlockBoundsKernel, &findBlockBoundsArgs[0], context.getNumAtoms());
-    if (!useLargeBlocks)
-        blockSorter->sort(sortedBlocks);
+    context.executeKernel(kernels.findBlockBoundsKernel, &findBlockBoundsArgs[0], context.getNumAtomBlocks());
+    context.executeKernel(kernels.computeSortKeysKernel, &computeSortKeysArgs[0], context.getNumAtomBlocks());
+    blockSorter->sort(sortedBlocks);
     context.executeKernel(kernels.sortBoxDataKernel, &sortBoxDataArgs[0], context.getNumAtoms());
     context.executeKernel(kernels.findInteractingBlocksKernel, &findInteractingBlocksArgs[0], context.getNumAtoms(), 256);
     forceRebuildNeighborList = false;
@@ -532,6 +535,7 @@ void CudaNonbondedUtilities::createKernelsForGroups(int groups) {
         defines["MAX_BITS_FOR_PAIRS"] = (canUsePairList ? (context.getComputeCapability() < 8.0 ? "2" : "3") : "0");
         CUmodule interactingBlocksProgram = context.createModule(CudaKernelSources::vectorOps+CudaKernelSources::findInteractingBlocks, defines);
         kernels.findBlockBoundsKernel = context.getKernel(interactingBlocksProgram, "findBlockBounds");
+        kernels.computeSortKeysKernel = context.getKernel(interactingBlocksProgram, "computeSortKeys");
         kernels.sortBoxDataKernel = context.getKernel(interactingBlocksProgram, "sortBoxData");
         kernels.findInteractingBlocksKernel = context.getKernel(interactingBlocksProgram, "findBlocksWithInteractions");
     }

--- a/platforms/cuda/src/kernels/findInteractingBlocks.cu
+++ b/platforms/cuda/src/kernels/findInteractingBlocks.cu
@@ -40,9 +40,10 @@ private:
  */
 extern "C" __global__ void findBlockBounds(int numAtoms, real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
         const real4* __restrict__ posq, real4* __restrict__ blockCenter, real4* __restrict__ blockBoundingBox, int* __restrict__ rebuildNeighborList,
-        real2* __restrict__ sortedBlocks) {
+        real2* __restrict__ blockSizeRange) {
     int index = blockIdx.x*blockDim.x+threadIdx.x;
     int base = index*TILE_SIZE;
+    real minSize = 1e38, maxSize = 0;
     while (base < numAtoms) {
         real4 pos = posq[base];
 #ifdef USE_PERIODIC
@@ -74,18 +75,66 @@ extern "C" __global__ void findBlockBounds(int numAtoms, real4 periodicBoxSize, 
         center.w = sqrt(center.w);
         blockBoundingBox[index] = blockSize;
         blockCenter[index] = center;
-        sortedBlocks[index] = make_real2(blockSize.x+blockSize.y+blockSize.z, index);
+        real totalSize = blockSize.x+blockSize.y+blockSize.z;
+        minSize = min(minSize, totalSize);
+        maxSize = max(maxSize, totalSize);
         index += blockDim.x*gridDim.x;
         base = index*TILE_SIZE;
     }
+    
+    // Record the range of sizes seen by threads in this block.
+
+    __shared__ real minBuffer[64], maxBuffer[64];
+    minBuffer[threadIdx.x] = minSize;
+    maxBuffer[threadIdx.x] = maxSize;
+    __syncthreads();
+    for (int step = 1; step < 64; step *= 2) {
+        if (threadIdx.x+step < 64 && threadIdx.x%(2*step) == 0) {
+            minBuffer[threadIdx.x] = min(minBuffer[threadIdx.x], minBuffer[threadIdx.x+step]);
+            maxBuffer[threadIdx.x] = max(maxBuffer[threadIdx.x], maxBuffer[threadIdx.x+step]);
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0)
+        blockSizeRange[blockIdx.x] = make_real2(minBuffer[0], maxBuffer[0]);
     if (blockIdx.x == 0 && threadIdx.x == 0)
         rebuildNeighborList[0] = 0;
+}
+
+extern "C" __global__ void computeSortKeys(const real4* __restrict__ blockBoundingBox, unsigned int* __restrict__ sortedBlocks, real2* __restrict__ blockSizeRange, int numSizes) {
+    // Find the total range of sizes recorded by all blocks.
+
+    __shared__ real2 sizeRange;
+    if (threadIdx.x == 0) {
+        sizeRange = blockSizeRange[0];
+        for (int i = 1; i < numSizes; i++) {
+            real2 size = blockSizeRange[i];
+            sizeRange.x = min(sizeRange.x, size.x);
+            sizeRange.y = max(sizeRange.y, size.y);
+        }
+        sizeRange.x = LOG(sizeRange.x);
+        sizeRange.y = LOG(sizeRange.y);
+    }
+    __syncthreads();
+
+    // Sort keys store the bin in the high order part and the block in the low
+    // order part.
+
+    int numSizeBins = 20;
+    real scale = numSizeBins/(sizeRange.y-sizeRange.x);
+    for (unsigned int i = threadIdx.x+blockIdx.x*blockDim.x; i < NUM_BLOCKS; i += blockDim.x*gridDim.x) {
+        real4 box = blockBoundingBox[i];
+        real size = LOG(box.x+box.y+box.z);
+        int bin = (size-sizeRange.x)*scale;
+        bin = max(0, min(bin, numSizeBins-1));
+        sortedBlocks[i] = (((unsigned int) bin)<<24) + i;
+    }
 }
 
 /**
  * Sort the data about bounding boxes so it can be accessed more efficiently in the next kernel.
  */
-extern "C" __global__ void sortBoxData(const real2* __restrict__ sortedBlock, const real4* __restrict__ blockCenter,
+extern "C" __global__ void sortBoxData(const unsigned int* __restrict__ sortedBlocks, const real4* __restrict__ blockCenter,
         const real4* __restrict__ blockBoundingBox, real4* __restrict__ sortedBlockCenter, half3* __restrict__ sortedBlockBoundingBox,
 #ifdef USE_LARGE_BLOCKS
         real4* __restrict__ largeBlockCenter, half3* __restrict__ largeBlockBoundingBox, real4 periodicBoxSize,
@@ -94,7 +143,7 @@ extern "C" __global__ void sortBoxData(const real2* __restrict__ sortedBlock, co
         const real4* __restrict__ posq, const real4* __restrict__ oldPositions,
         unsigned int* __restrict__ interactionCount, int* __restrict__ rebuildNeighborList, bool forceRebuild) {
     for (int i = threadIdx.x+blockIdx.x*blockDim.x; i < NUM_BLOCKS; i += blockDim.x*gridDim.x) {
-        int index = (int) sortedBlock[i].y;
+        unsigned int index = sortedBlocks[i] & 0xFFFFFF;
         sortedBlockCenter[i] = blockCenter[index];
         sortedBlockBoundingBox[i] = half3(trimTo3(blockBoundingBox[index]));
     }
@@ -102,12 +151,14 @@ extern "C" __global__ void sortBoxData(const real2* __restrict__ sortedBlock, co
     // Compute the sizes of large blocks (composed of 32 regular blocks) starting from each block.
     
     for (int i = threadIdx.x+blockIdx.x*blockDim.x; i < NUM_BLOCKS; i += blockDim.x*gridDim.x) {
-        real4 minPos = blockCenter[i]-blockBoundingBox[i];
-        real4 maxPos = blockCenter[i]+blockBoundingBox[i];
+        unsigned int index = sortedBlocks[i] & 0xFFFFFF;
+        real4 minPos = blockCenter[index]-blockBoundingBox[index];
+        real4 maxPos = blockCenter[index]+blockBoundingBox[index];
         int last = min(i+32, NUM_BLOCKS);
         for (int j = i+1; j < last; j++) {
-            real4 blockPos = blockCenter[j];
-            real4 width = blockBoundingBox[j];
+            index = sortedBlocks[j] & 0xFFFFFF;
+            real4 blockPos = blockCenter[index];
+            real4 width = blockBoundingBox[index];
 #ifdef USE_PERIODIC
             real4 center = 0.5f*(maxPos+minPos);
             APPLY_PERIODIC_TO_POS_WITH_CENTER(blockPos, center)
@@ -238,7 +289,7 @@ __device__ int saveSinglePairs(int x, int* atoms, int* flags, int length, unsign
 extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
         unsigned int* __restrict__ interactionCount, int* __restrict__ interactingTiles, unsigned int* __restrict__ interactingAtoms,
         int2* __restrict__ singlePairs, const real4* __restrict__ posq, unsigned int maxTiles, unsigned int maxSinglePairs, unsigned int startBlockIndex,
-        unsigned int numBlocks, real2* __restrict__ sortedBlocks, const real4* __restrict__ sortedBlockCenter, const half3* __restrict__ sortedBlockBoundingBox,
+        unsigned int numBlocks, unsigned int* __restrict__ sortedBlocks, const real4* __restrict__ sortedBlockCenter, const half3* __restrict__ sortedBlockBoundingBox,
 #ifdef USE_LARGE_BLOCKS
         real4* __restrict__ largeBlockCenter, half3* __restrict__ largeBlockBoundingBox,
 #endif
@@ -271,8 +322,7 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
     for (int block1 = startBlockIndex+warpIndex; block1 < startBlockIndex+numBlocks; block1 += totalWarps) {
         // Load data for this block.  Note that all threads in a warp are processing the same block.
         
-        real2 sortedKey = sortedBlocks[block1];
-        int x = (int) sortedKey.y;
+        int x = sortedBlocks[block1] & 0xFFFFFF;
         real4 blockCenterX = sortedBlockCenter[block1];
         real3 blockSizeX = sortedBlockBoundingBox[block1].toReal3();
         int neighborsInBuffer = 0;
@@ -363,7 +413,7 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
                     includeBlock2 = forceInclude = true;
 #endif
                 if (includeBlock2) {
-                    int y = (int) sortedBlocks[block2].y;
+                    int y = sortedBlocks[block2] & 0xFFFFFF;
                     #pragma unroll 4 // (MAX_EXCLUSIONS)
                     for (int k = 0; k < numExclusions; k++)
                         includeBlock2 &= (exclusionsForX[k] != y);
@@ -378,7 +428,7 @@ extern "C" __global__ __launch_bounds__(GROUP_SIZE,3) void findBlocksWithInterac
                 int i = __ffs(includeBlockFlags)-1;
                 includeBlockFlags &= includeBlockFlags-1;
                 forceInclude = (forceIncludeFlags>>i) & 1;
-                int y = (int) sortedBlocks[block2Base+i].y;
+                int y = sortedBlocks[block2Base+i] & 0xFFFFFF;
 
                 // Check each atom in block Y for interactions.
 


### PR DESCRIPTION
Fixes #4334.  The large blocks optimization added in #4147 creates a dilemma about how to sort atom blocks.  We want them to be sorted by size, because that produces the most compact neighbor list and makes computing interactions faster.  But we also want them sorted spatially, because otherwise the large blocks optimization isn't effective.  We compromised by disabling the large blocks optimization for small systems.  We sort spatially when using it, and by size when not using it.

This turned out to hurt performance in some cases, as described in #4334.  This PR uses a different compromise: it splits the difference between the two sorting methods.  It divides blocks by size into a small number of bins, while keeping the blocks within each bin spatially sorted.  That gives most of the benefit of each one.

Here are some benchmarks for simulating water boxes with 0.1 molar salt.  I show the speed for the existing code with the large blocks optimization disabled or enabled, and for the version in this PR.  The numbers are the time per 100,000 atoms to take 5000 steps, so smaller is better.

|Box Width|Atoms|w/o large blocks|Large blocks|This PR|
|---|---|---|---|---|
5|12227|7.93|7.96|7.43
10|98644|2.65|2.68|2.68
15|334217|2.71|2.72|2.60
20|790542|3.07|3.15|2.72
25|1546428|4.59|4.76|3.80

The new version is faster in almost all cases, and for the largest systems it's quite a bit faster.  Now here is the same thing, only reversing the order of the atoms so the salt comes before the water rather than after.

|Box Width|Atoms|w/o large blocks|Large blocks|This PR|
|---|---|---|---|---|
5|12227|7.55|12.15|7.67
10|98644|2.66|4.68|2.66
15|334217|2.73|3.31|2.62
20|790542|3.09|2.95|2.73
25|1546428|4.64|3.56|3.78

Previously that had a big effect on performance, and hurt performance a lot for the smaller systems.  With this PR it no longer has a significant effect.

I also tested it on more typical systems.  I included all our standard benchmark systems as well as FactorIX from the Amber benchmarks.  We don't usually include that one due to problems with the file: see #3391.  But it turned out to have a big performance regression in 8.1.  I had to hack the benchmark script to get it to run without errors.  These numbers are speeds in ns/day, so higher is better.

|Test|w/o large blocks|Large blocks|This PR|
|---|---|---|---|
DHFR|1,941.7|1,643.4|1,926.6
ApoA1|581.2|581.9|578.2
FactorIX|653.6|481.3|659.1
Cellulose|142.9|148.4|147.3
STMV|39.8|43.6|46.7

It's now similar to or faster than 8.1 in all cases.  I still want to tune a few parameters to see if I can get it slightly faster, and then I'll port the changes over to OpenCL as well.