### PR TITLE
Add LoongArch architecture LSX support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,11 @@ if ("${TARGET_ARCH}" MATCHES "ppc")
     set(PPC ON)
     add_definitions(-D__PPC__=1)
 endif()
+if ("${TARGET_ARCH}" MATCHES "loongarch64")
+    set(LOONGARCH64 ON)
+    add_definitions(-D__LOONGARCH64__=1 -mlsx)
+endif()
+
 
 # Where to install
 IF(WIN32)

--- a/cmake_modules/TargetArch.cmake
+++ b/cmake_modules/TargetArch.cmake
@@ -87,6 +87,8 @@ set(archdetect_c_code "
     #else
         #error cmake_ARCH ppc
     #endif
+#elif defined(__loongarch64)
+    #error cmake_ARCH loongarch64
 #endif
 
 #error cmake_ARCH unknown

--- a/openmmapi/include/openmm/internal/hardware.h
+++ b/openmmapi/include/openmm/internal/hardware.h
@@ -94,7 +94,7 @@ static int getNumProcessors() {
 #define cpuid __cpuid
 #else
 #if !defined(__ANDROID__) && !defined(__PNACL__) && !defined(__PPC__) \
-    && !defined(__ARM__) && !defined(__ARM64__)
+    && !defined(__ARM__) && !defined(__ARM64__) && !defined(__LOONGARCH64__)
     static void cpuid(int cpuInfo[4], int infoType) {
     #ifdef __LP64__
         __asm__ __volatile__ (


### PR DESCRIPTION
LoongArch is a new architecture, already supported by linux-6.1, gcc-12.

Test result：
100% tests passed, 0 tests failed out of 118

Total Test time (real) = 310.05 sec
[openmm_test.log](https://github.com/openmm/openmm/files/14367770/openmm_test.log)
