### PR TITLE
Minor optimization to validating exclusions

### DIFF
--- a/openmmapi/src/CustomNonbondedForceImpl.cpp
+++ b/openmmapi/src/CustomNonbondedForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2022 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2024 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -84,6 +84,8 @@ void CustomNonbondedForceImpl::initialize(ContextImpl& context) {
     for (int i = 0; i < owner.getNumExclusions(); i++) {
         int particle1, particle2;
         owner.getExclusionParticles(i, particle1, particle2);
+        int minp = min(particle1, particle2);
+        int maxp = max(particle1, particle2);
         if (particle1 < 0 || particle1 >= owner.getNumParticles()) {
             stringstream msg;
             msg << "CustomNonbondedForce: Illegal particle index for an exclusion: ";
@@ -96,7 +98,7 @@ void CustomNonbondedForceImpl::initialize(ContextImpl& context) {
             msg << particle2;
             throw OpenMMException(msg.str());
         }
-        if (exclusions[particle1].count(particle2) > 0 || exclusions[particle2].count(particle1) > 0) {
+        if (exclusions[minp].count(maxp) > 0) {
             stringstream msg;
             msg << "CustomNonbondedForce: Multiple exclusions are specified for particles ";
             msg << particle1;
@@ -104,8 +106,7 @@ void CustomNonbondedForceImpl::initialize(ContextImpl& context) {
             msg << particle2;
             throw OpenMMException(msg.str());
         }
-        exclusions[particle1].insert(particle2);
-        exclusions[particle2].insert(particle1);
+        exclusions[minp].insert(maxp);
     }
     if (owner.getNonbondedMethod() == CustomNonbondedForce::CutoffPeriodic) {
         Vec3 boxVectors[3];

--- a/openmmapi/src/NonbondedForceImpl.cpp
+++ b/openmmapi/src/NonbondedForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2024 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -81,6 +81,8 @@ void NonbondedForceImpl::initialize(ContextImpl& context) {
         int particle[2];
         double chargeProd, sigma, epsilon;
         owner.getExceptionParameters(i, particle[0], particle[1], chargeProd, sigma, epsilon);
+        int minp = min(particle[0], particle[1]);
+        int maxp = max(particle[0], particle[1]);
         for (int j = 0; j < 2; j++) {
             if (particle[j] < 0 || particle[j] >= owner.getNumParticles()) {
                 stringstream msg;
@@ -89,7 +91,7 @@ void NonbondedForceImpl::initialize(ContextImpl& context) {
                 throw OpenMMException(msg.str());
             }
         }
-        if (exceptions[particle[0]].count(particle[1]) > 0 || exceptions[particle[1]].count(particle[0]) > 0) {
+        if (exceptions[minp].count(maxp) > 0) {
             stringstream msg;
             msg << "NonbondedForce: Multiple exceptions are specified for particles ";
             msg << particle[0];
@@ -97,8 +99,7 @@ void NonbondedForceImpl::initialize(ContextImpl& context) {
             msg << particle[1];
             throw OpenMMException(msg.str());
         }
-        exceptions[particle[0]].insert(particle[1]);
-        exceptions[particle[1]].insert(particle[0]);
+        exceptions[minp].insert(maxp);
         if (sigma < 0)
             throw OpenMMException("NonbondedForce: sigma for an exception cannot be negative");
         if (epsilon < 0)


### PR DESCRIPTION
See #4452.  This slightly reduces context creation time for systems with very large numbers of exclusions.

cc @philipturner.  On your system with two CustomNonbondedForces and 4.8 million exclusions, this reduces context creation time by about 1.5 seconds.