### PR TITLE
ATMForce reorders inner contexts for better performance

### DIFF
--- a/openmmapi/src/ATMForceImpl.cpp
+++ b/openmmapi/src/ATMForceImpl.cpp
@@ -115,9 +115,6 @@ void ATMForceImpl::initialize(ContextImpl& context) {
 
     innerContext0 = context.createLinkedContext(innerSystem0, innerIntegrator0);
     innerContext1 = context.createLinkedContext(innerSystem1, innerIntegrator1);
-    vector<Vec3> positions(system.getNumParticles(), Vec3());
-    innerContext0->setPositions(positions);
-    innerContext1->setPositions(positions);
 
     // Create the kernel.
 

--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -1714,19 +1714,15 @@ public:
     virtual ComputeContext& getInnerComputeContext(ContextImpl& innerContext) = 0;
     
 private:
-    class ForceInfo;
     class ReorderListener;
     
     void initKernels(ContextImpl& context, ContextImpl& innerContext0, ContextImpl& innerContext1);
     
     bool hasInitializedKernel;
     ComputeContext& cc;
-
-    std::vector<mm_float4> displVector1;
-    std::vector<mm_float4> displVector0;
-
     ComputeArray displ1;
     ComputeArray displ0;
+    ComputeArray invAtomOrder, inner0InvAtomOrder, inner1InvAtomOrder;
     ComputeKernel copyStateKernel;
     ComputeKernel hybridForceKernel;
 

--- a/platforms/common/src/kernels/atmforce.cc
+++ b/platforms/common/src/kernels/atmforce.cc
@@ -3,12 +3,18 @@ KERNEL void hybridForce(int numParticles,
                         GLOBAL mm_long* RESTRICT force,
                         GLOBAL mm_long* RESTRICT force0,
                         GLOBAL mm_long* RESTRICT force1,
+                        GLOBAL int* RESTRICT invAtomOrder,
+                        GLOBAL int* RESTRICT inner0InvAtomOrder,
+                        GLOBAL int* RESTRICT inner1InvAtomOrder,
                         real dEdu0,
                         real dEdu1) {
     for (int i = GLOBAL_ID; i < numParticles; i += GLOBAL_SIZE) {
-        force[i] += (mm_long) (dEdu0*force0[i] + dEdu1*force1[i]);
-        force[i+paddedNumParticles] += (mm_long) (dEdu0*force0[i+paddedNumParticles] + dEdu1*force1[i+paddedNumParticles]);
-        force[i+paddedNumParticles*2] += (mm_long) (dEdu0*force0[i+paddedNumParticles*2] + dEdu1*force1[i+paddedNumParticles*2]);
+        int index = invAtomOrder[i];
+        int index0 = inner0InvAtomOrder[i];
+        int index1 = inner1InvAtomOrder[i];
+        force[index] += (mm_long) (dEdu0*force0[index0] + dEdu1*force1[index1]);
+        force[index+paddedNumParticles] += (mm_long) (dEdu0*force0[index0+paddedNumParticles] + dEdu1*force1[index1+paddedNumParticles]);
+        force[index+paddedNumParticles*2] += (mm_long) (dEdu0*force0[index0+paddedNumParticles*2] + dEdu1*force1[index1+paddedNumParticles*2]);
     }
 }
 
@@ -17,7 +23,10 @@ KERNEL void copyState(int numParticles,
                       GLOBAL real4* RESTRICT posq0,
                       GLOBAL real4* RESTRICT posq1,
                       GLOBAL float4* RESTRICT displ0,
-		      GLOBAL float4* RESTRICT displ1
+		      GLOBAL float4* RESTRICT displ1,
+                      GLOBAL int* RESTRICT atomOrder,
+                      GLOBAL int* RESTRICT inner0InvAtomOrder,
+                      GLOBAL int* RESTRICT inner1InvAtomOrder
 #ifdef USE_MIXED_PRECISION
                       ,
                       GLOBAL real4* RESTRICT posqCorrection,
@@ -26,15 +35,18 @@ KERNEL void copyState(int numParticles,
 #endif
                     ) {
     for (int i = GLOBAL_ID; i < numParticles; i += GLOBAL_SIZE) {
-        real4 p0 = posq[i] + make_real4((real) displ0[i].x, (real) displ0[i].y, (real) displ0[i].z, 0);
-        real4 p1 = posq[i] + make_real4((real) displ1[i].x, (real) displ1[i].y, (real) displ1[i].z, 0);
+        int atom = atomOrder[i];
+        int index0 = inner0InvAtomOrder[atom];
+        int index1 = inner1InvAtomOrder[atom];
+        real4 p0 = posq[i] + make_real4((real) displ0[atom].x, (real) displ0[atom].y, (real) displ0[atom].z, 0);
+        real4 p1 = posq[i] + make_real4((real) displ1[atom].x, (real) displ1[atom].y, (real) displ1[atom].z, 0);
         p0.w = posq0[i].w;
         p1.w = posq1[i].w;
-        posq0[i] = p0;
-        posq1[i] = p1;
+        posq0[index0] = p0;
+        posq1[index1] = p1;
 #ifdef USE_MIXED_PRECISION
-        posq0Correction[i] = posqCorrection[i];
-        posq1Correction[i] = posqCorrection[i];
+        posq0Correction[index0] = posqCorrection[i];
+        posq1Correction[index1] = posqCorrection[i];
 #endif
     }
 }

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2023 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2024 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -2959,13 +2959,13 @@ void ReferenceCalcATMForceKernel::copyState(ContextImpl& context, ContextImpl& i
     vector<Vec3> pos0(pos);
     for (int i = 0; i < pos0.size(); i++)
         pos0[i] += displ0[i];
-    extractPositions(innerContext0) = pos0;
+    innerContext0.setPositions(pos0);
 
     //in the target state, particles are displaced by displ1
     vector<Vec3> pos1(pos);
     for (int i = 0; i < pos1.size(); i++)
         pos1[i] += displ1[i];
-    extractPositions(innerContext1) = pos1;
+    innerContext1.setPositions(pos1);
 
     Vec3 a, b, c;
     context.getPeriodicBoxVectors(a, b, c);

--- a/tests/TestATMForce.h
+++ b/tests/TestATMForce.h
@@ -269,7 +269,8 @@ void testNonbonded() {
 
     //in this scenario the non-bonded force is added to the System, a copy is added to ATMForce and
     //the System's copy is disabled by giving it a force group that is not evaluated.
-    //This should cause atom reordering in the main context
+    //This used to be needed to ensure atoms would be reordered.  It isn't anymore, but
+    //this test is left in to make sure it still works.
     system.addForce(nbforce);
     atm->addForce(XmlSerializer::clone<Force>(*nbforce));
     nbforce->setForceGroup(1);
@@ -285,7 +286,6 @@ void testNonbonded() {
     double epert1 = u1 - u0;
 
     //in this second scenario the non-bonded force is remove from the System
-    //and atom reordering is disabled.
     system.removeForce(0);
     LangevinMiddleIntegrator integrator2(300, 1.0, 0.004);
     Context context2(system, integrator2, platform);


### PR DESCRIPTION
Fixes #4395.  The main context and the inner contexts are reordered independently now, so each one can pick an appropriate atom order based on its forces.

@egallicc can you try this out?  You should now get good performance without needing the workaround.