### PR TITLE
Faster algorithm for DrudeSCFIntegrator

### DIFF
--- a/plugins/drude/openmmapi/src/DrudeSCFIntegrator.cpp
+++ b/plugins/drude/openmmapi/src/DrudeSCFIntegrator.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -46,7 +46,7 @@ DrudeSCFIntegrator::DrudeSCFIntegrator(double stepSize) : DrudeIntegrator(stepSi
 {
     setDrudeTemperature(0.0);  // This is only used to initialize velocities for this integrator
     setStepSize(stepSize);
-    setMinimizationErrorTolerance(0.1);
+    setMinimizationErrorTolerance(10.0);
     setConstraintTolerance(1e-5);
     setMaxDrudeDistance(0.0);
 }

--- a/plugins/drude/openmmapi/src/DrudeSCFIntegrator.cpp
+++ b/plugins/drude/openmmapi/src/DrudeSCFIntegrator.cpp
@@ -46,7 +46,7 @@ DrudeSCFIntegrator::DrudeSCFIntegrator(double stepSize) : DrudeIntegrator(stepSi
 {
     setDrudeTemperature(0.0);  // This is only used to initialize velocities for this integrator
     setStepSize(stepSize);
-    setMinimizationErrorTolerance(10.0);
+    setMinimizationErrorTolerance(1.0);
     setConstraintTolerance(1e-5);
     setMaxDrudeDistance(0.0);
 }

--- a/plugins/drude/platforms/common/src/CommonDrudeKernels.cpp
+++ b/plugins/drude/platforms/common/src/CommonDrudeKernels.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2020 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -375,37 +375,45 @@ double CommonIntegrateDrudeLangevinStepKernel::computeKineticEnergy(ContextImpl&
 }
 
 CommonIntegrateDrudeSCFStepKernel::~CommonIntegrateDrudeSCFStepKernel() {
-    if (minimizerPos != NULL)
-        lbfgs_free(minimizerPos);
 }
 
 void CommonIntegrateDrudeSCFStepKernel::initialize(const System& system, const DrudeSCFIntegrator& integrator, const DrudeForce& force) {
     cc.initializeContexts();
     ContextSelector selector(cc);
-
-    // Identify Drude particles.
-    
-    for (int i = 0; i < force.getNumParticles(); i++) {
+    int numDrude = force.getNumParticles();
+    drudeParams.initialize<mm_float4>(cc, numDrude, "drudeParams");
+    drudeIndices.initialize<int>(cc, numDrude, "drudeIndices");
+    drudeParents.initialize<mm_int4>(cc, numDrude, "drudeParents");
+    vector<mm_float4> paramVec(numDrude);
+    vector<mm_int4> parentVec(numDrude);
+    drudeIndexVec.resize(numDrude);
+    for (int i = 0; i < numDrude; i++) {
         int p, p1, p2, p3, p4;
         double charge, polarizability, aniso12, aniso34;
         force.getParticleParameters(i, p, p1, p2, p3, p4, charge, polarizability, aniso12, aniso34);
-        drudeParticles.push_back(p);
+        double a1 = (p2 == -1 ? 1 : aniso12);
+        double a2 = (p3 == -1 || p4 == -1 ? 1 : aniso34);
+        double a3 = 3-a1-a2;
+        double k3 = ONE_4PI_EPS0*charge*charge/(polarizability*a3);
+        double k1 = ONE_4PI_EPS0*charge*charge/(polarizability*a1) - k3;
+        double k2 = ONE_4PI_EPS0*charge*charge/(polarizability*a2) - k3;
+        paramVec[i] = mm_float4((float) k1, (float) k2, (float) k3, 0.0f);
+        drudeIndexVec[i] = p;
+        parentVec[i] = mm_int4(p1, p2, p3, p4);
     }
-    
-    // Initialize the energy minimizer.
-    
-    minimizerPos = lbfgs_malloc(drudeParticles.size()*3);
-    if (minimizerPos == NULL)
-        throw OpenMMException("DrudeSCFIntegrator: Failed to allocate memory");
-    lbfgs_parameter_init(&minimizerParams);
-    minimizerParams.linesearch = LBFGS_LINESEARCH_BACKTRACKING_STRONG_WOLFE;    
+    drudeParams.upload(paramVec);
+    drudeIndices.upload(drudeIndexVec);
+    drudeParents.upload(parentVec);
 
     // Create the kernels.
     
     ComputeProgram program = cc.compileProgram(CommonKernelSources::verlet);
     kernel1 = program->createKernel("integrateVerletPart1");
     kernel2 = program->createKernel("integrateVerletPart2");
+    program = cc.compileProgram(CommonDrudeKernelSources::drudeSCF);
+    minimizeKernel = program->createKernel("minimizeDrudePositions");
     prevStepSize = -1.0;
+    event = cc.createEvent();
 }
 
 void CommonIntegrateDrudeSCFStepKernel::execute(ContextImpl& context, const DrudeSCFIntegrator& integrator) {
@@ -431,6 +439,14 @@ void CommonIntegrateDrudeSCFStepKernel::execute(ContextImpl& context, const Drud
         kernel2->addArg(integration.getPosDelta());
         if (cc.getUseMixedPrecision())
             kernel2->addArg(cc.getPosqCorrection());
+        minimizeKernel->addArg(drudeParams.getSize());
+        minimizeKernel->addArg(cc.getPaddedNumAtoms());
+        minimizeKernel->addArg();
+        minimizeKernel->addArg(cc.getPosq());
+        minimizeKernel->addArg(cc.getLongForceBuffer());
+        minimizeKernel->addArg(drudeParams);
+        minimizeKernel->addArg(drudeIndices);
+        minimizeKernel->addArg(drudeParents);
     }
     if (dt != prevStepSize) {
         if (cc.getUseDoublePrecision() || cc.getUseMixedPrecision()) {
@@ -480,96 +496,26 @@ double CommonIntegrateDrudeSCFStepKernel::computeKineticEnergy(ContextImpl& cont
     return cc.getIntegrationUtilities().computeKineticEnergy(0.5*integrator.getStepSize());
 }
 
-struct MinimizerData {
-    ContextImpl& context;
-    ComputeContext& cc;
-    vector<int>& drudeParticles;
-    MinimizerData(ContextImpl& context, ComputeContext& cc, vector<int>& drudeParticles) : context(context), cc(cc), drudeParticles(drudeParticles) {}
-};
-
-static lbfgsfloatval_t evaluate(void *instance, const lbfgsfloatval_t *x, lbfgsfloatval_t *g, const int n, const lbfgsfloatval_t step) {
-    MinimizerData* data = reinterpret_cast<MinimizerData*>(instance);
-    ContextImpl& context = data->context;
-    ComputeContext& cc = data->cc;
-    vector<int>& drudeParticles = data->drudeParticles;
-    int numDrudeParticles = drudeParticles.size();
-
-    // Set the particle positions.
-    
-    cc.getPosq().download(cc.getPinnedBuffer());
-    if (cc.getUseDoublePrecision()) {
-        mm_double4* posq = (mm_double4*) cc.getPinnedBuffer();
-        for (int i = 0; i < numDrudeParticles; ++i) {
-            mm_double4& p = posq[drudeParticles[i]];
-            p.x = x[3*i];
-            p.y = x[3*i+1];
-            p.z = x[3*i+2];
-        }
-    }
-    else {
-        mm_float4* posq = (mm_float4*) cc.getPinnedBuffer();
-        for (int i = 0; i < numDrudeParticles; ++i) {
-            mm_float4& p = posq[drudeParticles[i]];
-            p.x = x[3*i];
-            p.y = x[3*i+1];
-            p.z = x[3*i+2];
-        }
-    }
-    cc.getPosq().upload(cc.getPinnedBuffer());
-
-    // Compute the forces and energy for this configuration.
-
-    double energy = context.calcForcesAndEnergy(true, true, context.getIntegrator().getIntegrationForceGroups());
-    long long* force = (long long*) cc.getPinnedBuffer();
-    cc.getLongForceBuffer().download(force);
-    double forceScale = -1.0/0x100000000;
-    int paddedNumAtoms = cc.getPaddedNumAtoms();
-    for (int i = 0; i < numDrudeParticles; ++i) {
-        int index = drudeParticles[i];
-        g[3*i] = forceScale*force[index];
-        g[3*i+1] = forceScale*force[index+paddedNumAtoms];
-        g[3*i+2] = forceScale*force[index+paddedNumAtoms*2];
-    }
-    return energy;
-}
-
 void CommonIntegrateDrudeSCFStepKernel::minimize(ContextImpl& context, double tolerance) {
-    // Record the initial positions.
-
-    int numDrudeParticles = drudeParticles.size();
-    cc.getPosq().download(cc.getPinnedBuffer());
-    if (cc.getUseDoublePrecision()) {
-        mm_double4* posq = (mm_double4*) cc.getPinnedBuffer();
-        for (int i = 0; i < numDrudeParticles; ++i) {
-            mm_double4 p = posq[drudeParticles[i]];
-            minimizerPos[3*i] = p.x;
-            minimizerPos[3*i+1] = p.y;
-            minimizerPos[3*i+2] = p.z;
+    minimizeKernel->setArg(2, (float) tolerance);
+    long long* forces = (long long*) cc.getPinnedBuffer();
+    double scale = 1/(double) 0x100000000;
+    double lastForce = 0;
+    int numDrude = drudeParams.getSize();
+    int paddedNumAtoms = cc.getPaddedNumAtoms();
+    for (int iteration = 0; iteration < 50; iteration++) {
+        context.calcForcesAndEnergy(true, false, context.getIntegrator().getIntegrationForceGroups());
+        cc.getLongForceBuffer().download(forces, false);
+        event->enqueue();
+        minimizeKernel->execute(drudeParams.getSize());
+        event->wait();
+        double totalForce = 0;
+        for (int i : drudeIndexVec) {
+            Vec3 f(scale*forces[i], scale*forces[i+paddedNumAtoms], scale*forces[i+paddedNumAtoms*2]);
+            totalForce += f.dot(f);
         }
+        if (sqrt(totalForce/(3*numDrude)) < tolerance || (iteration > 0 && totalForce > 0.9*lastForce))
+            break;
+        lastForce = totalForce;
     }
-    else {
-        mm_float4* posq = (mm_float4*) cc.getPinnedBuffer();
-        for (int i = 0; i < numDrudeParticles; ++i) {
-            mm_float4 p = posq[drudeParticles[i]];
-            minimizerPos[3*i] = p.x;
-            minimizerPos[3*i+1] = p.y;
-            minimizerPos[3*i+2] = p.z;
-        }
-        minimizerParams.xtol = 1e-7;
-    }
-    
-    // Determine a normalization constant for scaling the tolerance.
-    
-    double norm = 0.0;
-    for (int i = 0; i < 3*numDrudeParticles; i++)
-        norm += minimizerPos[i]*minimizerPos[i];
-    norm /= numDrudeParticles;
-    norm = (norm < 1 ? 1 : sqrt(norm));
-    minimizerParams.epsilon = tolerance/norm;
-    
-    // Perform the minimization.
-
-    lbfgsfloatval_t fx;
-    MinimizerData data(context, cc, drudeParticles);
-    lbfgs(numDrudeParticles*3, minimizerPos, &fx, evaluate, NULL, &data, &minimizerParams);
 }

--- a/plugins/drude/platforms/common/src/CommonDrudeKernels.cpp
+++ b/plugins/drude/platforms/common/src/CommonDrudeKernels.cpp
@@ -438,7 +438,7 @@ void CommonIntegrateDrudeSCFStepKernel::execute(ContextImpl& context, const Drud
         kernel2->addArg(integration.getPosDelta());
         if (cc.getUseMixedPrecision())
             kernel2->addArg(cc.getPosqCorrection());
-        minimizeKernel->addArg(drudeParams.getSize());
+        minimizeKernel->addArg((int) drudeParams.getSize());
         minimizeKernel->addArg(cc.getPaddedNumAtoms());
         minimizeKernel->addArg();
         minimizeKernel->addArg(cc.getPosq());

--- a/plugins/drude/platforms/common/src/CommonDrudeKernels.h
+++ b/plugins/drude/platforms/common/src/CommonDrudeKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2019 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -35,7 +35,6 @@
 #include "openmm/DrudeKernels.h"
 #include "openmm/common/ComputeContext.h"
 #include "openmm/common/ComputeArray.h"
-#include "lbfgs.h"
 
 namespace OpenMM {
 
@@ -121,7 +120,7 @@ private:
 class CommonIntegrateDrudeSCFStepKernel : public IntegrateDrudeSCFStepKernel {
 public:
     CommonIntegrateDrudeSCFStepKernel(const std::string& name, const Platform& platform, ComputeContext& cc) :
-            IntegrateDrudeSCFStepKernel(name, platform), cc(cc), minimizerPos(NULL), hasInitializedKernels(false) {
+            IntegrateDrudeSCFStepKernel(name, platform), cc(cc), hasInitializedKernels(false) {
     }
     ~CommonIntegrateDrudeSCFStepKernel();
     /**
@@ -151,10 +150,10 @@ private:
     ComputeContext& cc;
     double prevStepSize;
     bool hasInitializedKernels;
-    std::vector<int> drudeParticles;
-    lbfgsfloatval_t *minimizerPos;
-    lbfgs_parameter_t minimizerParams;
-    ComputeKernel kernel1, kernel2;
+    std::vector<int> drudeIndexVec;
+    ComputeArray drudeParams, drudeIndices, drudeParents;
+    ComputeKernel kernel1, kernel2, minimizeKernel;
+    ComputeEvent event;
 };
 
 } // namespace OpenMM

--- a/plugins/drude/platforms/common/src/CommonDrudeKernels.h
+++ b/plugins/drude/platforms/common/src/CommonDrudeKernels.h
@@ -153,7 +153,6 @@ private:
     std::vector<int> drudeIndexVec;
     ComputeArray drudeParams, drudeIndices, drudeParents;
     ComputeKernel kernel1, kernel2, minimizeKernel;
-    ComputeEvent event;
 };
 
 } // namespace OpenMM

--- a/plugins/drude/platforms/common/src/kernels/drudeSCF.cc
+++ b/plugins/drude/platforms/common/src/kernels/drudeSCF.cc
@@ -6,14 +6,14 @@ KERNEL void minimizeDrudePositions(int numDrude, int paddedNumAtoms, float toler
         int index = drudeIndex[i];
         int4 parents = drudeParents[i];
         float4 params = drudeParams[i];
-        real4 fscale = make_real4(params.z, params.z, params.z, 0);
+        real3 fscale = make_real3(params.z, params.z, params.z);
         if (parents.y != -1) {
-            real4 dir = posq[parents.x]-posq[parents.y];
+            real3 dir = trimTo3(posq[parents.x]-posq[parents.y]);
             dir *= RSQRT(dot(dir, dir));
             fscale += params.x*dir;
         }
         if (parents.z != -1 && parents.w != -1) {
-            real4 dir = posq[parents.z]-posq[parents.w];
+            real3 dir = trimTo3(posq[parents.z]-posq[parents.w]);
             dir *= RSQRT(dot(dir, dir));
             fscale += params.y*dir;
         }

--- a/plugins/drude/platforms/common/src/kernels/drudeSCF.cc
+++ b/plugins/drude/platforms/common/src/kernels/drudeSCF.cc
@@ -1,0 +1,29 @@
+KERNEL void minimizeDrudePositions(int numDrude, int paddedNumAtoms, float tolerance, GLOBAL real4* RESTRICT posq,
+        GLOBAL const mm_long* RESTRICT force, GLOBAL float4* RESTRICT drudeParams, GLOBAL int* RESTRICT drudeIndex,
+        GLOBAL int4* RESTRICT drudeParents) {
+    const real scale = 1/(real) 0x100000000;
+    for (int i = GLOBAL_ID; i < numDrude; i += GLOBAL_SIZE) {
+        int index = drudeIndex[i];
+        int4 parents = drudeParents[i];
+        float4 params = drudeParams[i];
+        real4 fscale = make_real4(params.z, params.z, params.z, 0);
+        if (parents.y != -1) {
+            real4 dir = posq[parents.x]-posq[parents.y];
+            dir *= RSQRT(dot(dir, dir));
+            fscale += params.x*dir;
+        }
+        if (parents.z != -1 && parents.w != -1) {
+            real4 dir = posq[parents.z]-posq[parents.w];
+            dir *= RSQRT(dot(dir, dir));
+            fscale += params.y*dir;
+        }
+        real4 pos = posq[index];
+        real4 f = make_real4(scale*force[index], scale*force[index+paddedNumAtoms], scale*force[index+paddedNumAtoms*2], 0);
+        real damping = (SQRT(f.x*f.x + f.y*f.y + f.z*f.z) > 10*tolerance ? 0.5f : 1.0f);
+        pos.x += damping*f.x/fscale.x;
+        pos.y += damping*f.y/fscale.y;
+        pos.z += damping*f.z/fscale.z;
+        posq[index] = pos;
+    }
+}
+

--- a/plugins/drude/platforms/reference/src/ReferenceDrudeKernels.h
+++ b/plugins/drude/platforms/reference/src/ReferenceDrudeKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013 Stanford University and the Authors.           *
+ * Portions copyright (c) 2013-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -35,7 +35,6 @@
 #include "ReferencePlatform.h"
 #include "openmm/DrudeKernels.h"
 #include "openmm/Vec3.h"
-#include "lbfgs.h"
 #include <utility>
 #include <vector>
 
@@ -127,7 +126,7 @@ private:
 class ReferenceIntegrateDrudeSCFStepKernel : public IntegrateDrudeSCFStepKernel {
 public:
     ReferenceIntegrateDrudeSCFStepKernel(const std::string& name, const Platform& platform, ReferencePlatform::PlatformData& data) :
-        IntegrateDrudeSCFStepKernel(name, platform), data(data), minimizerPos(NULL) {
+        IntegrateDrudeSCFStepKernel(name, platform), data(data) {
     }
     ~ReferenceIntegrateDrudeSCFStepKernel();
     /**
@@ -155,11 +154,10 @@ public:
 private:
     void minimize(ContextImpl& context, double tolerance);
     ReferencePlatform::PlatformData& data;
-    std::vector<int> drudeParticles;
     std::vector<double> particleInvMass;
-    lbfgsfloatval_t *minimizerPos;
-    lbfgs_parameter_t minimizerParams;
     double maxDrudeDistance;
+    std::vector<int> particle, particle1, particle2, particle3, particle4;
+    std::vector<double> k1, k2, k3;
 };
 
 } // namespace OpenMM

--- a/plugins/drude/tests/TestDrudeSCFIntegrator.h
+++ b/plugins/drude/tests/TestDrudeSCFIntegrator.h
@@ -100,6 +100,7 @@ void testWater() {
     // Simulate it and check energy conservation and the total force on the Drude particles.
 
     DrudeSCFIntegrator integ(0.0005);
+    integ.setMinimizationErrorTolerance(0.1);
     Context context(system, integ, platform);
     context.setPositions(positions);
     context.applyConstraints(1e-5);

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -1050,10 +1050,10 @@ class TestAPIUnits(unittest.TestCase):
         integrator = DrudeSCFIntegrator(0.002)
         self.assertEqual(integrator.getStepSize(), 0.002*picoseconds)
         self.assertAlmostEqualUnit(integrator.getMinimizationErrorTolerance(),
-                                   0.1*kilojoule_per_mole/nanometer)
-        integrator.setMinimizationErrorTolerance(1*kilocalorie_per_mole/angstrom)
+                                   1*kilojoule_per_mole/nanometer)
+        integrator.setMinimizationErrorTolerance(0.1*kilocalorie_per_mole/angstrom)
         self.assertAlmostEqualUnit(integrator.getMinimizationErrorTolerance(),
-                                   1*kilocalorie_per_mole/angstrom)
+                                   0.1*kilocalorie_per_mole/angstrom)
 
     def testDrudeLangevinIntegrator(self):
         """ Tests the DrudeLangevinIntegrator API features """


### PR DESCRIPTION
Previously DrudeSCFIntegrator just called the generic L-BFGS optimizer to solve for the Drude particle positions.  That worked but was very slow.  I replaced it with a new algorithm that tends to be much faster.  It works roughly like this.

1. Compute the forces on the Drude particles.
2. Jump to the minimum of the harmonic restraining force while assuming all other forces are constant.
3. Iterate until it converges.

I also made one other change.  The default value for the minimization tolerance was 0.1 kJ/mol/nm.  That worked for the test case, which just involves a small cluster of water molecules, but in more typical systems it turned out to be far too low.  The minimizer would thrash, never managing to get the forces down to anything close to that.  I increased it to 10 kJ/mol/nm.  Even that may still be a bit on the low side.  I'd appreciate feedback on what values people find work best in their own systems.