### PR TITLE
Optimize bonded forces by reducing intra-warp atomic conflicts

### DIFF
--- a/platforms/common/src/kernels/bonded.cc
+++ b/platforms/common/src/kernels/bonded.cc
@@ -1,0 +1,103 @@
+inline DEVICE void saveBondedForce(GLOBAL mm_ulong* RESTRICT forceBuffer, unsigned int atom, real3 force) {
+    ATOMIC_ADD(&forceBuffer[atom], (mm_ulong) realToFixedPoint(force.x));
+    ATOMIC_ADD(&forceBuffer[atom+PADDED_NUM_ATOMS], (mm_ulong) realToFixedPoint(force.y));
+    ATOMIC_ADD(&forceBuffer[atom+PADDED_NUM_ATOMS*2], (mm_ulong) realToFixedPoint(force.z));
+}
+
+// Several threads of one warp write forces of the same atom quite often.
+// Head segmented reduction decreases the number of such intra-warp atomic conflicts and the
+// total number of atomic adds.
+
+#if defined(USE_HIP) && !defined(USE_DOUBLE_PRECISION)
+
+inline DEVICE inline real3 headSegmentedSum(real3 input, unsigned int key, bool* isLeader) {
+    const unsigned int laneId = (threadIdx.x & (warpSize - 1));
+    const unsigned int prevLaneKey = __shfl(key, laneId - 1);
+    const bool head = laneId == 0 || key != prevLaneKey;
+
+#if defined(AMD_RDNA)
+    const unsigned int n = __popc(__ballot(1));
+    unsigned int flags = __ballot(head);
+    flags >>= 1;
+    flags &= ~((static_cast<unsigned int>(1) << laneId) - 1);
+    flags |= static_cast<unsigned int>(1) << (n - 1);
+    const unsigned int nextSegmentStart = __ffs(flags);
+#else
+    const unsigned int n = __popcll(__ballot(1));
+    unsigned long long flags = __ballot(head);
+    flags >>= 1;
+    flags &= ~((static_cast<unsigned long long>(1) << laneId) - 1);
+    flags |= static_cast<unsigned long long>(1) << (n - 1);
+    const unsigned int nextSegmentStart = __ffsll(flags);
+#endif
+
+    real3 output = input;
+    *isLeader = head;
+
+    unsigned int offset = 1;
+    while (__ballot(laneId + offset < nextSegmentStart)) {
+        const real3 other = warpShuffle(output, laneId + offset);
+        const real k = real(laneId + offset < nextSegmentStart);
+        output += k * other;
+        offset *= 2;
+    }
+    return output;
+}
+
+inline DEVICE void saveBondedForceWithConflicts(unsigned int bond, unsigned int numBonds, GLOBAL mm_ulong* RESTRICT forceBuffer, unsigned int atom, real3 force) {
+    (void)bond;
+    (void)numBonds;
+    bool isLeader;
+    force = headSegmentedSum(force, atom, &isLeader);
+    if (isLeader) {
+        saveBondedForce(forceBuffer, atom, force);
+    }
+}
+
+#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700 && !defined(USE_DOUBLE_PRECISION)
+
+inline DEVICE real3 headSegmentedSum(unsigned int mask, real3 input, unsigned int key, bool* outHead) {
+    const unsigned int laneId = (threadIdx.x & (warpSize - 1));
+    const unsigned int prevLaneKey = __shfl_up_sync(mask, key, 1);
+    const bool head = laneId == 0 || key != prevLaneKey;
+
+    const unsigned int n = __popc(mask);
+    unsigned int flags = __ballot_sync(mask, head);
+    flags >>= 1;
+    flags &= ~((static_cast<unsigned int>(1) << laneId) - 1);
+    flags |= static_cast<unsigned int>(1) << (n - 1);
+    const unsigned int nextSegmentStart = __ffs(flags);
+
+    real3 output = input;
+    *outHead = head;
+
+    unsigned int offset = 1;
+    while (__any_sync(mask, laneId + offset < nextSegmentStart)) {
+        const real k = real(laneId + offset < nextSegmentStart);
+        output.x += k * __shfl_down_sync(mask, output.x, offset),
+        output.y += k * __shfl_down_sync(mask, output.y, offset),
+        output.z += k * __shfl_down_sync(mask, output.z, offset);
+        offset *= 2;
+    }
+    return output;
+}
+
+inline DEVICE void saveBondedForceWithConflicts(unsigned int bond, unsigned int numBonds, GLOBAL mm_ulong* RESTRICT forceBuffer, unsigned int atom, real3 force) {
+    const unsigned int activeLanes = numBonds - bond / warpSize * warpSize;
+    const unsigned int activeMask = activeLanes >= warpSize ? 0xffffffff : ((1u << activeLanes) - 1);
+    bool isLeader;
+    force = headSegmentedSum(activeMask, force, atom, &isLeader);
+    if (isLeader) {
+        saveBondedForce(forceBuffer, atom, force);
+    }
+}
+
+#else
+
+inline DEVICE void saveBondedForceWithConflicts(unsigned int bond, unsigned int numBonds, GLOBAL mm_ulong* RESTRICT forceBuffer, unsigned int atom, real3 force) {
+    (void)bond;
+    (void)numBonds;
+    saveBondedForce(forceBuffer, atom, force);
+}
+
+#endif


### PR DESCRIPTION
A follow-up of #4632

It can be tested on the HIP (though it needs commits from #4632 ) or CUDA platforms.

An optimization of bonded forces: atom indices for many forces are usually grouped so threads of one warp can write forces to the same index, so there are atomic conflicts within the warp. 
My idea is to do a reduction of consecutive segments of forces for the same atom index (using head segmented reduction). See [conflicts-with-atoms.txt](https://github.com/user-attachments/files/16785576/conflicts-with-atoms.txt), there are atom indices of 128 bonds for each force and some statistics: avgConflicts is the number of such conflicts that can be eliminated with head segmented sum.
This optimization is implemented for HIP and then ported to CUDA. On AMD GPUs it improves overall performance by 2-5% (except for gbsa and rf with small drop of ~0-1%).
For CUDA I've tested on Titan V, 3090, 4070 Ti Super: 3090 has +1-2% but -2% for gbsa, Titan V  has +2-3% but also -2% for gbsa, 4070 Ti Super has the biggest change +2-6% (6% for apoa1). I don't have access to older architectures or more low-end GPUs (2060 on my desktop show +-3% random performance fluctuations so it's impossible to benchmark on it reproducibly).
I don't know if it's worth having this optimization for CUDA (the `#elif defined(__CUDA_ARCH__) ...` part can be easily removed/commented), on AMD it seems to provide a bit more consistent improvement, it would be great to keep it. Also I'm not sure if you are ok with having a platform specific kernel code in the Common platform. I look forward to your decision.