### PR TITLE
Fixed error in barostat

### DIFF
--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -1693,7 +1693,7 @@ private:
     ComputeContext& cc;
     bool hasInitializedKernels, rigidMolecules, atomsWereReordered;
     int numMolecules;
-    ComputeArray savedPositions, savedFloatForces, savedLongForces;
+    ComputeArray savedPositions, savedFloatForces, savedLongForces, savedVelocities;
     ComputeArray moleculeAtoms;
     ComputeArray moleculeStartIndex;
     ComputeKernel kernel;

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -8034,6 +8034,7 @@ void CommonApplyMonteCarloBarostatKernel::initialize(const System& system, const
     this->rigidMolecules = rigidMolecules;
     ContextSelector selector(cc);
     savedPositions.initialize(cc, cc.getPaddedNumAtoms(), cc.getUseDoublePrecision() ? sizeof(mm_double4) : sizeof(mm_float4), "savedPositions");
+    savedVelocities.initialize(cc, cc.getPaddedNumAtoms(), cc.getUseDoublePrecision() || cc.getUseMixedPrecision() ? sizeof(mm_double4) : sizeof(mm_float4), "savedVelocities");
     savedLongForces.initialize<long long>(cc, cc.getPaddedNumAtoms()*3, "savedLongForces");
     try {
         cc.getFloatForceBuffer(); // This will throw an exception on the CUDA platform.
@@ -8049,6 +8050,7 @@ void CommonApplyMonteCarloBarostatKernel::initialize(const System& system, const
 void CommonApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& context) {
     ContextSelector selector(cc);
     cc.getPosq().copyTo(savedPositions);
+    cc.getVelm().copyTo(savedVelocities);
     cc.getLongForceBuffer().copyTo(savedLongForces);
     if (savedFloatForces.isInitialized())
         cc.getFloatForceBuffer().copyTo(savedFloatForces);
@@ -8112,6 +8114,7 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
 void CommonApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& context) {
     ContextSelector selector(cc);
     savedPositions.copyTo(cc.getPosq());
+    savedVelocities.copyTo(cc.getVelm());
     savedLongForces.copyTo(cc.getLongForceBuffer());
     cc.setPosCellOffsets(lastPosCellOffsets);
     if (savedFloatForces.isInitialized())


### PR DESCRIPTION
Fixes #4360.  It's closely related to #4049, #4106, and #4119.  It's yet another problem that happened when atom reordering took place in the middle of a barostat move that then got rejected.  In this case the problem was in velocities.  Reordering would cause the array of particle velocities to be reordered.  When we rejected the move, they didn't get put back again.  This caused the velocities of the water molecules to get shuffled.

For flexible water models that didn't actually matter much.  They just reflected a Boltzmann distribution either way.  But for rigid water, it meant the constrained directions no longer matched the directions of zero velocities.  When velocity constraints were next applied, it would cause a sudden drop in the temperature.

This fix should be included in 8.1.1.