### PR TITLE
Fixed error in AmberPrmtopFile checking for periodic system

### DIFF
--- a/wrappers/python/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/openmm/app/amberprmtopfile.py
@@ -249,7 +249,7 @@ class AmberPrmtopFile(object):
                      ff.LJPME:'LJPME'}
         if nonbondedMethod not in methodMap:
             raise ValueError('Illegal value for nonbonded method')
-        if not self._prmtop.getIfBox() and nonbondedMethod in (ff.CutoffPeriodic, ff.Ewald, ff.PME, ff.LJPME):
+        if self.topology.getPeriodicBoxVectors() is None and nonbondedMethod in (ff.CutoffPeriodic, ff.Ewald, ff.PME, ff.LJPME):
             raise ValueError('Illegal nonbonded method for a non-periodic system')
         constraintMap = {None:None,
                          ff.HBonds:'h-bonds',


### PR DESCRIPTION
Fixes #4771.  If a prmtop file did not specify periodic boundary conditions, but the user provided them to the constructor, `createSystem()` would incorrectly throw an exception when they tried to specify a periodic nonbonded method.