### PR TITLE
Prevent deadlock using CustomCPPForceImpl with multiple GPUs

### DIFF
--- a/platforms/cuda/tests/TestCudaCustomCPPForce.cpp
+++ b/platforms/cuda/tests/TestCudaCustomCPPForce.cpp
@@ -33,5 +33,7 @@
 #include "TestCustomCPPForce.h"
 
 void runPlatformTests() {
+    platform.setPropertyDefaultValue("DeviceIndex", "0,0");
+    testForce();
 }
 

--- a/platforms/hip/tests/TestHipCustomCPPForce.cpp
+++ b/platforms/hip/tests/TestHipCustomCPPForce.cpp
@@ -33,4 +33,6 @@
 #include "TestCustomCPPForce.h"
 
 void runPlatformTests() {
+    platform.setPropertyDefaultValue("DeviceIndex", "0,0");
+    testForce();
 }

--- a/platforms/opencl/tests/TestOpenCLCustomCPPForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLCustomCPPForce.cpp
@@ -33,5 +33,7 @@
 #include "TestCustomCPPForce.h"
 
 void runPlatformTests() {
+    platform.setPropertyDefaultValue("DeviceIndex", "0,0");
+    testForce();
 }
 


### PR DESCRIPTION
Fixes https://github.com/openmm/openmm-plumed/issues/88.

Multi-GPU parallelization and CustomCPPForceImpl both use the same worker threads, but for different purposes.  Multi-GPU uses them to let the GPUs do work in parallel.  CustomCPPForceImpl uses them to let the C++ code run in parallel with other work on the GPU.  Trying to do both at once leads to a deadlock.  To fix the problem, I made CustomCPPForceImpl check whether you are using multiple GPUs, and not try to do any further parallelization if it is already running on a worker thread.