### PR TITLE
Allow multiple registrations of the same atom type if definitions identical

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -438,14 +438,9 @@ class ForceField(object):
         if name in self._atomTypes:
             #  allow multiple registrations of the same atom type provided the definitions are identical
             existing = self._atomTypes[name]
-            if (
-                existing.atomClass != parameters['class']
-            ) or (
-                existing.mass != float(parameters['mass'])
-            ) or (
-                existing.element.symbol != parameters['element']
-            ):
-                raise ValueError('Found multiple definitions for atom type: '+name)
+            if existing.atomClass == parameters['class'] and existing.mass == float(parameters['mass']) and existing.element.symbol == parameters['element']:
+                return
+            raise ValueError('Found multiple definitions for atom type: '+name)
         atomClass = parameters['class']
         mass = _convertParameterToNumber(parameters['mass'])
         element = None

--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -436,7 +436,16 @@ class ForceField(object):
         """Register a new atom type."""
         name = parameters['name']
         if name in self._atomTypes:
-            raise ValueError('Found multiple definitions for atom type: '+name)
+            #  allow multiple registrations of the same atom type provided the definitions are identical
+            existing = self._atomTypes[name]
+            if (
+                existing.atomClass != parameters['class']
+            ) or (
+                existing.mass != float(parameters['mass'])
+            ) or (
+                existing.element.symbol != parameters['element']
+            ):
+                raise ValueError('Found multiple definitions for atom type: '+name)
         atomClass = parameters['class']
         mass = _convertParameterToNumber(parameters['mass'])
         element = None


### PR DESCRIPTION
This implements a suggestion that `openmforcefields` appears to need for current versions of GAFF and/or `prmchk2`: https://github.com/openmm/openmmforcefields/issues/281#issuecomment-1599598920

I have no idea how to test this here and I haven't thought of unintended consequences. It certainly seems like the short of change that could have side effects.