### PR TITLE
Revised code from installing CUDA on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux CUDA 10.0
+          - name: Linux CUDA 12.4
             os: ubuntu-latest
-            python-version: "3.7"
-            cuda-version: "10.0"
+            python-version: "3.11"
+            cuda-version: "12.4"
             OPENCL: false
             CMAKE_FLAGS: |
               -DOPENMM_BUILD_CUDA_TESTS=OFF \
@@ -42,16 +42,16 @@ jobs:
               -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF \
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
               -DOPENMM_BUILD_EXAMPLES=OFF \
-              -DOPENCL_LIBRARY=/usr/local/cuda-10.0/lib64/libOpenCL.so \
-              -DCUDA_CUDART_LIBRARY=/usr/local/cuda-10.0/lib64/libcudart.so \
-              -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-10.0/bin/nvcc \
-              -DCUDA_SDK_ROOT_DIR=/usr/local/cuda-10.0/ \
-              -DCUDA_TOOLKIT_INCLUDE=/usr/local/cuda-10.0/include \
-              -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.0/ \
+              -DOPENCL_LIBRARY=/usr/local/cuda-12.4/lib64/libOpenCL.so \
+              -DCUDA_CUDART_LIBRARY=/usr/local/cuda-12.4/lib64/libcudart.so \
+              -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-12.4/bin/nvcc \
+              -DCUDA_SDK_ROOT_DIR=/usr/local/cuda-12.4/ \
+              -DCUDA_TOOLKIT_INCLUDE=/usr/local/cuda-12.4/include \
+              -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.4/ \
 
           - name: Linux CUDA 11.2
             os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.11"
             OPENCL: false
             cuda-version: "11.2"
             CMAKE_FLAGS: |
@@ -72,7 +72,7 @@ jobs:
 
           - name: Linux AMD OpenCL
             os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.11"
             OPENCL: true
             cuda-version: ""
             CMAKE_FLAGS: |
@@ -90,9 +90,9 @@ jobs:
               -DOPENCL_INCLUDE_DIR=${GITHUB_WORKSPACE}/AMDAPPSDK/include \
               -DOPENCL_LIBRARY=${GITHUB_WORKSPACE}/AMDAPPSDK/lib/x86_64/libOpenCL.so \
 
-          - name: Linux CPU Python 3.7 with static lib
+          - name: Linux CPU Python 3.11 with static lib
             os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.11"
             OPENCL: false
             cuda-version: ""
             CC: $CCACHE/clang
@@ -102,8 +102,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.7 with condaforge compilers
-            python-version: "3.7"
+          - name: Linux CPU Python 3.11 with condaforge compilers
+            python-version: "3.11"
             os: ubuntu-latest
             OPENCL: false
             cuda-version: ""
@@ -112,8 +112,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.7
-            python-version: "3.7"
+          - name: Linux CPU Python 3.9
+            python-version: "3.9"
             os: ubuntu-latest
             OPENCL: false
             cuda-version: ""

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,6 @@ jobs:
               -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF \
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
               -DOPENMM_BUILD_EXAMPLES=OFF \
-              -DOPENCL_LIBRARY=/usr/local/cuda-12.4/lib64/libOpenCL.so \
               -DCUDA_CUDART_LIBRARY=/usr/local/cuda-12.4/lib64/libcudart.so \
               -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-12.4/bin/nvcc \
               -DCUDA_SDK_ROOT_DIR=/usr/local/cuda-12.4/ \
@@ -63,7 +62,6 @@ jobs:
               -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF \
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
               -DOPENMM_BUILD_EXAMPLES=OFF \
-              -DOPENCL_LIBRARY=/usr/local/cuda-11.2/lib64/libOpenCL.so \
               -DCUDA_CUDART_LIBRARY=/usr/local/cuda-11.2/lib64/libcudart.so \
               -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-11.2/bin/nvcc \
               -DCUDA_SDK_ROOT_DIR=/usr/local/cuda-11.2/ \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,11 +49,11 @@ jobs:
               -DCUDA_TOOLKIT_INCLUDE=/usr/local/cuda-12.4/include \
               -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.4/ \
 
-          - name: Linux CUDA 11.2
+          - name: Linux CUDA 11.8
             os: ubuntu-latest
             python-version: "3.11"
             OPENCL: false
-            cuda-version: "11.2"
+            cuda-version: "11.8"
             CMAKE_FLAGS: |
               -DOPENMM_BUILD_CUDA_TESTS=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \

--- a/devtools/ci/gh-actions/scripts/install_cuda.sh
+++ b/devtools/ci/gh-actions/scripts/install_cuda.sh
@@ -12,8 +12,14 @@ sudo apt-key del 7fa2af80
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
-apt list cuda --all-versions
-sudo apt-get -y install cuda
+CUDA_APT=${CUDA_VERSION/./-}
+sudo apt-get install -y \
+    libgl1-mesa-dev cuda-compiler-${CUDA_APT} \
+    cuda-drivers cuda-driver-dev-${CUDA_APT} \
+    cuda-cudart-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} \
+    libcufft-${CUDA_APT} ${CUFFT}-dev-${CUDA_APT} \
+    cuda-nvrtc-${CUDA_APT} cuda-nvrtc-dev-${CUDA_APT} \
+    cuda-nvprof-${CUDA_APT}
 sudo apt-get clean
 
 export CUDA_HOME=/usr/local/cuda-${CUDA_VERSION}

--- a/devtools/ci/gh-actions/scripts/install_cuda.sh
+++ b/devtools/ci/gh-actions/scripts/install_cuda.sh
@@ -17,7 +17,7 @@ sudo apt-get install -y \
     libgl1-mesa-dev cuda-compiler-${CUDA_APT} \
     cuda-drivers cuda-driver-dev-${CUDA_APT} \
     cuda-cudart-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} \
-    libcufft-${CUDA_APT} ${CUFFT}-dev-${CUDA_APT} \
+    libcufft-${CUDA_APT} libcufft-dev-${CUDA_APT} \
     cuda-nvrtc-${CUDA_APT} cuda-nvrtc-dev-${CUDA_APT} \
     cuda-nvprof-${CUDA_APT}
 sudo apt-get clean

--- a/devtools/ci/gh-actions/scripts/install_cuda.sh
+++ b/devtools/ci/gh-actions/scripts/install_cuda.sh
@@ -1,7 +1,6 @@
-# This script install CUDA on Ubuntu-based systemws
-# It uses the Nvidia repos for Ubuntu 18.04, which as of Dec 2020
-# includes packages for CUDA 10.0, 10.1, 10.2, 11.0, 11.1, 11.2
-# Future versions might require an updated repo (maybe Ubuntu 20)
+# This script install CUDA on Ubuntu-based systems
+# It uses the Nvidia repos for Ubuntu 22.04
+# Future versions might require an updated repo
 # It expects a $CUDA_VERSION environment variable set to major.minor (e.g. 10.0)
 
 set -euxo pipefail
@@ -9,23 +8,10 @@ set -euxo pipefail
 # Enable retrying
 echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
-sudo wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 --tries 5 \
-    -O /etc/apt/preferences.d/cuda-repository-pin-600 \
-    https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
-sudo apt-get update -qq
-
-CUDA_APT=${CUDA_VERSION/./-}
-## cufft changed package names in CUDA 11
-if [[ ${CUDA_VERSION} == 10.* ]]; then CUFFT="cuda-cufft"; else CUFFT="libcufft"; fi
-sudo apt-get install -y \
-    libgl1-mesa-dev cuda-compiler-${CUDA_APT} \
-    cuda-drivers cuda-driver-dev-${CUDA_APT} \
-    cuda-cudart-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} \
-    ${CUFFT}-${CUDA_APT} ${CUFFT}-dev-${CUDA_APT} \
-    cuda-nvrtc-${CUDA_APT} cuda-nvrtc-dev-${CUDA_APT} \
-    cuda-nvprof-${CUDA_APT}
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+sudo apt-get -y install cuda=${CUDA_VERSION}.-
 sudo apt-get clean
 
 export CUDA_HOME=/usr/local/cuda-${CUDA_VERSION}

--- a/devtools/ci/gh-actions/scripts/install_cuda.sh
+++ b/devtools/ci/gh-actions/scripts/install_cuda.sh
@@ -11,7 +11,7 @@ echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
-sudo apt-get -y install cuda=${CUDA_VERSION}.-
+sudo apt-get -y install cuda=${CUDA_VERSION}
 sudo apt-get clean
 
 export CUDA_HOME=/usr/local/cuda-${CUDA_VERSION}

--- a/devtools/ci/gh-actions/scripts/install_cuda.sh
+++ b/devtools/ci/gh-actions/scripts/install_cuda.sh
@@ -19,7 +19,7 @@ sudo apt-get install -y \
     cuda-cudart-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} \
     libcufft-${CUDA_APT} libcufft-dev-${CUDA_APT} \
     cuda-nvrtc-${CUDA_APT} cuda-nvrtc-dev-${CUDA_APT} \
-    cuda-nvprof-${CUDA_APT}
+    cuda-nvprof-${CUDA_APT} cuda-profiler-api-${CUDA_APT}
 sudo apt-get clean
 
 export CUDA_HOME=/usr/local/cuda-${CUDA_VERSION}

--- a/devtools/ci/gh-actions/scripts/install_cuda.sh
+++ b/devtools/ci/gh-actions/scripts/install_cuda.sh
@@ -8,10 +8,12 @@ set -euxo pipefail
 # Enable retrying
 echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
+sudo apt-key del 7fa2af80
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
-sudo apt-get -y install cuda=${CUDA_VERSION}
+apt list cuda --all-versions
+sudo apt-get -y install cuda
 sudo apt-get clean
 
 export CUDA_HOME=/usr/local/cuda-${CUDA_VERSION}


### PR DESCRIPTION
CUDA builds have recently begun failing.  I'm not sure why, though I think it might be that github has started using a newer version of Ubuntu.  I'm attempting to get it working again.

I also updated the versions of CUDA and Python in various builds to better reflect the versions we currently support.