### PR TITLE
Handling `rigidWater=True` when `res.name` not `HOH`

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -1255,14 +1255,18 @@ class ForceField(object):
         # Find the template matching each residue and assign atom types.
 
         templateForResidue = self._matchAllResiduesToTemplates(data, topology, residueTemplates, ignoreExternalBonds)
+        HOH=False
         for res in topology.residues():
             if res.name == 'HOH':
                 # Determine whether this should be a rigid water.
-
+                
+                HOH=True
                 if rigidWater is None:
                     rigidResidue[res.index] = templateForResidue[res.index].rigidWater
                 elif rigidWater:
                     rigidResidue[res.index] = True
+        if rigidWater and not HOH:
+            warnings.warn("`rigidWater` was set to True but no `HOH` residues found.")
 
         # Create the System and add atoms
 


### PR DESCRIPTION
There are known [synonyms](https://github.com/openmm/openmm/blob/00e3b767689bb96429a41dde35260c66dc2a02c1/wrappers/python/openmm/app/data/pdbNames.xml#L277) for water's residue name, e.g., 

```python
 <Residue name="HOH" alt1="H20" alt2="WAT" alt3="SOL" alt4="TIP3" alt5="TP3" alt6="TIP">
```

To the best of my knowledge, besides `HOH`, these alternate names go unrecognized when setting `rigidWater=True` in `ForceField.createSystem()`, [line 1259](https://github.com/openmm/openmm/blob/00e3b767689bb96429a41dde35260c66dc2a02c1/wrappers/python/openmm/app/forcefield.py#L1259):

```python
        for res in topology.residues():
            if res.name == 'HOH':
                # Determine whether this should be a rigid water.

                if rigidWater is None:
                    rigidResidue[res.index] = templateForResidue[res.index].rigidWater
                elif rigidWater:
                    rigidResidue[res.index] = True
```

The residue name of water to be `HOH` is a reasonable and must be a calculated decision, however, it isn't immediately apparent to me that setting `rigidWater=True` goes unnoticed when using any other of water's synonyms. This PR makes a simple warning statement to notify the user that `rigidWater=True` may still have resulted in flexible water molecules. 

I wanted to get initial feedback before proposing more general solutions (i.e., generalizing the if statement to handle all water synonyms, etc.) to make sure I haven't missed any previous discussion on this choice. Thanks!