### PR TITLE
Fix residueTemplates argument in addMembrane

### DIFF
--- a/wrappers/python/openmm/app/modeller.py
+++ b/wrappers/python/openmm/app/modeller.py
@@ -1575,7 +1575,11 @@ class Modeller(object):
 
         needExtraWater = (boxSizeZ > patchSize[2])
         if needExtraWater:
-            modeller.addSolvent(forcefield, neutralize=False, residueTemplates=residueTemplates)
+            newResidueTemplates = {}
+            for r1, r2 in zip(self.topology.residues(), modeller.topology.residues()):
+                if r1 in residueTemplates:
+                    newResidueTemplates[r2] = residueTemplates[r1]
+            modeller.addSolvent(forcefield, neutralize=False, residueTemplates=newResidueTemplates)
 
         # Record the positions of all waters that have been added.
 


### PR DESCRIPTION
This is similar to https://github.com/openmm/openmm/pull/4528 but was missed out. When the membrane and protein are combined a new topology is created. This invalidates the residueTemplates dict so it must be recreated before calling addSolvent.