### PR TITLE
Fix import of netcdf_file for compatibility with scipy 1.14

### DIFF
--- a/wrappers/python/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/openmm/app/internal/amber_file_parser.py
@@ -1442,8 +1442,7 @@ class AmberNetcdfRestart(object):
         try:
             from scipy.io import netcdf_file
         except ImportError:
-            raise ImportError('scipy is necessary to parse NetCDF '
-                                'restarts')
+            raise ImportError('scipy is necessary to parse NetCDF restarts')
 
         self.filename = filename
         self.velocities = self.boxVectors = self.time = None

--- a/wrappers/python/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/openmm/app/internal/amber_file_parser.py
@@ -1440,14 +1440,10 @@ class AmberNetcdfRestart(object):
     """
     def __init__(self, filename, asNumpy=False):
         try:
-            from scipy.io import NetCDFFile
+            from scipy.io import netcdf_file
         except ImportError:
-            # scipy < 1.8.0
-            try:
-                from scipy.io.netcdf import NetCDFFile
-            except ImportError:
-                raise ImportError('scipy is necessary to parse NetCDF '
-                                  'restarts')
+            raise ImportError('scipy is necessary to parse NetCDF '
+                                'restarts')
 
         self.filename = filename
         self.velocities = self.boxVectors = self.time = None
@@ -1457,10 +1453,10 @@ class AmberNetcdfRestart(object):
         # to valid memory while the file handle is open. Since the context
         # manager GCs the ncfile handle, the memory for the original variables
         # is no longer valid. So copy those arrays while the handle is still
-        # open. This is unnecessary in scipy v.0.12 and lower because NetCDFFile
+        # open. This is unnecessary in scipy v.0.12 and lower because netcdf_file
         # accidentally leaks the file handle, but that was 'fixed' in 0.13. This
         # fix taken from MDTraj
-        ncfile = NetCDFFile(filename, 'r')
+        ncfile = netcdf_file(filename, 'r')
         try:
             self.natom = ncfile.dimensions['atom']
             self.coordinates = np.array(ncfile.variables['coordinates'][:])

--- a/wrappers/python/tests/TestAmberInpcrdFile.py
+++ b/wrappers/python/tests/TestAmberInpcrdFile.py
@@ -5,15 +5,10 @@ from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
 try:
-    from scipy.io import NetCDFFile
+    from scipy.io import netcdf_file
     SCIPY_IMPORT_FAILED = False
 except ImportError:
-    try:
-        # scipy < 1.8.0
-        from scipy.io import netcdf
-        SCIPY_IMPORT_FAILED = False
-    except:
-        SCIPY_IMPORT_FAILED = True
+    SCIPY_IMPORT_FAILED = True
 
 def compareByElement(array1, array2, cmp):
     for x, y in zip(array1, array2):


### PR DESCRIPTION
In scipy=1.14 the `NetCDFFile` alias is no longer exported. Instead, use `from scipy.io import netcdf_file` which looks to be compatible [as far back as scipy=0.6](https://github.com/scipy/scipy/blob/maintenance/0.6.x/scipy/io/__init__.py#L13). (I tested as far back as scipy=1.0 which is the earliest I could install with conda).

Fixes https://github.com/openmm/openmm/issues/4601