### PR TITLE
API improvements

### DIFF
--- a/docs-source/developerguide/03_writing_plugins.rst
+++ b/docs-source/developerguide/03_writing_plugins.rst
@@ -125,7 +125,7 @@ Both of these classes should be packaged into a dynamic library (.so on Linux,
 must also implement the two functions from PluginInitializer.h.
 :code:`registerPlatforms()` will do nothing, since this plugin does not
 implement any new Platforms.  :code:`registerKernelFactories()` should call
-\ :code:`Platform::getPlatformByName("OpenCL")` to get the OpenCL Platform,
+\ :code:`Platform::getPlatform("OpenCL")` to get the OpenCL Platform,
 then create a new OpenCLStringForceKernelFactory and call
 :code:`registerKernelFactory()` on the Platform to register it.  If the OpenCL
 Platform is not available, you should catch the exception then return without

--- a/docs-source/usersguide/application/02_running_sims.rst
+++ b/docs-source/usersguide/application/02_running_sims.rst
@@ -428,7 +428,7 @@ of the :class:`Platform` to use.  This overrides the default logic.
 :class:`Simulation`.  The following lines specify to use the :class:`CUDA` platform:
 ::
 
-    platform = Platform.getPlatformByName('CUDA')
+    platform = Platform.getPlatform('CUDA')
     simulation = Simulation(prmtop.topology, system, integrator, platform)
 
 The platform name should be one of :code:`OpenCL`, :code:`CUDA`, :code:`CPU`, or
@@ -441,7 +441,7 @@ work across two different GPUs (CUDA devices 0 and 1), doing all computations in
 double precision:
 ::
 
-    platform = Platform.getPlatformByName('CUDA')
+    platform = Platform.getPlatform('CUDA')
     properties = {'DeviceIndex': '0,1', 'Precision': 'double'}
     simulation = Simulation(prmtop.topology, system, integrator, platform, properties)
 

--- a/docs-source/usersguide/application/03_model_building_editing.rst
+++ b/docs-source/usersguide/application/03_model_building_editing.rst
@@ -248,7 +248,7 @@ PDB file.
         simulation.context.setPositions(modeller.positions)
         simulation.minimizeEnergy(maxIterations=100)
         print('Saving...')
-        positions = simulation.context.getState(getPositions=True).getPositions()
+        positions = simulation.context.getState(positions=True).getPositions()
         PDBFile.writeFile(simulation.topology, positions, open('output.pdb', 'w'))
         print('Done')
 

--- a/docs-source/usersguide/application/04_advanced_sim_examples.rst
+++ b/docs-source/usersguide/application/04_advanced_sim_examples.rst
@@ -209,7 +209,7 @@ the potential energy of each one.  Assume we have already created our :class:`Sy
         for file in os.listdir('structures'):
             pdb = PDBFile(os.path.join('structures', file))
             simulation.context.setPositions(pdb.positions)
-            state = simulation.context.getState(getEnergy=True)
+            state = simulation.context.getState(energy=True)
             print(file, state.getPotentialEnergy())
 
     .. caption::
@@ -220,6 +220,6 @@ We use Python’s :code:`listdir()` function to list all the files in the
 directory.  We create a :class:`PDBFile` object for each one and call
 :meth:`setPositions()` on the Context to specify the particle positions loaded
 from the PDB file.  We then compute the energy by calling :meth:`getState()`
-with the option :code:`getEnergy=True`\ , and print it to the console along
+with the option :code:`energy=True`\ , and print it to the console along
 with the name of the file.
 

--- a/docs-source/usersguide/library/04_platform_specifics.rst
+++ b/docs-source/usersguide/library/04_platform_specifics.rst
@@ -12,7 +12,7 @@ Context constructor:
 
 .. code-block:: c
 
-    Platform& platform = Platform::getPlatformByName("OpenCL");
+    Platform& platform = Platform::getPlatform("OpenCL");
     map<string, string> properties;
     properties["DeviceIndex"] = "1";
     Context context(system, integrator, platform, properties);

--- a/docs-source/usersguide/library/05_languages_not_cpp.rst
+++ b/docs-source/usersguide/library/05_languages_not_cpp.rst
@@ -588,7 +588,7 @@ notable differences:
    available.  For example:
    ::
 
-    myContext.getState(getEnergy=True, getForce=False, …)
+    myContext.getState(energy=True, force=False, …)
 
 #. Wherever the C++ API uses references to return multiple values from a method,
    the Python API returns a tuple.  For example, in C++ you would query a

--- a/examples/argon-chemical-potential.py
+++ b/examples/argon-chemical-potential.py
@@ -129,7 +129,7 @@ for (lambda_index, lambda_value) in enumerate(lambda_values):
       integrator.step(nprod_steps)
 
       # Get coordinates.
-      state = context.getState(getPositions=True)
+      state = context.getState(positions=True)
       positions = state.getPositions(asNumpy=True)
 
       # Store positions.
@@ -149,7 +149,7 @@ for (lambda_index, lambda_value) in enumerate(lambda_values):
       # Compute reduced potentials of all snapshots.
       for n in range(nprod_iterations):
          context.setPositions(position_history[n])
-         state = context.getState(getEnergy=True)
+         state = context.getState(energy=True)
          u_kln[lambda_index, l, n] = beta * state.getPotentialEnergy()
 
       # Clean up.

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -99,10 +99,10 @@ def printTestResult(test_result, options):
 def timeIntegration(context, steps, initialSteps):
     """Integrate a Context for a specified number of steps, then return how many seconds it took."""
     context.getIntegrator().step(initialSteps) # Make sure everything is fully initialized
-    context.getState(getEnergy=True)
+    context.getState(energy=True)
     start = datetime.now()
     context.getIntegrator().step(steps)
-    context.getState(getEnergy=True)
+    context.getState(energy=True)
     end = datetime.now()
     elapsed = end-start
     return elapsed.seconds + elapsed.microseconds*1e-6
@@ -384,7 +384,7 @@ def runOneTest(testName, options):
         tol = 1.0e-8
         context.applyConstraints(tol)
         context.applyVelocityConstraints(tol)
-        state = context.getState(getPositions=True, getVelocities=True, getEnergy=True, getForces=True, getParameters=True)
+        state = context.getState(positions=True, velocities=True, energy=True, forces=True, parameters=True)
 
     # Time integration, ensuring we trigger kernel compilation before we start timing
     steps = 20

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -347,7 +347,7 @@ def runOneTest(testName, options):
     test_result['timestep_in_fs'] = dt.value_in_unit(unit.femtoseconds)
     properties = {}
     initialSteps = 5
-    platform = mm.Platform.getPlatformByName(options.platform)
+    platform = mm.Platform.getPlatform(options.platform)
     if options.device is not None and 'DeviceIndex' in platform.getPropertyNames():
         properties['DeviceIndex'] = options.device
         if ',' in options.device or ' ' in options.device:

--- a/olla/include/openmm/Platform.h
+++ b/olla/include/openmm/Platform.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2024 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -186,12 +186,20 @@ public:
      */
     static Platform& getPlatform(int index);
     /**
+     * Get a registered Platform by name.  If no Platform with that name has been
+     * registered, this throws an exception.
+     */
+    static Platform& getPlatform(const std::string& name);
+    /**
      * Get any failures caused during the last call to loadPluginsFromDirectory
      */
     static std::vector<std::string> getPluginLoadFailures();
     /**
      * Get the registered Platform with a particular name.  If no Platform with that name has been
      * registered, this throws an exception.
+     * 
+     * This is identical to the version of getPlatform() that takes a name.  It
+     * is here for backward compatibility.
      */
     static Platform& getPlatformByName(const std::string& name);
     /**

--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2024 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -161,6 +161,10 @@ Platform& Platform::getPlatform(int index) {
         return *getPlatforms()[index];
     }
     throw OpenMMException("Invalid platform index");
+}
+
+Platform& Platform::getPlatform(const string& name) {
+    return getPlatformByName(name);
 }
 
 std::vector<std::string> Platform::getPluginLoadFailures() {

--- a/tests/TestCustomManyParticleForce.h
+++ b/tests/TestCustomManyParticleForce.h
@@ -603,7 +603,7 @@ void testLargeSystem() {
     system.addForce(force);
     VerletIntegrator integrator1(0.001);
     VerletIntegrator integrator2(0.001);
-    Context context1(system, integrator1, Platform::getPlatformByName("Reference"));
+    Context context1(system, integrator1, Platform::getPlatform("Reference"));
     Context context2(system, integrator2, platform);
     context1.setPositions(positions);
     context2.setPositions(positions);
@@ -698,7 +698,7 @@ void testCentralParticleModeLargeSystem() {
     system.addForce(force);
     VerletIntegrator integrator1(0.001);
     VerletIntegrator integrator2(0.001);
-    Context context1(system, integrator1, Platform::getPlatformByName("Reference"));
+    Context context1(system, integrator1, Platform::getPlatform("Reference"));
     Context context2(system, integrator2, platform);
     context1.setPositions(positions);
     context2.setPositions(positions);

--- a/tests/TestEnforcePeriodicBox.cpp
+++ b/tests/TestEnforcePeriodicBox.cpp
@@ -70,7 +70,7 @@ void testTruncatedOctahedron() {
     system.addForce(force);
     
     VerletIntegrator integrator(0.01);
-    Context context(system, integrator, Platform::getPlatformByName("Reference"));
+    Context context(system, integrator, Platform::getPlatform("Reference"));
     context.setPositions(positions);
     State initialState = context.getState(State::Positions | State::Energy, true);
     for (int i = 0; i < numMolecules; i++) {

--- a/tests/TestEwald.h
+++ b/tests/TestEwald.h
@@ -304,7 +304,7 @@ void testTriclinic2() {
     Context context1(system, integ1, platform);
     context1.setPositions(positions);
     VerletIntegrator integ2(0.001);
-    Context context2(system, integ2, Platform::getPlatformByName("Reference"));
+    Context context2(system, integ2, Platform::getPlatform("Reference"));
     context2.setPositions(positions);
     State state1 = context1.getState(State::Forces | State::Energy, false, 2);
     State state2 = context2.getState(State::Forces | State::Energy, false, 2);

--- a/tests/TestFindMolecules.cpp
+++ b/tests/TestFindMolecules.cpp
@@ -57,7 +57,7 @@ void testFindMolecules() {
                 bonds->addBond(index, index-1, 1.0, 1.0);
         }
     VerletIntegrator integrator(1.0);
-    Context context(system, integrator, Platform::getPlatformByName("Reference"));
+    Context context(system, integrator, Platform::getPlatform("Reference"));
     ContextImpl* contextImpl = *reinterpret_cast<ContextImpl**>(&context);
     const vector<vector<int> >& molecules = contextImpl->getMolecules();
     ASSERT_EQUAL(numMolecules, molecules.size());

--- a/tests/TestVirtualSites.h
+++ b/tests/TestVirtualSites.h
@@ -468,7 +468,7 @@ void testOverlappingSites() {
     }
     VerletIntegrator i1(0.002);
     VerletIntegrator i2(0.002);
-    Context c1(system, i1, Platform::getPlatformByName("Reference"));
+    Context c1(system, i1, Platform::getPlatform("Reference"));
     Context c2(system, i2, platform);
     c1.setPositions(positions);
     c2.setPositions(positions);

--- a/wrappers/python/openmm/app/checkpointreporter.py
+++ b/wrappers/python/openmm/app/checkpointreporter.py
@@ -149,7 +149,7 @@ class CheckpointReporter(object):
 
             self._file.seek(0)
             if self._writeState:
-                state = simulation.context.getState(getPositions=True, getVelocities=True, getParameters=True, getIntegratorParameters=True)
+                state = simulation.context.getState(positions=True, velocities=True, parameters=True, integratorParameters=True)
                 self._file.write(mm.XmlSerializer.serialize(state))
             else:
                 self._file.write(simulation.context.createCheckpoint())

--- a/wrappers/python/openmm/app/metadynamics.py
+++ b/wrappers/python/openmm/app/metadynamics.py
@@ -172,7 +172,7 @@ class Metadynamics(object):
             simulation.step(nextSteps)
             if simulation.currentStep % self.frequency == 0:
                 position = self._force.getCollectiveVariableValues(simulation.context)
-                energy = simulation.context.getState(getEnergy=True, groups={forceGroup}).getPotentialEnergy()
+                energy = simulation.context.getState(energy=True, groups={forceGroup}).getPotentialEnergy()
                 height = self.height*np.exp(-energy/(unit.MOLAR_GAS_CONSTANT_R*self._deltaT))
                 self._addGaussian(position, height, simulation.context)
             if self.saveFrequency is not None and simulation.currentStep % self.saveFrequency == 0:

--- a/wrappers/python/openmm/app/modeller.py
+++ b/wrappers/python/openmm/app/modeller.py
@@ -1065,7 +1065,7 @@ class Modeller(object):
         context.setPositions(newPositions)
         LocalEnergyMinimizer.minimize(context, 1.0, 50)
         self.topology = newTopology
-        self.positions = context.getState(getPositions=True).getPositions()
+        self.positions = context.getState(positions=True).getPositions()
         del context
         return actualVariants
 
@@ -1528,7 +1528,7 @@ class Modeller(object):
         for i in range(steps):
             weight1 = i/(steps-1)
             weight2 = 1.0-weight1
-            mergedPositions = context.getState(getPositions=True).getPositions(asNumpy=hasNumpy).value_in_unit(nanometer)
+            mergedPositions = context.getState(positions=True).getPositions(asNumpy=hasNumpy).value_in_unit(nanometer)
             if hasNumpy:
                 mergedPositions[numMembraneParticles:] = weight1*proteinPosArray + weight2*scaledProteinPosArray
             else:
@@ -1540,7 +1540,7 @@ class Modeller(object):
         # Add the membrane to the protein.
 
         modeller = Modeller(self.topology, self.positions)
-        modeller.add(membraneTopology, context.getState(getPositions=True).getPositions()[:numMembraneParticles])
+        modeller.add(membraneTopology, context.getState(positions=True).getPositions()[:numMembraneParticles])
         modeller.topology.setPeriodicBoxVectors(membraneTopology.getPeriodicBoxVectors())
         del context
         del system

--- a/wrappers/python/openmm/app/simulation.py
+++ b/wrappers/python/openmm/app/simulation.py
@@ -262,8 +262,8 @@ class Simulation(object):
                 getForces = True
             if next[4]:
                 getEnergy = True
-        state = self.context.getState(getPositions=getPositions, getVelocities=getVelocities, getForces=getForces,
-                                      getEnergy=getEnergy, getParameters=True, enforcePeriodicBox=periodic,
+        state = self.context.getState(positions=getPositions, velocities=getVelocities, forces=getForces,
+                                      energy=getEnergy, parameters=True, enforcePeriodicBox=periodic,
                                       groups=self.context.getIntegrator().getIntegrationForceGroups())
         for reporter, next in reports:
             reporter.report(self, state)
@@ -325,7 +325,7 @@ class Simulation(object):
             a File-like object to write the state to, or alternatively a
             filename
         """
-        state = self.context.getState(getPositions=True, getVelocities=True, getParameters=True, getIntegratorParameters=True)
+        state = self.context.getState(positions=True, velocities=True, parameters=True, integratorParameters=True)
         xml = mm.XmlSerializer.serialize(state)
         if isinstance(file, str):
             with open(file, 'w') as f:

--- a/wrappers/python/openmm/testInstallation.py
+++ b/wrappers/python/openmm/testInstallation.py
@@ -52,7 +52,7 @@ def run_tests():
         try:
             simulation = Simulation(pdb.topology, system, integrator, platform)
             simulation.context.setPositions(pdb.positions)
-            forces[i] = simulation.context.getState(getForces=True).getForces()
+            forces[i] = simulation.context.getState(forces=True).getForces()
             del simulation
             print("- Successfully computed forces")
         except:

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/extend.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/extend.i
@@ -9,27 +9,30 @@
     def getIntegrator(self):
         return self._integrator
 
-    def getState(self, getPositions=False, getVelocities=False,
+    def getState(self, positions=False, velocities=False,
+                 forces=False, energy=False, parameters=False,
+                 parameterDerivatives=False, integratorParameters=False,
+                 enforcePeriodicBox=False, groups=-1,
+                 getPositions=False, getVelocities=False,
                  getForces=False, getEnergy=False, getParameters=False,
-                 getParameterDerivatives=False, getIntegratorParameters=False,
-                 enforcePeriodicBox=False, groups=-1):
+                 getParameterDerivatives=False, getIntegratorParameters=False):
         """Get a State object recording the current state information stored in this context.
 
         Parameters
         ----------
-        getPositions : bool=False
+        positions : bool=False
             whether to store particle positions in the State
-        getVelocities : bool=False
+        velocities : bool=False
             whether to store particle velocities in the State
-        getForces : bool=False
+        forces : bool=False
             whether to store the forces acting on particles in the State
-        getEnergy : bool=False
+        energy : bool=False
             whether to store potential and kinetic energy in the State
-        getParameters : bool=False
+        parameters : bool=False
             whether to store context parameters in the State
-        getParameterDerivatives : bool=False
+        parameterDerivatives : bool=False
             whether to store parameter derivatives in the State
-        getIntegratorParameters : bool=False
+        integratorParameters : bool=False
             whether to store integrator parameters in the State
         enforcePeriodicBox : bool=False
             if false, the position of each particle will be whatever position
@@ -41,6 +44,20 @@
             forces and energies. The default value includes all groups. groups
             can also be passed as an unsigned integer interpreted as a bitmask,
             in which case group i will be included if (groups&(1<<i)) != 0.
+        getPositions : bool=False
+            Deprecated.  Use `positions` instead.
+        getVelocities : bool=False
+            Deprecated.  Use `velocities` instead.
+        getForces : bool=False
+            Deprecated.  Use `forces` instead.
+        getEnergy : bool=False
+            Deprecated.  Use `energy` instead.
+        getParameters : bool=False
+            Deprecated.  Use `parameters` instead.
+        getParameterDerivatives : bool=False
+            Deprecated.  Use `parameterDerivatives` instead.
+        getIntegratorParameters : bool=False
+            Deprecated.  Use `integratorParameters` instead.
         """
         try:
             # is the input integer-like?
@@ -55,19 +72,19 @@
         if groups_mask >= 0x80000000:
             groups_mask -= 0x100000000
         types = 0
-        if getPositions:
+        if positions or getPositions:
             types += State.Positions
-        if getVelocities:
+        if velocities or getVelocities:
             types += State.Velocities
-        if getForces:
+        if forces or getForces:
             types += State.Forces
-        if getEnergy:
+        if energy or getEnergy:
             types += State.Energy
-        if getParameters:
+        if parameters or getParameters:
             types += State.Parameters
-        if getParameterDerivatives:
+        if parameterDerivatives or getParameterDerivatives:
             types += State.ParameterDerivatives
-        if getIntegratorParameters:
+        if integratorParameters or getIntegratorParameters:
             types += State.IntegratorParameters
         state = _openmm.Context_getState(self, types, enforcePeriodicBox, groups_mask)
         return state

--- a/wrappers/python/tests/TestATMForce.py
+++ b/wrappers/python/tests/TestATMForce.py
@@ -27,7 +27,7 @@ class TestATMForce(unittest.TestCase):
         system.addForce(atmforce)
 
         integrator = VerletIntegrator(1.0)
-        platform = Platform.getPlatformByName('Reference')
+        platform = Platform.getPlatform('Reference')
         context = Context(system, integrator, platform)
 
         positions = []

--- a/wrappers/python/tests/TestAmberPrmtopFile.py
+++ b/wrappers/python/tests/TestAmberPrmtopFile.py
@@ -177,7 +177,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
         integrator = VerletIntegrator(1.0*femtoseconds)
         # Use reference platform, since it should always be present and
         # 'working', and the system is plenty small so this won't be too slow
-        sim = Simulation(prmtop3.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        sim = Simulation(prmtop3.topology, system, integrator, Platform.getPlatform('Reference'))
         # Check that the energy is about what we expect it to be
         sim.context.setPositions(inpcrd3.positions)
         ene = sim.context.getState(getEnergy=True, enforcePeriodicBox=True).getPotentialEnergy()
@@ -207,7 +207,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
         integrator = VerletIntegrator(1.0*femtoseconds)
         # Use reference platform, since it should always be present and
         # 'working', and the system is plenty small so this won't be too slow
-        sim = Simulation(prmtop3.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        sim = Simulation(prmtop3.topology, system, integrator, Platform.getPlatform('Reference'))
         # Check that the energy is about what we expect it to be
         sim.context.setPositions(inpcrd3.getPositions())
         ene = sim.context.getState(getEnergy=True, enforcePeriodicBox=True).getPotentialEnergy()
@@ -265,7 +265,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
         integrator = VerletIntegrator(1.0*femtoseconds)
         # Use reference platform, since it should always be present and
         # 'working', and the system is plenty small so this won't be too slow
-        sim = Simulation(prmtop4.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        sim = Simulation(prmtop4.topology, system, integrator, Platform.getPlatform('Reference'))
         # Check that the energy is about what we expect it to be
         sim.context.setPositions(inpcrd4.positions)
         ene = sim.context.getState(getEnergy=True, enforcePeriodicBox=True).getPotentialEnergy()
@@ -310,7 +310,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
         for i in range(5):
             system = prmtop2.createSystem(implicitSolvent=solventType[i], nonbondedMethod=nonbondedMethod[i], implicitSolventSaltConc=salt[i])
             integrator = VerletIntegrator(0.001)
-            context = Context(system, integrator, Platform.getPlatformByName("Reference"))
+            context = Context(system, integrator, Platform.getPlatform("Reference"))
             context.setPositions(pdb.positions)
             state1 = context.getState(getForces=True)
             with open('systems/alanine-dipeptide-implicit-forces/'+file[i]+'.xml') as infile:
@@ -380,7 +380,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
         for i,f in enumerate(system.getForces()):
             f.setForceGroup(i)
         integrator = VerletIntegrator(0.001)
-        context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator, Platform.getPlatform('Reference'))
         context.setPositions(crd.positions)
         
         # Compare to energies computed with pytraj.energy_decomposition()
@@ -422,7 +422,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
                 if isinstance(f, CustomGBForce) or isinstance(f, GBSAOBCForce):
                     f.setForceGroup(1)
             integrator = VerletIntegrator(0.001)
-            context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+            context = Context(system, integrator, Platform.getPlatform('Reference'))
             context.setPositions(inpcrd.positions)
             energy = context.getState(getEnergy=True, groups={1}).getPotentialEnergy().value_in_unit(kilojoules_per_mole)
             self.assertAlmostEqual(energy, expectedEnergy, delta=5e-4*abs(energy))
@@ -460,7 +460,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
             system = prmtop.createSystem(constraints=constraints)
             integrator = VerletIntegrator(0.001*picoseconds)
             # If a constraint was added to a massless particle, this will throw an exception.
-            context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+            context = Context(system, integrator, Platform.getPlatform('Reference'))
 
     def testWaterBonds(self):
         """Test that water molecules have the right set of bonds"""

--- a/wrappers/python/tests/TestBytes.py
+++ b/wrappers/python/tests/TestBytes.py
@@ -8,7 +8,7 @@ class TestBytes(unittest.TestCase):
         system.addParticle(1.0)
         refPositions = [(0,0,0)]
 
-        platform = mm.Platform.getPlatformByName('Reference')
+        platform = mm.Platform.getPlatform('Reference')
         context = mm.Context(system, mm.VerletIntegrator(0), platform)
         context.setPositions(refPositions)
         chk = context.createCheckpoint()

--- a/wrappers/python/tests/TestCharmmFiles.py
+++ b/wrappers/python/tests/TestCharmmFiles.py
@@ -139,7 +139,7 @@ class TestCharmmFiles(unittest.TestCase):
             a.charge = 0.0
 
         # Now compute the full energy
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
         system = psf.createSystem(params, nonbondedMethod=PME,
                                   nonbondedCutoff=8*angstroms)
 
@@ -168,7 +168,7 @@ class TestCharmmFiles(unittest.TestCase):
                 f.setForceGroup(1)
             else:
                 f.setForceGroup(0)
-        context = Context(system, VerletIntegrator(2*femtoseconds), Platform.getPlatformByName('Reference'))
+        context = Context(system, VerletIntegrator(2*femtoseconds), Platform.getPlatform('Reference'))
         context.setPositions(crd.positions)
         state = context.getState(getEnergy=True, groups={1})
         energy = state.getPotentialEnergy().value_in_unit(kilocalories_per_mole)
@@ -184,7 +184,7 @@ class TestCharmmFiles(unittest.TestCase):
         psf.setBox(30.0*angstroms, 30.0*angstroms, 30.0*angstroms)
 
         # Now compute the full energy
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
         system = psf.createSystem(params, nonbondedMethod=PME, ewaldErrorTolerance=0.00005)
         integrator = DrudeLangevinIntegrator(300*kelvin, 1.0/picosecond, 1*kelvin, 10/picosecond, 0.001*picoseconds)
         con = Context(system, integrator, plat)
@@ -234,7 +234,7 @@ class TestCharmmFiles(unittest.TestCase):
         psf.setBox(33.2*angstroms, 33.2*angstroms, 33.2*angstroms)
 
         # Now compute the full energy
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
         system = psf.createSystem(params, nonbondedMethod=PME, ewaldErrorTolerance=0.00005)
         integrator = DrudeLangevinIntegrator(300*kelvin, 1.0/picosecond, 1*kelvin, 10/picosecond, 0.001*picoseconds)
         con = Context(system, integrator, plat)
@@ -251,7 +251,7 @@ class TestCharmmFiles(unittest.TestCase):
         crd = CharmmCrdFile('systems/chlb_cgenff.crd')
         params = CharmmParameterSet('systems/top_all36_cgenff.rtf',
                                     'systems/par_all36_cgenff.prm')
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
         system = psf.createSystem(params)
         con = Context(system, VerletIntegrator(2*femtoseconds), plat)
         con.setPositions(crd.positions)
@@ -310,7 +310,7 @@ class TestCharmmFiles(unittest.TestCase):
         for i in range(5):
             system = self.psf_c.createSystem(self.params, implicitSolvent=solventType[i], nonbondedMethod=nonbondedMethod[i], implicitSolventSaltConc=salt[i])
             integrator = VerletIntegrator(0.001)
-            context = Context(system, integrator, Platform.getPlatformByName("Reference"))
+            context = Context(system, integrator, Platform.getPlatform("Reference"))
             context.setPositions(self.pdb.positions)
             state1 = context.getState(getForces=True)
             #out = open('systems/ala-ala-ala-implicit-forces/'+file[i]+'.xml', 'w')
@@ -338,7 +338,7 @@ class TestCharmmFiles(unittest.TestCase):
             a.charge = 0.0
 
         # Now compute the full energy
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
 
         system_strict     = psf.createSystem(params_strict    , nonbondedMethod=PME,
                                   nonbondedCutoff=8*angstroms)
@@ -365,7 +365,7 @@ class TestCharmmFiles(unittest.TestCase):
         force = [f for f in system.getForces() if isinstance(f, CustomTorsionForce)][0]
         group = force.getForceGroup()
         integrator = VerletIntegrator(0.001)
-        context = Context(system, integrator, Platform.getPlatformByName("Reference"))
+        context = Context(system, integrator, Platform.getPlatform("Reference"))
         angle = 0.1
         pos1 = [Vec3(0,0,0), Vec3(1,0,0), Vec3(1,1,0), Vec3(0,1,math.tan(angle))] # theta = angle
         pos2 = [Vec3(0,0,0), Vec3(1,0,0), Vec3(1,1,0), Vec3(2,1,math.tan(angle))] # theta = pi-angle
@@ -448,7 +448,7 @@ class TestCharmmFiles(unittest.TestCase):
                 params = CharmmParameterSet('systems/charmm22.rtf', parfile.name)
                 os.remove(parfile.name)
             system = self.psf_c.createSystem(params, nonbondedMethod=NoCutoff)
-            context = Context(system, VerletIntegrator(1*femtoseconds), Platform.getPlatformByName('Reference'))
+            context = Context(system, VerletIntegrator(1*femtoseconds), Platform.getPlatform('Reference'))
             context.setPositions(crd.positions)
             energy = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(kilocalories_per_mole)
             self.assertAlmostEqual(energy, modeEnergy[abs(nbxmod)], delta=1e-3*abs(energy))
@@ -459,7 +459,7 @@ class TestCharmmFiles(unittest.TestCase):
         pdb = PDBFile('systems/MoS2.pdb')
         params = CharmmParameterSet('systems/MoS2.prm')
         system = psf.createSystem(params, nonbondedMethod=NoCutoff)
-        context = Context(system, VerletIntegrator(1*femtoseconds), Platform.getPlatformByName('Reference'))
+        context = Context(system, VerletIntegrator(1*femtoseconds), Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         energy = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(kilocalories_per_mole)
         # Compare with value computed with NAMD.
@@ -507,7 +507,7 @@ class TestCharmmFiles(unittest.TestCase):
         crd = CharmmCrdFile('systems/ala3_solv.crd')
         params = CharmmParameterSet('systems/par_all36_prot.prm',
                                     'systems/toppar_water_ions.str')
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
         system_charmm = psf.createSystem(params, nonbondedMethod=PME,
                                   nonbondedCutoff=8 * angstroms)
         topology = psf.topology

--- a/wrappers/python/tests/TestDcdFile.py
+++ b/wrappers/python/tests/TestDcdFile.py
@@ -39,7 +39,7 @@ class TestDCDFile(unittest.TestCase):
         # Create a simulation and write some frames to a DCD file.
         
         integrator = mm.VerletIntegrator(0.001*unit.picoseconds)
-        simulation = app.Simulation(pdb.topology, system, integrator, mm.Platform.getPlatformByName('Reference'))
+        simulation = app.Simulation(pdb.topology, system, integrator, mm.Platform.getPlatform('Reference'))
         dcd = app.DCDReporter(fname, 2)
         simulation.reporters.append(dcd)
         simulation.context.setPositions(pdb.positions)
@@ -53,7 +53,7 @@ class TestDCDFile(unittest.TestCase):
         # Create a new simulation and have it append some more frames.
 
         integrator = mm.VerletIntegrator(0.001*unit.picoseconds)
-        simulation = app.Simulation(pdb.topology, system, integrator, mm.Platform.getPlatformByName('Reference'))
+        simulation = app.Simulation(pdb.topology, system, integrator, mm.Platform.getPlatform('Reference'))
         dcd = app.DCDReporter(fname, 2, append=True)
         simulation.reporters.append(dcd)
         simulation.context.setPositions(pdb.positions)

--- a/wrappers/python/tests/TestDesmondDMSFile.py
+++ b/wrappers/python/tests/TestDesmondDMSFile.py
@@ -90,7 +90,7 @@ class TestDesmondDMSFile(unittest.TestCase):
         """Test OPLS potential energy of nabumetone """
         system = self.dms_opls1.createSystem(nonbondedMethod=NoCutoff, OPLS = True)
         integrator = LangevinIntegrator(300*kelvin, 1.0/picosecond, 0.0005*picoseconds)
-        context = Context(system, integrator,Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator,Platform.getPlatform('Reference'))
         context.setPositions(self.dms_opls1.positions)
         ene = context.getState(getEnergy=True).getPotentialEnergy()
         self.assertAlmostEqual(ene.value_in_unit(kilojoules_per_mole), 94.21, places=2)
@@ -99,7 +99,7 @@ class TestDesmondDMSFile(unittest.TestCase):
         """Test OPLS potential energy of beta-cyclodextrin/nabumetone complex """
         system = self.dms_opls2.createSystem(nonbondedMethod=NoCutoff, OPLS = True)
         integrator = LangevinIntegrator(300*kelvin, 1.0/picosecond, 0.0005*picoseconds)
-        context = Context(system, integrator,Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator,Platform.getPlatform('Reference'))
         context.setPositions(self.dms_opls2.positions)
         ene = context.getState(getEnergy=True).getPotentialEnergy()
         self.assertAlmostEqual(ene.value_in_unit(kilojoules_per_mole), 903.04, places=2)

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -323,7 +323,7 @@ class TestForceField(unittest.TestCase):
             forcefield = ForceField('amber96.xml', f'implicit/{solventType[i]}.xml')
             system = forcefield.createSystem(self.pdb2.topology, nonbondedMethod=nonbondedMethod[i], implicitSolventKappa=kappa[i])
             integrator = VerletIntegrator(0.001)
-            context = Context(system, integrator, Platform.getPlatformByName("Reference"))
+            context = Context(system, integrator, Platform.getPlatform("Reference"))
             context.setPositions(self.pdb2.positions)
             state1 = context.getState(getForces=True)
             if file[i] is not None:
@@ -872,7 +872,7 @@ class TestForceField(unittest.TestCase):
             a.charge = 0.0
 
         # Now compute the full energy
-        plat = Platform.getPlatformByName('Reference')
+        plat = Platform.getPlatform('Reference')
         system = psf.createSystem(params, nonbondedMethod=PME,
                                   nonbondedCutoff=5*angstroms)
 
@@ -1122,7 +1122,7 @@ END"""))
             if isinstance(f, NonbondedForce):
                 f.setPMEParameters(3.4, 64, 64, 64)
         integrator = DrudeLangevinIntegrator(300, 1.0, 1.0, 10.0, 0.001)
-        context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator, Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
 
         # Compare the energy to values computed by CHARMM.  Here is what it outputs:
@@ -1200,7 +1200,7 @@ self.scriptExecuted = True
         for i, f in enumerate(system.getForces()):
             f.setForceGroup(i)
         integrator = VerletIntegrator(0.001)
-        context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator, Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         energies = {}
         for i, f in enumerate(system.getForces()):
@@ -1244,7 +1244,7 @@ self.scriptExecuted = True
 </ForceField> """
         ff = ForceField(StringIO(xml))
         system = ff.createSystem(pdb.topology)
-        context = Context(system, VerletIntegrator(2*femtoseconds), Platform.getPlatformByName('Reference'))
+        context = Context(system, VerletIntegrator(2*femtoseconds), Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         energy1 = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(kilojoules_per_mole)
 
@@ -1257,7 +1257,7 @@ self.scriptExecuted = True
         f.addParticle(0, 0.404468018036, 0.6276)
         f.addParticle(0, 0.251367073323, 0.1962296)
         system.addForce(f)
-        context = Context(system, VerletIntegrator(2*femtoseconds), Platform.getPlatformByName('Reference'))
+        context = Context(system, VerletIntegrator(2*femtoseconds), Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         energy2 = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(kilojoules_per_mole)
         self.assertAlmostEqual(energy1, energy2)
@@ -1417,7 +1417,7 @@ class AmoebaTestForceField(unittest.TestCase):
         forcefield = ForceField('amoeba2013.xml', 'amoeba2013_gk.xml')
         system = forcefield.createSystem(pdb.topology, polarization='direct')
         integrator = VerletIntegrator(0.001)
-        context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator, Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         state1 = context.getState(getForces=True)
         with open('systems/alanine-dipeptide-amoeba-forces.xml') as input:
@@ -1433,7 +1433,7 @@ class AmoebaTestForceField(unittest.TestCase):
         for i, f in enumerate(system.getForces()):
             f.setForceGroup(i)
         integrator = VerletIntegrator(0.001)
-        context = Context(system, integrator, Platform.getPlatformByName('Reference'))
+        context = Context(system, integrator, Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         energies = {}
         for i, f in enumerate(system.getForces()):

--- a/wrappers/python/tests/TestForceGroups.py
+++ b/wrappers/python/tests/TestForceGroups.py
@@ -14,7 +14,7 @@ class TestForceGroups(unittest.TestCase):
             force.setForceGroup(i)
             system.addForce(force)
 
-        platform = mm.Platform.getPlatformByName('Reference')
+        platform = mm.Platform.getPlatform('Reference')
         context = mm.Context(system, mm.VerletIntegrator(0), platform)
         context.setPositions([(0,0,0)])
         self.context = context

--- a/wrappers/python/tests/TestGromacsTopFile.py
+++ b/wrappers/python/tests/TestGromacsTopFile.py
@@ -45,7 +45,7 @@ class TestGromacsTopFile(unittest.TestCase):
             if isinstance(force, PeriodicTorsionForce):
                 force.setForceGroup(1)
         context = Context(system, VerletIntegrator(1*femtosecond),
-                          Platform.getPlatformByName('Reference'))
+                          Platform.getPlatform('Reference'))
         context.setPositions(gro.positions)
         ene = context.getState(getEnergy=True, groups=2**1).getPotentialEnergy()
         self.assertAlmostEqual(ene.value_in_unit(kilojoules_per_mole), 341.6905133582857)
@@ -57,7 +57,7 @@ class TestGromacsTopFile(unittest.TestCase):
         system = top.createSystem()
 
         context = Context(system, VerletIntegrator(1*femtosecond),
-                          Platform.getPlatformByName('Reference'))
+                          Platform.getPlatform('Reference'))
         context.setPositions(gro.positions)
         ene = context.getState(getEnergy=True).getPotentialEnergy()
         self.assertAlmostEqual(ene.value_in_unit(kilojoules_per_mole), -346.940915296)
@@ -72,7 +72,7 @@ class TestGromacsTopFile(unittest.TestCase):
                 f.setUseLongRangeCorrection(True)
 
         context = Context(system, VerletIntegrator(1*femtosecond),
-                          Platform.getPlatformByName('Reference'))
+                          Platform.getPlatform('Reference'))
         context.setPositions(gro.positions)
         energy = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(kilojoules_per_mole)
         self.assertAlmostEqual(energy, 3135.33, delta=energy*0.005)
@@ -173,7 +173,7 @@ class TestGromacsTopFile(unittest.TestCase):
         self.assertEqual(1, len(top._moleculeTypes['BENX'].vsites2))
 
         context = Context(system, VerletIntegrator(1*femtosecond),
-                          Platform.getPlatformByName('Reference'))
+                          Platform.getPlatform('Reference'))
         context.setPositions(gro.positions)
         context.computeVirtualSites()
         ene = context.getState(getEnergy=True).getPotentialEnergy()
@@ -203,7 +203,7 @@ class TestGromacsTopFile(unittest.TestCase):
         system = top.createSystem()
         for i, f in enumerate(system.getForces()):
             f.setForceGroup(i)
-        context = Context(system, VerletIntegrator(1*femtosecond), Platform.getPlatformByName('Reference'))
+        context = Context(system, VerletIntegrator(1*femtosecond), Platform.getPlatform('Reference'))
         context.setPositions(gro.positions)
         energy = {}
         for i, f in enumerate(system.getForces()):

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -64,7 +64,7 @@ class TestIntegrators(unittest.TestCase):
         velocities = [ (random.random()-0.5, random.random()-0.5, random.random()-0.5) for i in range(numParticles) ]
 
         # Create Context
-        platform = Platform.getPlatformByName('Reference')
+        platform = Platform.getPlatform('Reference')
         context = Context(system, integrator, platform)
         context.setPositions(positions)
         context.setVelocities(velocities)
@@ -161,7 +161,7 @@ class TestIntegrators(unittest.TestCase):
         # Create a System with a single particle and no forces
         system = System()
         system.addParticle(12.0*amu)
-        platform = Platform.getPlatformByName('Reference')
+        platform = Platform.getPlatform('Reference')
         initial_positions = [Vec3(0,0,0)]
         initial_velocities = [Vec3(1,0,0)]
         nsteps = 125 # number of steps to take

--- a/wrappers/python/tests/TestMetadynamics.py
+++ b/wrappers/python/tests/TestMetadynamics.py
@@ -25,7 +25,7 @@ class TestMetadynamics(unittest.TestCase):
         residue = topology.addResidue('H2', chain)
         topology.addAtom('H1', element.hydrogen, residue)
         topology.addAtom('H2', element.hydrogen, residue)
-        simulation = Simulation(topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(topology, system, integrator, Platform.getPlatform('Reference'))
         simulation.context.setPositions([Vec3(0, 0, 0), Vec3(1, 0, 0)])
         meta.step(simulation, 200000)
         fe = meta.getFreeEnergy()

--- a/wrappers/python/tests/TestNumpyCompatibility.py
+++ b/wrappers/python/tests/TestNumpyCompatibility.py
@@ -22,7 +22,7 @@ class TestNumpyCompatibility(unittest.TestCase):
         integrator = mm.LangevinIntegrator(300*unit.kelvin, 1.0/unit.picoseconds,
                                            2.0*unit.femtoseconds)
         self.simulation = app.Simulation(prmtop.topology, system, integrator,
-                                    mm.Platform.getPlatformByName('Reference'))
+                                    mm.Platform.getPlatform('Reference'))
 
 
     def test_setPositions(self):

--- a/wrappers/python/tests/TestPdbxFile.py
+++ b/wrappers/python/tests/TestPdbxFile.py
@@ -69,7 +69,7 @@ class TestPdbxFile(unittest.TestCase):
         parm = AmberPrmtopFile('systems/alanine-dipeptide-implicit.prmtop')
         system = parm.createSystem()
         sim = Simulation(parm.topology, system, VerletIntegrator(1*femtoseconds),
-                         Platform.getPlatformByName('Reference'))
+                         Platform.getPlatform('Reference'))
         sim.context.setPositions(PDBFile('systems/alanine-dipeptide-implicit.pdb').getPositions())
         sim.reporters.append(PDBxReporter('test.cif', 1))
         sim.step(10)
@@ -101,7 +101,7 @@ class TestPdbxFile(unittest.TestCase):
         parm = AmberPrmtopFile('systems/alanine-dipeptide-explicit.prmtop')
         system = parm.createSystem(nonbondedCutoff=1.0, nonbondedMethod=PME)
         sim = Simulation(parm.topology, system, VerletIntegrator(1*femtoseconds),
-                         Platform.getPlatformByName('Reference'))
+                         Platform.getPlatform('Reference'))
         orig_pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
         sim.context.setPositions(orig_pdb.getPositions())
         sim.context.setPeriodicBoxVectors(*parm.topology.getPeriodicBoxVectors())

--- a/wrappers/python/tests/TestSimulatedTempering.py
+++ b/wrappers/python/tests/TestSimulatedTempering.py
@@ -20,7 +20,7 @@ class TestSimulatedTempering(unittest.TestCase):
         residue = topology.addResidue('H2', chain)
         topology.addAtom('H1', element.hydrogen, residue)
         topology.addAtom('H2', element.hydrogen, residue)
-        simulation = Simulation(topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(topology, system, integrator, Platform.getPlatform('Reference'))
         st = SimulatedTempering(simulation, numTemperatures=10, minTemperature=200*kelvin, maxTemperature=400*kelvin, tempChangeInterval=5, reportInterval=10000)
         self.assertEqual(10, len(st.temperatures))
         self.assertEqual(200*kelvin, st.temperatures[0])
@@ -72,7 +72,7 @@ class TestSimulatedTempering(unittest.TestCase):
         residue = topology.addResidue('H2', chain)
         topology.addAtom('H1', element.hydrogen, residue)
         topology.addAtom('H2', element.hydrogen, residue)
-        simulation = Simulation(topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(topology, system, integrator, Platform.getPlatform('Reference'))
         simulation.context.setPositions([Vec3(0, 0, 0), Vec3(1, 0, 0)])
 
         # Check the temperature is correct before creating the simulated tempering simulation

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -17,7 +17,7 @@ class TestSimulation(unittest.TestCase):
 
         # Create a Simulation.
 
-        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatform('Reference'))
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*kelvin)
         initialState = simulation.context.getState(getPositions=True, getVelocities=True)
@@ -74,7 +74,7 @@ class TestSimulation(unittest.TestCase):
 
         # Create a Simulation.
 
-        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatform('Reference'))
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*kelvin)
         initialState = simulation.context.getState(getPositions=True, getVelocities=True)
@@ -107,7 +107,7 @@ class TestSimulation(unittest.TestCase):
 
         # Create a Simulation.
 
-        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatform('Reference'))
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*kelvin)
         self.assertEqual(0, simulation.currentStep)
@@ -130,7 +130,7 @@ class TestSimulation(unittest.TestCase):
 
         # Create a Simulation.
 
-        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatformByName('Reference'))
+        simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatform('Reference'))
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*kelvin)
         self.assertEqual(0, simulation.currentStep)

--- a/wrappers/python/tests/TestXtcFile.py
+++ b/wrappers/python/tests/TestXtcFile.py
@@ -163,7 +163,7 @@ class TestXtcFile(unittest.TestCase):
                 pdb.topology,
                 system,
                 integrator,
-                mm.Platform.getPlatformByName("Reference"),
+                mm.Platform.getPlatform("Reference"),
             )
             xtc = app.XTCReporter(fname, 2)
             simulation.reporters.append(xtc)
@@ -182,7 +182,7 @@ class TestXtcFile(unittest.TestCase):
                 pdb.topology,
                 system,
                 integrator,
-                mm.Platform.getPlatformByName("Reference"),
+                mm.Platform.getPlatform("Reference"),
             )
             xtc = app.XTCReporter(fname, 2, append=True)
             simulation.reporters.append(xtc)


### PR DESCRIPTION
Implements #4432.  This makes two changes.  First, you can call `getPlatform(name)` instead of `getPlatformByName(name)`.  Second, you can call `getState(positions=True)` instead of `getState(getPositions=True)`.  The old forms are still supported for backward compatibility.