### PR TITLE
added type checking for Simulation.step()

### DIFF
--- a/wrappers/python/openmm/app/simulation.py
+++ b/wrappers/python/openmm/app/simulation.py
@@ -142,8 +142,11 @@ class Simulation(object):
         """
         mm.LocalEnergyMinimizer.minimize(self.context, tolerance, maxIterations, reporter)
 
-    def step(self, steps):
+    def step(self, steps: int):
         """Advance the simulation by integrating a specified number of time steps."""
+        if not isinstance(steps, int):
+            raise TypeError(f'Expected type int for steps, got {type(steps)}')
+            
         self._simulate(endStep=self.currentStep+steps)
 
     def runForClockTime(self, time, checkpointFile=None, stateFile=None, checkpointInterval=None):

--- a/wrappers/python/openmm/app/simulation.py
+++ b/wrappers/python/openmm/app/simulation.py
@@ -144,8 +144,8 @@ class Simulation(object):
 
     def step(self, steps: int):
         """Advance the simulation by integrating a specified number of time steps."""
-        if not isinstance(steps, int):
-            raise TypeError(f'Expected type int for steps, got {type(steps)}')
+        if int(steps) != steps:
+            raise TypeError(f'Expected an integer for steps, got {type(steps)}')
             
         self._simulate(endStep=self.currentStep+steps)
 


### PR DESCRIPTION
Fixes #4503 

Calling Simulation.step() will now raise a TypeError when passed a non-integer value. A type hint was added as well.

A more lenient approach would be to to convert a passed float to an int and provide the user with a warning instead. In my opinion, a fractional step does not really make a lot of sense and therefore restricting the number of steps to be taken to an integer is a better option.