### PR TITLE
Prevent HipContext.h from including vkFFT.h

### DIFF
--- a/platforms/hip/include/HipContext.h
+++ b/platforms/hip/include/HipContext.h
@@ -55,7 +55,6 @@
 #include "HipIntegrationUtilities.h"
 #include "HipNonbondedUtilities.h"
 #include "HipPlatform.h"
-#include "HipFFT3D.h"
 #include "openmm/OpenMMException.h"
 #include "openmm/common/ComputeContext.h"
 #include "openmm/Kernel.h"
@@ -183,18 +182,6 @@ public:
      * Construct a ComputeEvent object of the appropriate class for this platform.
      */
     ComputeEvent createEvent();
-    /**
-     * Create a new HipFFT3D.
-     *
-     * @param xsize   the first dimension of the data sets on which FFTs will be performed
-     * @param ysize   the second dimension of the data sets on which FFTs will be performed
-     * @param zsize   the third dimension of the data sets on which FFTs will be performed
-     * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
-     * @param stream  HIP stream
-     * @param in      the data to transform, ordered such that in[x*ysize*zsize + y*zsize + z] contains element (x, y, z)
-     * @param out     on exit, this contains the transformed data
-     */
-    HipFFT3D* createFFT(int xsize, int ysize, int zsize, bool realToComplex, hipStream_t stream, HipArray& in, HipArray& out);
     /**
      * Get the smallest legal size for a dimension of the grid supported by the FFT.
      */

--- a/platforms/hip/src/HipContext.cpp
+++ b/platforms/hip/src/HipContext.cpp
@@ -696,10 +696,6 @@ ComputeEvent HipContext::createEvent() {
     return shared_ptr<ComputeEventImpl>(new HipEvent(*this));
 }
 
-HipFFT3D* HipContext::createFFT(int xsize, int ysize, int zsize, bool realToComplex, hipStream_t stream, HipArray& in, HipArray& out) {
-    return new HipFFT3D(*this, xsize, ysize, zsize, realToComplex, stream, in, out);
-}
-
 int HipContext::findLegalFFTDimension(int minimum) {
     return HipFFT3D::findLegalDimension(minimum);
 }

--- a/platforms/hip/src/HipKernels.cpp
+++ b/platforms/hip/src/HipKernels.cpp
@@ -34,6 +34,7 @@
 #include "CommonKernelSources.h"
 #include "HipBondedUtilities.h"
 #include "HipExpressionUtilities.h"
+#include "HipFFT3D.h"
 #include "HipIntegrationUtilities.h"
 #include "HipNonbondedUtilities.h"
 #include "HipKernelSources.h"
@@ -508,9 +509,9 @@ void HipCalcNonbondedForceKernel::initialize(const System& system, const Nonbond
                 }
 
                 hipStream_t fftStream = usePmeStream ? pmeStream : cu.getCurrentStream();
-                fft = cu.createFFT(gridSizeX, gridSizeY, gridSizeZ, true, fftStream, pmeGrid1, pmeGrid2);
+                fft = new HipFFT3D(cu, gridSizeX, gridSizeY, gridSizeZ, true, fftStream, pmeGrid1, pmeGrid2);
                 if (doLJPME)
-                    dispersionFft = cu.createFFT(dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true, fftStream, pmeGrid1, pmeGrid2);
+                    dispersionFft = new HipFFT3D(cu, dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true, fftStream, pmeGrid1, pmeGrid2);
                 hasInitializedFFT = true;
 
                 // Initialize the b-spline moduli.

--- a/plugins/amoeba/platforms/hip/src/AmoebaHipKernels.cpp
+++ b/plugins/amoeba/platforms/hip/src/AmoebaHipKernels.cpp
@@ -38,6 +38,7 @@
 #include "openmm/internal/AmoebaVdwForceImpl.h"
 #include "openmm/internal/NonbondedForceImpl.h"
 #include "HipBondedUtilities.h"
+#include "HipFFT3D.h"
 #include "HipForceInfo.h"
 #include "HipKernelSources.h"
 #include "SimTKOpenMMRealType.h"
@@ -68,7 +69,7 @@ void HipCalcAmoebaMultipoleForceKernel::initialize(const System& system, const A
         ContextSelector selector(cc);
         HipArray& grid1 = cu.unwrap(pmeGrid1);
         HipArray& grid2 = cu.unwrap(pmeGrid2);
-        fft = cu.createFFT(gridSizeX, gridSizeY, gridSizeZ, false, cu.getCurrentStream(), grid1, grid2);
+        fft = new HipFFT3D(cu, gridSizeX, gridSizeY, gridSizeZ, false, cu.getCurrentStream(), grid1, grid2);
     }
 }
 
@@ -97,8 +98,8 @@ void HipCalcHippoNonbondedForceKernel::initialize(const System& system, const Hi
         sort = new HipSort(cu, new SortTrait(), cc.getNumAtoms());
         HipArray& grid1 = cu.unwrap(pmeGrid1);
         HipArray& grid2 = cu.unwrap(pmeGrid2);
-        fft = cu.createFFT(gridSizeX, gridSizeY, gridSizeZ, true, cu.getCurrentStream(), grid1, grid2);
-        dfft = cu.createFFT(dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true, cu.getCurrentStream(), grid1, grid2);
+        fft = new HipFFT3D(cu, gridSizeX, gridSizeY, gridSizeZ, true, cu.getCurrentStream(), grid1, grid2);
+        dfft = new HipFFT3D(cu, dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true, cu.getCurrentStream(), grid1, grid2);
     }
 }
 


### PR DESCRIPTION
This made it impossible for any external package to provide a HIP implementation of a feature.  `#include "HipContext.h"` would lead to a compilation error, because vkFFT.h couldn't be found.