### PR TITLE
Fixed numeric overflow

### DIFF
--- a/platforms/cpu/src/CpuSETTLE.cpp
+++ b/platforms/cpu/src/CpuSETTLE.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2018 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2024 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -37,13 +37,13 @@ using namespace std;
 
 CpuSETTLE::CpuSETTLE(const System& system, const ReferenceSETTLEAlgorithm& settle, ThreadPool& threads) : threads(threads) {
     int numBlocks = 10*threads.getNumThreads();
-    int numClusters = settle.getNumClusters();
+    long long numClusters = settle.getNumClusters();
     vector<double> mass(system.getNumParticles());
     for (int i = 0; i < system.getNumParticles(); i++)
         mass[i] = system.getParticleMass(i);
     for (int i = 0; i < numBlocks; i++) {
-        int start = i*numClusters/numBlocks;
-        int end = (i+1)*numClusters/numBlocks;
+        int start = (int) (i*numClusters/numBlocks);
+        int end = (int) ((i+1)*numClusters/numBlocks);
         if (start != end) {
             int numThreadClusters = end-start;
             vector<int> atom1(numThreadClusters), atom2(numThreadClusters), atom3(numThreadClusters);


### PR DESCRIPTION
Fixes #4644.

This error happened when simulating a very large system on a computer with a very large number of cores.  Specifically if the product of the number of water molecules times the number of cores was greater than about 200 million, it would overflow the range of a 32 bit int, leading to an exception.