### PR TITLE
Don't require importlib_metadata

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -58,10 +58,13 @@ def _getDataDirectories():
         _dataDirectories = [os.path.join(os.path.dirname(__file__), 'data')]
         try:
             from importlib_metadata import entry_points
-            for entry in entry_points().select(group='openmm.forcefielddir'):
-                _dataDirectories.append(entry.load()())
         except:
-            pass # importlib_metadata is not installed
+            try:
+                from importlib.metadata import entry_points
+            except:
+                return _dataDirectories
+        for entry in entry_points().select(group='openmm.forcefielddir'):
+            _dataDirectories.append(entry.load()())
     return _dataDirectories
 
 def _convertParameterToNumber(param):

--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -62,9 +62,12 @@ def _getDataDirectories():
             try:
                 from importlib.metadata import entry_points
             except:
-                return _dataDirectories
-        for entry in entry_points().select(group='openmm.forcefielddir'):
-            _dataDirectories.append(entry.load()())
+                pass
+        try:
+            for entry in entry_points().select(group='openmm.forcefielddir'):
+                _dataDirectories.append(entry.load()())
+        except:
+            pass # importlib_metadata is not installed
     return _dataDirectories
 
 def _convertParameterToNumber(param):


### PR DESCRIPTION
`importlib_metadata` was created to backport `importlib.metadata` to older versions of Python.  If you're using a recent Python version that does have it (which includes all versions we support), this allows the entry points to be loaded even if `importlib_metadata` isn't installed.