### PR TITLE
XTCReporter overwrites existing xtc file

### DIFF
--- a/wrappers/python/openmm/app/xtcfile.py
+++ b/wrappers/python/openmm/app/xtcfile.py
@@ -99,6 +99,8 @@ class XTCFile(object):
             raise ValueError(
                 "Particle position is infinite.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan"
             )
+        if (np.abs(positions * 1000) > (2 ** 31 - 1)).any():
+            raise ValueError("Particle position is too large for XTC format")
 
         self._modelCount += 1
         if (

--- a/wrappers/python/openmm/app/xtcreporter.py
+++ b/wrappers/python/openmm/app/xtcreporter.py
@@ -29,6 +29,8 @@ class XTCReporter(object):
         self._enforcePeriodicBox = enforcePeriodicBox
         self._fileName = file
         self._xtc = None
+        if not append:
+            open(file, 'wb').close()
 
     def describeNextReport(self, simulation):
         """Get information about the next report this object will generate.


### PR DESCRIPTION
This pull request addresses issue #4651.

Currently, if an XTC file already exists, the XTCReporter raises an exception the first time it tries to write a frame. With this pull request, it will instead overwrite the existing file, consistent with the behavior of the PDB and DCD reporters.

Additionally, a check on the positions has been added. The XTCFile scales up positions by 1000 and store them as integers. If a position value exceeds 2E6, the xtc file becomes corrupted and unreadable by an xtc parser. This fix introduces a validation step that raises an exception if the positions exceed the limit that xtc format can handle.