### PR TITLE
Update offset parameters with `updateParametersinContext`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build?
 
 # macOS
 .DS_Store
+settings.json

--- a/olla/include/openmm/kernels.h
+++ b/olla/include/openmm/kernels.h
@@ -629,8 +629,11 @@ public:
      * @param lastParticle   the index of the last particle whose parameters might have changed
      * @param firstException the index of the first exception whose parameters might have changed
      * @param lastException  the index of the last exception whose parameters might have changed
+     * @param firstOffset    the index of the first offset whose parameters might have changed
+     * @param lastOffset     the index of the last offset whose parameters might have changed
+     * 
      */
-    virtual void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException) = 0;
+    virtual void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset) = 0;
     /**
      * Get the parameters being used for PME.
      *

--- a/openmmapi/include/openmm/NonbondedForce.h
+++ b/openmmapi/include/openmm/NonbondedForce.h
@@ -637,7 +637,7 @@ private:
     std::vector<ParticleOffsetInfo> particleOffsets;
     std::vector<ExceptionOffsetInfo> exceptionOffsets;
     std::map<std::pair<int, int>, int> exceptionMap;
-    mutable int numContexts, firstChangedParticle, lastChangedParticle, firstChangedException, lastChangedException;
+    mutable int numContexts, firstChangedParticle, lastChangedParticle, firstChangedException, lastChangedException, firstChangedOffset, lastChangedOffset;
 };
 
 /**

--- a/openmmapi/include/openmm/internal/NonbondedForceImpl.h
+++ b/openmmapi/include/openmm/internal/NonbondedForceImpl.h
@@ -61,7 +61,7 @@ public:
     double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups);
     std::map<std::string, double> getDefaultParameters();
     std::vector<std::string> getKernelNames();
-    void updateParametersInContext(ContextImpl& context, int firstParticle, int lastParticle, int firstException, int lastException);
+    void updateParametersInContext(ContextImpl& context, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset);
     void getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
     void getLJPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
     /**

--- a/openmmapi/src/NonbondedForceImpl.cpp
+++ b/openmmapi/src/NonbondedForceImpl.cpp
@@ -345,8 +345,8 @@ double NonbondedForceImpl::calcDispersionCorrection(const System& system, const 
     return 8*numParticles*numParticles*M_PI*(sum1/(9*pow(cutoff, 9))-sum2/(3*pow(cutoff, 3))+sum3);
 }
 
-void NonbondedForceImpl::updateParametersInContext(ContextImpl& context, int firstParticle, int lastParticle, int firstException, int lastException) {
-    kernel.getAs<CalcNonbondedForceKernel>().copyParametersToContext(context, owner, firstParticle, lastParticle, firstException, lastException);
+void NonbondedForceImpl::updateParametersInContext(ContextImpl& context, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset) {
+    kernel.getAs<CalcNonbondedForceKernel>().copyParametersToContext(context, owner, firstParticle, lastParticle, firstException, lastException, firstOffset, lastOffset);
     context.systemChanged();
 }
 

--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -251,8 +251,10 @@ public:
      * @param lastParticle   the index of the last particle whose parameters might have changed
      * @param firstException the index of the first exception whose parameters might have changed
      * @param lastException  the index of the last exception whose parameters might have changed
+     * @param firstOffset    the index of the first offset whose parameters might have changed
+     * @param lastOffset     the index of the last offset whose parameters might have changed
      */
-    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException);
+    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset);
     /**
      * Get the parameters being used for PME.
      *

--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -277,7 +277,7 @@ private:
     class PmeIO;
     void computeParameters(ContextImpl& context, bool offsetsOnly);
     CpuPlatform::PlatformData& data;
-    int numParticles, num14, chargePosqIndex, ljPosqIndex;
+    int numParticles, num14, numOffsets, chargePosqIndex, ljPosqIndex;
     std::vector<std::vector<int> > bonded14IndexArray;
     std::vector<std::vector<double> > bonded14ParamArray;
     double nonbondedCutoff, switchingDistance, rfDielectric, ewaldAlpha, ewaldDispersionAlpha, ewaldSelfEnergy, dispersionCoefficient;

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -759,7 +759,15 @@ void CpuCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, 
         int particle;
         double charge, sigma, epsilon;
         force.getParticleParameterOffset(i, param, particle, charge, sigma, epsilon);
-        particleParamOffsets[make_pair(param, particle)] = {charge, sigma, epsilon};
+        auto paramPos = find(paramNames.begin(), paramNames.end(), param);
+        int paramIndex;
+        if (paramPos == paramNames.end()) {
+            paramIndex = paramNames.size();
+            paramNames.push_back(param);
+        }
+        else
+            paramIndex = paramPos-paramNames.begin();
+        particleParamOffsets[particle].push_back(make_tuple(charge, sigma, epsilon, paramIndex));
     }
 
     computeParameters(context, false);

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -718,7 +718,7 @@ double CpuCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeFo
     return energy;
 }
 
-void CpuCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException) {
+void CpuCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset) {
     if (force.getNumParticles() != numParticles)
         throw OpenMMException("updateParametersInContext: The number of particles has changed");
 
@@ -753,6 +753,15 @@ void CpuCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, 
         bonded14IndexArray[i][0] = particle1;
         bonded14IndexArray[i][1] = particle2;
     }
+    for (int i = firstOffset; i <= lastOffset; ++i) {
+        // Update particle parameter offsets
+        string param;
+        int particle;
+        double charge, sigma, epsilon;
+        force.getParticleParameterOffset(i, param, particle, charge, sigma, epsilon);
+        particleParamOffsets[make_pair(param, particle)] = {charge, sigma, epsilon};
+    }
+
     computeParameters(context, false);
     
     // Recompute the coefficient for the dispersion correction.

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -548,6 +548,7 @@ void CpuCalcNonbondedForceKernel::initialize(const System& system, const Nonbond
     hasExceptionOffsets = (force.getNumExceptionParameterOffsets() > 0);
     particleParamOffsets.resize(force.getNumParticles());
     exceptionParamOffsets.resize(force.getNumExceptions());
+    numOffsets = force.getNumParticleParameterOffsets();
     for (int i = 0; i < force.getNumParticleParameterOffsets(); i++) {
         string param;
         int particle;
@@ -753,6 +754,9 @@ void CpuCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, 
         bonded14IndexArray[i][0] = particle1;
         bonded14IndexArray[i][1] = particle2;
     }
+
+    if (force.getNumParticleParameterOffsets() != numOffsets)
+        throw OpenMMException("updateParametersInContext: The number of particles with Offsets has changed");
     for (int i = firstOffset; i <= lastOffset; ++i) {
         // Update particle parameter offsets
         string param;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -119,8 +119,10 @@ public:
      * @param lastParticle   the index of the last particle whose parameters might have changed
      * @param firstException the index of the first exception whose parameters might have changed
      * @param lastException  the index of the last exception whose parameters might have changed
+     * @param firstOffset    the index of the first offset whose parameters might have changed
+     * @param lastOffset     the index of the last offset whose parameters might have changed
      */
-    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException);
+    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset);
     /**
      * Get the parameters being used for PME.
      * 

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1126,6 +1126,24 @@ void CudaCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context,
         }
         baseExceptionParams.upload(baseExceptionParamsVec);
     }
+
+    if (firstOffset <= lastOffset) {
+        <vector<vector<float4> > particleOffsetVec(force.getNumParticles());
+
+        string param;
+        int particle;
+        double charge, sigma, epsilon;
+        force.getParticleParameterOffset(i, param, particle, charge, sigma, epsilon);
+        auto paramPos = find(paramNames.begin(), paramNames.end(), param);
+        int paramIndex;
+        if (paramPos == paramNames.end()) {
+            paramIndex = paramNames.size();
+            paramNames.push_back(param);
+        }
+        else
+            paramIndex = paramPos-paramNames.begin();
+        particleOffsetVec[particle].push_back(make_float4(charge, sigma, epsilon, paramIndex));
+    }
     
     // Compute other values.
     

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1048,7 +1048,7 @@ double CudaCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeF
     return energy;
 }
 
-void CudaCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException) {
+void CudaCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset) {
     // Make sure the new parameters are acceptable.
     
     ContextSelector selector(cu);

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -118,8 +118,9 @@ public:
      * @param lastParticle   the index of the last particle whose parameters might have changed
      * @param firstException the index of the first exception whose parameters might have changed
      * @param lastException  the index of the last exception whose parameters might have changed
-     */
-    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException);
+     * @param firstOffset    the index of the first offset whose parameters might have changed
+     * @param lastOffset     the index of the last offset whose parameters might have changed*/
+    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffet, int lastOffset);
     /**
      * Get the parameters being used for PME.
      *

--- a/platforms/opencl/include/OpenCLParallelKernels.h
+++ b/platforms/opencl/include/OpenCLParallelKernels.h
@@ -128,8 +128,10 @@ public:
      * @param lastParticle   the index of the last particle whose parameters might have changed
      * @param firstException the index of the first exception whose parameters might have changed
      * @param lastException  the index of the last exception whose parameters might have changed
+     * @param firstOffset    the index of the first offset whose parameters might have changed
+     * @param lastOffset     the index of the last offset whose parameters might have changed
      */
-    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException);
+    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset);
     /**
      * Get the parameters being used for PME.
      *

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -1149,7 +1149,6 @@ void OpenCLCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& contex
 
     if (firstOffset <= lastOffset) {
         vector<vector<mm_float4> > particleOffsetVec(force.getNumParticles());
-        vector<vector<mm_float4> > exceptionOffsetVec(numExceptions);
         for (int i = 0; i < force.getNumParticleParameterOffsets(); i++) {
             string param;
             int particle;
@@ -1177,7 +1176,7 @@ void OpenCLCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& contex
             particleOffsetIndicesVec.push_back(p.size());
         if (force.getNumParticleParameterOffsets() > 0) {
             particleParamOffsets.upload(p);
-            particleOffsetIndices.upload(particleOffsetIndicesVec);
+            particleOffsetIndices.uploadSubArray(&particleOffsetIndicesVec[firstOffset], firstOffset, lastOffset-firstOffset+1);
         }
     }
 

--- a/platforms/opencl/src/OpenCLParallelKernels.cpp
+++ b/platforms/opencl/src/OpenCLParallelKernels.cpp
@@ -226,9 +226,9 @@ double OpenCLParallelCalcNonbondedForceKernel::execute(ContextImpl& context, boo
     return 0.0;
 }
 
-void OpenCLParallelCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException) {
+void OpenCLParallelCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset) {
     for (int i = 0; i < (int) kernels.size(); i++)
-        getKernel(i).copyParametersToContext(context, force, firstParticle, lastParticle, firstException, lastException);
+        getKernel(i).copyParametersToContext(context, force, firstParticle, lastParticle, firstException, lastException, firstOffset, lastOffset);
 }
 
 void OpenCLParallelCalcNonbondedForceKernel::getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const {

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -659,7 +659,7 @@ public:
     void getLJPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
 private:
     void computeParameters(ContextImpl& context);
-    int numParticles, num14;
+    int numParticles, num14, numOffsets;
     std::vector<std::vector<int> >bonded14IndexArray;
     std::vector<std::vector<double> > particleParamArray, bonded14ParamArray;
     std::vector<std::array<double, 3> > baseParticleParams, baseExceptionParams;

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -635,8 +635,10 @@ public:
      * @param lastParticle   the index of the last particle whose parameters might have changed
      * @param firstException the index of the first exception whose parameters might have changed
      * @param lastException  the index of the last exception whose parameters might have changed
+     * @param firstOffset    the index of the first offset whose parameters might have changed
+     * @param lastOffset     the index of the last offset whose parameters might have changed
      */
-    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException);
+    void copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset);
     /**
      * Get the parameters being used for PME.
      * 

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -932,6 +932,7 @@ void ReferenceCalcNonbondedForceKernel::initialize(const System& system, const N
         bonded14IndexArray[i][0] = particle1;
         bonded14IndexArray[i][1] = particle2;
     }
+    numOffsets = force.getNumParticleParameterOffsets();
     for (int i = 0; i < force.getNumParticleParameterOffsets(); i++) {
         string param;
         int particle;
@@ -1070,6 +1071,9 @@ void ReferenceCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& con
         bonded14IndexArray[i][0] = particle1;
         bonded14IndexArray[i][1] = particle2;
     }
+    if (force.getNumParticleParameterOffsets() != numOffsets)
+        throw OpenMMException("updateParametersInContext: The number of particles with Offsets has changed");
+
     for (int i = firstOffset; i <= lastOffset; ++i) {
         // Update particle parameter offsets
         string param;

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -1035,7 +1035,7 @@ double ReferenceCalcNonbondedForceKernel::execute(ContextImpl& context, bool inc
     return energy;
 }
 
-void ReferenceCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException) {
+void ReferenceCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& context, const NonbondedForce& force, int firstParticle, int lastParticle, int firstException, int lastException, int firstOffset, int lastOffset) {
     if (force.getNumParticles() != numParticles)
         throw OpenMMException("updateParametersInContext: The number of particles has changed");
 
@@ -1069,6 +1069,14 @@ void ReferenceCalcNonbondedForceKernel::copyParametersToContext(ContextImpl& con
         force.getExceptionParameters(nb14s[i], particle1, particle2, baseExceptionParams[i][0], baseExceptionParams[i][1], baseExceptionParams[i][2]);
         bonded14IndexArray[i][0] = particle1;
         bonded14IndexArray[i][1] = particle2;
+    }
+    for (int i = firstOffset; i <= lastOffset; ++i) {
+        // Update particle parameter offsets
+        string param;
+        int particle;
+        double charge, sigma, epsilon;
+        force.getParticleParameterOffset(i, param, particle, charge, sigma, epsilon);
+        particleParamOffsets[make_pair(param, particle)] = {charge, sigma, epsilon};
     }
     
     // Recompute the coefficient for the dispersion correction.


### PR DESCRIPTION
I decided to have a go at implementing #4724 . This was more for a learning experience and an attempt to be helpful. Reference and CPU seemed fairly straight forward but I got a bit stuck on the GPU codes.  I mostly tried following the same template as updating parameters and exceptions. 

This seems to do what I intend it to do in the following script, but I haven't managed to sort an error call for OpenCL when the number of offsets change:

```
import openmm
from openmm import unit

def generateSystem():
    system = openmm.System()
    system.addParticle(1)
    system.addParticle(1)
    return system

def generateContext(system, platformname):
    platform = openmm.Platform.getPlatformByName(platformname)
    context = openmm.Context(system, openmm.LangevinIntegrator(298 * unit.kelvin, 1 / unit.picosecond, 2 * unit.femtosecond), platform)
    context.setPeriodicBoxVectors(openmm.Vec3(1, 0, 0), openmm.Vec3(0, 1, 0), openmm.Vec3(0, 0, 1))
    context.setPositions([openmm.Vec3(0, 0, 0), openmm.Vec3(0.4, 0, 0)])
    return context

def run_test(platformname):
    # generate a simple system of two Lennard-Jones particles
    system = generateSystem()
    force = openmm.NonbondedForce()
    system.addForce(force)
    force.addParticle(5 * unit.elementary_charge, 1 * unit.nanometer, 0 * unit.kilocalories_per_mole)
    force.addParticle(-5 * unit.elementary_charge, 1 * unit.nanometer, 0 * unit.kilocalories_per_mole)
    force.addGlobalParameter("lambda", 0)
    force.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
    force.setCutoffDistance(0.5 * unit.nanometer)
    context = generateContext(system, platformname)

    print(f"({platformname}) Unperturbed:", context.getState(getEnergy=True).getPotentialEnergy())

    # Add offset to particle 1
    offset_id = force.addParticleParameterOffset("lambda", 1, 0, 0, 0)  # Charge scale is 0 so will not impact the energy regardless of lambda
    context = generateContext(system, platformname)
    print(f"({platformname}) Should be the same:", context.getState(getEnergy=True).getPotentialEnergy())

    context.setParameter('lambda', 1)
    print(f"({platformname}) Should still be the same:", context.getState(getEnergy=True).getPotentialEnergy())

    force.setParticleParameterOffset(offset_id, "lambda", 1, 5, 0, 0)  # Change scale to -charge
    force.updateParametersInContext(context)
    print(f"({platformname}) Should be zero:", context.getState(getEnergy=True).getPotentialEnergy())

    context.setParameter('lambda', 0.0)
    print(f"({platformname}) Should be back to normal:", context.getState(getEnergy=True).getPotentialEnergy())

    # Test that adding a new offset errors
    print(f"({platformname}) We should be about to error!!!")
    force.addParticleParameterOffset("lambda", 0, 0, 0, 0) # Add an offset to particle 0 - this should raise an error
    try:
        force.updateParametersInContext(context)
    except openmm.OpenMMException as e:
        print(f"{platformname} : {e}")

print("Running test on Reference:")
run_test("Reference")

print("Running test on CPU")
run_test("CPU")

print("Running test on OpenCL")
run_test("OpenCL")
```

(I haven't done, but am happy to do, the exception offsets) 

Hopefully this is helpful - if you have some tips for the GPU code I don't mind doing that too. 