### PR TITLE
Improved performance of writeModel()

### DIFF
--- a/wrappers/python/openmm/app/dcdfile.py
+++ b/wrappers/python/openmm/app/dcdfile.py
@@ -122,6 +122,7 @@ class DCDFile(object):
         if is_quantity(positions):
             positions = positions.value_in_unit(nanometers)
         import numpy as np
+        positions = np.asarray(positions)
         if np.isnan(positions).any():
             raise ValueError('Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
         if np.isinf(positions).any():

--- a/wrappers/python/openmm/app/pdbfile.py
+++ b/wrappers/python/openmm/app/pdbfile.py
@@ -344,6 +344,7 @@ class PDBFile(object):
         if is_quantity(positions):
             positions = positions.value_in_unit(angstroms)
         import numpy as np
+        positions = np.asarray(positions)
         if np.isnan(positions).any():
             raise ValueError('Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
         if np.isinf(positions).any():

--- a/wrappers/python/openmm/app/pdbxfile.py
+++ b/wrappers/python/openmm/app/pdbxfile.py
@@ -419,6 +419,7 @@ class PDBxFile(object):
         if is_quantity(positions):
             positions = positions.value_in_unit(angstroms)
         import numpy as np
+        positions = np.asarray(positions)
         if np.isnan(positions).any():
             raise ValueError('Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan')
         if np.isinf(positions).any():

--- a/wrappers/python/openmm/app/xtcfile.py
+++ b/wrappers/python/openmm/app/xtcfile.py
@@ -91,6 +91,7 @@ class XTCFile(object):
         if is_quantity(positions):
             positions = positions.value_in_unit(nanometers)
         import numpy as np
+        positions = np.asarray(positions)
         if np.isnan(positions).any():
             raise ValueError(
                 "Particle position is NaN.  For more information, see https://github.com/openmm/openmm/wiki/Frequently-Asked-Questions#nan"


### PR DESCRIPTION
Fixes #4676.  The problem was introduced in #4330.  It made writing faster if you passed the positions as a numpy array, but much slower if you passed them as a list.