### PR TITLE
Reduced memory use while identifying molecule groups

### DIFF
--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -35,6 +35,7 @@
 #include <cmath>
 #include <set>
 #include <sstream>
+#include <unordered_set>
 #include <utility>
 
 using namespace OpenMM;
@@ -201,24 +202,27 @@ void ComputeContext::findMoleculeGroups() {
 
         // First make a list of every other atom to which each atom is connect by a constraint or force group.
 
-        vector<vector<int> > atomBonds(system.getNumParticles());
+        vector<unordered_set<int> > atomBondSets(system.getNumParticles());
         for (int i = 0; i < system.getNumConstraints(); i++) {
             int particle1, particle2;
             double distance;
             system.getConstraintParameters(i, particle1, particle2, distance);
-            atomBonds[particle1].push_back(particle2);
-            atomBonds[particle2].push_back(particle1);
+            atomBondSets[particle1].insert(particle2);
+            atomBondSets[particle2].insert(particle1);
         }
         for (auto force : forces) {
             vector<int> particles;
             for (int j = 0; j < force->getNumParticleGroups(); j++) {
                 force->getParticlesInGroup(j, particles);
                 for (int k = 1; k < (int) particles.size(); k++) {
-                    atomBonds[particles[k]].push_back(particles[k-1]);
-                    atomBonds[particles[k-1]].push_back(particles[k]);
+                    atomBondSets[particles[k]].insert(particles[k-1]);
+                    atomBondSets[particles[k-1]].insert(particles[k]);
                 }
             }
         }
+        vector<vector<int> > atomBonds(system.getNumParticles());
+        for (int i = 0; i < system.getNumParticles(); i++)
+            atomBonds[i].insert(atomBonds[i].begin(), atomBondSets[i].begin(),atomBondSets[i].end());
 
         // Now identify atoms by which molecule they belong to.
 

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -213,11 +213,10 @@ void ComputeContext::findMoleculeGroups() {
             vector<int> particles;
             for (int j = 0; j < force->getNumParticleGroups(); j++) {
                 force->getParticlesInGroup(j, particles);
-                for (int k = 1; k < (int) particles.size(); k++)
-                    for (int m = 0; m < k; m++) {
-                        atomBonds[particles[k]].push_back(particles[m]);
-                        atomBonds[particles[m]].push_back(particles[k]);
-                    }
+                for (int k = 1; k < (int) particles.size(); k++) {
+                    atomBonds[particles[k]].push_back(particles[k-1]);
+                    atomBonds[particles[k-1]].push_back(particles[k]);
+                }
             }
         }
 


### PR DESCRIPTION
This should fix the problems reported in #4707.  Instead of considering every particle in a group to be directly bonded to every other, it treats them as bonded in a linear chain.  When a group contains a very large number of particles, this uses much less memory.