### PR TITLE
Fix minor issue in error message with non-existent self.lines

### DIFF
--- a/wrappers/python/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/openmm/app/internal/amber_file_parser.py
@@ -1334,7 +1334,7 @@ class AmberAsciiRestart(object):
             hasbox = hasvels = True
         else:
             raise TypeError('Badly formatted restart file. Has %d lines '
-                            'for %d atoms.' % (len(self.lines), self.natom))
+                            'for %d atoms.' % (len(lines), self.natom))
 
         if self._asNumpy:
             coordinates = np.zeros((self.natom, 3), np.float32)


### PR DESCRIPTION
Makes the error message print correctly. The variable `self.lines` does not exist, it was a typo.