### PR TITLE
Updated Python versions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
           - name: Linux CUDA 12.4
             os: ubuntu-latest
             env: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.13"
             cuda-version: "12.4"
             OPENCL: false
             CMAKE_FLAGS: |
@@ -52,7 +52,7 @@ jobs:
           - name: Linux CUDA 11.8
             os: ubuntu-latest
             env: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.13"
             OPENCL: false
             cuda-version: "11.8"
             CMAKE_FLAGS: |
@@ -73,7 +73,7 @@ jobs:
           - name: Linux AMD OpenCL
             os: ubuntu-latest
             env: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.13"
             OPENCL: true
             cuda-version: ""
             CMAKE_FLAGS: |
@@ -94,7 +94,7 @@ jobs:
           - name: Linux HIP
             os: ubuntu-latest
             env: ubuntu-latest-hip
-            python-version: "3.11"
+            python-version: "3.13"
             OPENCL: false
             CMAKE_FLAGS: |
               -DOPENMM_BUILD_HIP_LIB=ON \
@@ -106,10 +106,10 @@ jobs:
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
               -DOPENMM_BUILD_EXAMPLES=OFF
 
-          - name: Linux CPU Python 3.11 with static lib
+          - name: Linux CPU Python 3.13 with static lib
             os: ubuntu-latest
             env: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.13"
             OPENCL: false
             cuda-version: ""
             CC: $CCACHE/clang
@@ -119,8 +119,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.11 with condaforge compilers
-            python-version: "3.11"
+          - name: Linux CPU Python 3.13 with condaforge compilers
+            python-version: "3.13"
             os: ubuntu-latest
             env: ubuntu-latest
             OPENCL: false
@@ -130,8 +130,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.9
-            python-version: "3.9"
+          - name: Linux CPU Python 3.10
+            python-version: "3.10"
             os: ubuntu-latest
             env: ubuntu-latest
             OPENCL: false
@@ -140,8 +140,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: Linux CPU Python 3.11
-            python-version: "3.11"
+          - name: Linux CPU Python 3.13
+            python-version: "3.13"
             os: ubuntu-latest
             env: ubuntu-latest
             OPENCL: false
@@ -160,8 +160,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=OFF \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: MacOS Intel Python 3.11
-            python-version: "3.11"
+          - name: MacOS Intel Python 3.13
+            python-version: "3.13"
             os: macos-13
             env: macos
             OPENCL: false
@@ -170,8 +170,8 @@ jobs:
               -DOPENMM_BUILD_OPENCL_LIB=ON \
               -DOPENMM_BUILD_OPENCL_TESTS=OFF \
 
-          - name: MacOS ARM Python 3.11
-            python-version: "3.11"
+          - name: MacOS ARM Python 3.13
+            python-version: "3.13"
             os: macos-latest
             env: macos
             OPENCL: false
@@ -326,8 +326,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Windows CUDA 11.2 Python 3.11
-            python-version: "3.11"
+          - name: Windows CUDA 11.2 Python 3.13
+            python-version: "3.13"
             cuda-version: "11.2"
             CMAKE_FLAGS: |
               -DCUDA_TOOLKIT_ROOT_DIR="%CUDA_TOOLKIT_ROOT_DIR%" ^
@@ -461,19 +461,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: PowerPC CPU/CUDA 10.2 Python 3.11 with condaforge compilers
+          - name: PowerPC CPU/CUDA 10.2 Python 3.13 with condaforge compilers
             docker-image: quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
-            python-version: "3.11"
+            python-version: "3.13"
             compilers: compilers
 
-          #- name: PowerPC CPU Python 3.11 devtoolset-7 compilers
+          #- name: PowerPC CPU Python 3.13 devtoolset-7 compilers
           #  docker-image: quay.io/condaforge/linux-anvil-ppc64le
-          #  python-version: "3.11"
+          #  python-version: "3.13"
           #  compilers: devtoolset-7
 
-          - name: ARM CPU Python 3.11 with condaforge compilers
+          - name: ARM CPU Python 3.13 with condaforge compilers
             docker-image: quay.io/condaforge/linux-anvil-aarch64
-            python-version: "3.11"
+            python-version: "3.13"
             compilers: compilers
 
 

--- a/devtools/ci/gh-actions/conda-envs/build-macos.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-macos.yml
@@ -12,6 +12,7 @@ dependencies:
 - swig
 - numpy
 - doxygen
+- setuptools
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest-hip.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest-hip.yml
@@ -10,6 +10,7 @@ dependencies:
 # host
 - python
 - doxygen
+- setuptools
 - hip-devel
 - hipcc
 - rocm-cmake

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-latest.yml
@@ -15,6 +15,7 @@ dependencies:
 - numpy
 - ocl-icd-system
 - doxygen
+- setuptools
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-ubuntu-pypy.yml
@@ -15,6 +15,7 @@ dependencies:
 - numpy
 - ocl-icd-system
 - doxygen
+- setuptools
 # test
 - pytest
 - pytest-xdist

--- a/devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
+++ b/devtools/ci/gh-actions/conda-envs/build-windows-latest.yml
@@ -14,6 +14,7 @@ dependencies:
 - swig
 - numpy
 - doxygen
+- setuptools
 - khronos-opencl-icd-loader
 # test
 - pytest

--- a/devtools/ci/gh-actions/conda-envs/docs.yml
+++ b/devtools/ci/gh-actions/conda-envs/docs.yml
@@ -12,6 +12,7 @@ dependencies:
 - cython
 - swig
 - doxygen
+- setuptools
 - sphinx==4.0.2
 - sphinxcontrib-bibtex
 - breathe>=4.30,<5.0


### PR DESCRIPTION
We're currently running tests on Python 3.9 and 3.11.  This updates it to 3.10 and 3.13.