### PR TITLE
Write DCD version as 24 instead of 21 to fix ability of CHARMM to read DCD trajectories written by OpenMM

### DIFF
--- a/wrappers/python/openmm/app/dcdfile.py
+++ b/wrappers/python/openmm/app/dcdfile.py
@@ -92,7 +92,7 @@ class DCDFile(object):
                 raise ValueError('Cannot append to a DCD file that contains a different number of atoms')
         else:
             header = struct.pack('<i4c9if', 84, b'C', b'O', b'R', b'D', 0, firstStep, interval, 0, 0, 0, 0, 0, 0, dt)
-            header += struct.pack('<13i', boxFlag, 0, 0, 0, 0, 0, 0, 0, 0, 21, 84, 164, 2)
+            header += struct.pack('<13i', boxFlag, 0, 0, 0, 0, 0, 0, 0, 0, 24, 84, 164, 2)
             header += struct.pack('<80s', b'Created by OpenMM')
             header += struct.pack('<80s', b'Created '+time.asctime(time.localtime(time.time())).encode('ascii'))
             header += struct.pack('<4i', 164, 4, len(list(topology.atoms())), 4)


### PR DESCRIPTION
Revert #3521; see #4405.

Essentially OpenMM is writing values that are compatible with the symmetric shape matrix, even if it is not calculated the same way. For a version of 21 in the DCD file to be valid, OpenMM would need to store X Y Z and alpha beta gamma (in degrees). Therefore, a version of 24 is more appropriate.

Eventually it may be better to actually calculate the symmetric shape matrix, but this PR should fix compatibility with CHARMM. 

Tagging @peastman and @RickVenable.