### PR TITLE
Remove doxygen pin

### DIFF
--- a/devtools/ci/gh-actions/conda-envs/build-macos.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-macos.yml
@@ -11,7 +11,7 @@ dependencies:
 - cython
 - swig
 - numpy
-- doxygen 1.8.14
+- doxygen
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest-hip.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest-hip.yml
@@ -9,7 +9,7 @@ dependencies:
 - sysroot_linux-64 2.17
 # host
 - python
-- doxygen 1.8.14
+- doxygen
 - hip-devel
 - hipcc
 - rocm-cmake

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
@@ -14,7 +14,7 @@ dependencies:
 - swig
 - numpy
 - ocl-icd-system
-- doxygen 1.8.14
+- doxygen
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
@@ -14,7 +14,7 @@ dependencies:
 - swig
 - numpy
 - ocl-icd-system
-- doxygen 1.8.14
+- doxygen
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
@@ -13,7 +13,7 @@ dependencies:
 - cython
 - swig
 - numpy
-- doxygen 1.8.14
+- doxygen
 - khronos-opencl-icd-loader
 # test
 - pytest

--- a/devtools/ci/gh-actions/conda-envs/docs.yml
+++ b/devtools/ci/gh-actions/conda-envs/docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy
 - cython
 - swig
-- doxygen 1.8.14
+- doxygen
 - sphinx==4.0.2
 - sphinxcontrib-bibtex
 - breathe>=4.30,<5.0


### PR DESCRIPTION
In CI we've been pinning doxygen to an old version.  I don't know if there's actually a good reason for it, and it has started causing one of the builds to fail since the version isn't available.  I'm trying removing it.