### PR TITLE
Cleaner printing of units

### DIFF
--- a/wrappers/python/openmm/unit/quantity.py
+++ b/wrappers/python/openmm/unit/quantity.py
@@ -215,8 +215,7 @@ class Quantity(object):
     def __repr__(self):
         """
         """
-        return (Quantity.__name__ + '(value=' + repr(self._value) + ', unit=' +
-                str(self.unit) + ')')
+        return str(self)
 
     def format(self, format_spec):
         return format_spec % self._value + ' ' + str(self.unit.get_symbol())

--- a/wrappers/python/tests/TestUnits.py
+++ b/wrappers/python/tests/TestUnits.py
@@ -630,7 +630,7 @@ class TestUnits(QuantityTestCase):
         """ Miscellaneous tests for the unit package """
         self.assertTrue(u.meter is not None)
         self.assertFalse(u.meter is None)
-        self.assertEqual(repr(1.2*u.meters), 'Quantity(value=1.2, unit=meter)')
+        self.assertEqual(repr(1.2*u.meters), '1.2 m')
         class Foo(object):
             def bar(self):
                 return 'bar'


### PR DESCRIPTION
This changes the default string representation of Quantities to print values with units in a simpler form.  With the current code:

```python
>>> 1.5*nanometers
Quantity(value=1.5, unit=nanometer)
```

With this PR:

```python
>>> 1.5*nanometers
1.5 nm
```