### PR TITLE
setVelocitiesToTemperature() works with massless Drude particles

### DIFF
--- a/plugins/drude/openmmapi/src/DrudeHelpers.cpp
+++ b/plugins/drude/openmmapi/src/DrudeHelpers.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2022 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2023 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -122,6 +122,10 @@ vector<Vec3> assignDrudeVelocities(const System &system, double temperature, dou
             Vec3 relVelocity = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*sqrt(BOLTZ*drudeTemperature/redMass);
             velocities[atom1] = comVelocity - fracM2 * relVelocity;
             velocities[atom2] = comVelocity + fracM1 * relVelocity;
+        }
+        else if (mass2 != 0) {
+            double velocityScale = sqrt(BOLTZ*temperature/mass2);
+            velocities[atom2] = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*velocityScale;
         }
     }
     return velocities;

--- a/plugins/drude/tests/TestDrudeSCFIntegrator.h
+++ b/plugins/drude/tests/TestDrudeSCFIntegrator.h
@@ -131,7 +131,7 @@ void testWater() {
     }
 }
 
-void testInitialTemperature() {
+void testInitialTemperature(double drudeMass) {
     // Check temperature initialization for a collection of randomly placed particles
     const int numRealParticles = 50000;
     const int numParticles = 2 * numRealParticles;
@@ -139,7 +139,6 @@ void testInitialTemperature() {
     const double targetTemperature = 300;
     const double drudeTemperature = 0;
     const double realMass = 10;
-    const double drudeMass = 1;
     System system;
     OpenMM_SFMT::SFMT sfmt;
     init_gen_rand(0, sfmt);
@@ -195,7 +194,8 @@ int main(int argc, char* argv[]) {
         setupKernels(argc, argv);
         testWater();
         runPlatformTests();
-        testInitialTemperature();
+        testInitialTemperature(0);
+        testInitialTemperature(1);
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;


### PR DESCRIPTION
If a Drude particle had zero mass, `setVelocitiesToTemperature()` would set the velocity of its parent particle to zero.  This was an issue when using DrudeSCFIntegrator.