### PR TITLE
Compare and track openmm.unit.BaseUnit objects by name

### DIFF
--- a/wrappers/python/openmm/unit/baseunit.py
+++ b/wrappers/python/openmm/unit/baseunit.py
@@ -68,7 +68,7 @@ class BaseUnit(object):
         self.dimension = base_dim
         self.name = name
         self.symbol = symbol
-        self._conversion_factors[self.dimension][self.name][self.name] = 1.0
+        BaseUnit._conversion_factors[self.dimension][self.name][self.name] = 1.0
 
     def __lt__(self, other):
         """
@@ -137,7 +137,7 @@ class BaseUnit(object):
             raise TypeError('Cannot define conversion for BaseUnits with different dimensions.')
         assert(factor != 0)
         assert(self != other)
-        conversion_factors = self._conversion_factors[self.dimension]
+        conversion_factors = BaseUnit._conversion_factors[self.dimension]
         conversion_factors_self = conversion_factors[self.name]
         conversion_factors_other = conversion_factors[other.name]
         # import all transitive conversions
@@ -170,7 +170,7 @@ class BaseUnit(object):
         if self.dimension != other.dimension:
             raise TypeError('Cannot get conversion for BaseUnits with different dimensions.')
         if self.name == other.name: return 1.0
-        conversion_factors_self = self._conversion_factors[self.dimension][self.name]
+        conversion_factors_self = BaseUnit._conversion_factors[self.dimension][self.name]
         if not other.name in conversion_factors_self:
             raise LookupError('No conversion defined from BaseUnit "%s" to "%s".' % (self, other))
         return conversion_factors_self[other.name]

--- a/wrappers/python/openmm/unit/baseunit.py
+++ b/wrappers/python/openmm/unit/baseunit.py
@@ -38,6 +38,8 @@ from __future__ import print_function, division, absolute_import
 __author__ = "Christopher M. Bruns"
 __version__ = "0.6"
 
+import collections
+
 class BaseUnit(object):
     '''
     Physical unit expressed in exactly one BaseDimension.
@@ -47,23 +49,26 @@ class BaseUnit(object):
     '''
     __array_priority__ = 100
 
+    # Global table of conversion factors between base units
+    _conversion_factors = collections.defaultdict(lambda: collections.defaultdict(dict))
+
     def __init__(self, base_dim, name, symbol):
         """Creates a new BaseUnit.
 
         Parameters
          - self: The newly created BaseUnit.
          - base_dim: (BaseDimension) The dimension of the new unit, e.g. 'mass'
-         - name: (string) Name of the unit, e.g. "kilogram"
+         - name: (string) Name of the unit, e.g. "kilogram".  This will be used
+            to distinguish between BaseUnit objects with the same dimension: two
+            BaseUnit objects with the same dimension that are given the same
+            name will be treated as equal to each other.
          - symbol: (string) Symbol for the unit, e.g. 'kg'.  This symbol will appear in
             Quantity string descriptions.
         """
         self.dimension = base_dim
         self.name = name
         self.symbol = symbol
-        self._conversion_factor_to = {}
-        self._conversion_factor_to[self] = 1.0
-        self._conversion_factor_to_by_name = {}
-        self._conversion_factor_to_by_name[self.name] = 1.0
+        self._conversion_factors[self.dimension][self.name][self.name] = 1.0
 
     def __lt__(self, other):
         """
@@ -74,6 +79,14 @@ class BaseUnit(object):
             return self.dimension < other.dimension
         # Second on conversion factor
         return self.conversion_factor_to(other) < 1.0
+
+    def __eq__(self, other):
+        if not isinstance(other, BaseUnit):
+            return False
+        return self.dimension == other.dimension and self.name == other.name
+
+    def __hash__(self):
+        return hash((self.dimension, self.name))
 
     def iter_base_dimensions(self):
         """
@@ -123,28 +136,25 @@ class BaseUnit(object):
         if self.dimension != other.dimension:
             raise TypeError('Cannot define conversion for BaseUnits with different dimensions.')
         assert(factor != 0)
-        assert(not self is other)
+        assert(self != other)
+        conversion_factors = self._conversion_factors[self.dimension]
+        conversion_factors_self = conversion_factors[self.name]
+        conversion_factors_other = conversion_factors[other.name]
         # import all transitive conversions
-        self._conversion_factor_to[other] = factor
-        self._conversion_factor_to_by_name[other.name] = factor
-        for (unit, cfac) in other._conversion_factor_to.items():
-            if unit is self: continue
-            if unit in self._conversion_factor_to: continue
-            self._conversion_factor_to[unit] = factor * cfac
-            unit._conversion_factor_to[self] = pow(factor * cfac, -1)
-            self._conversion_factor_to_by_name[unit.name] = factor * cfac
-            unit._conversion_factor_to_by_name[self.name] = pow(factor * cfac, -1)
+        conversion_factors_self[other.name] = factor
+        for (unit_name, cfac) in conversion_factors_other.items():
+            if unit_name == self.name: continue
+            if unit_name in conversion_factors_self: continue
+            conversion_factors_self[unit_name] = factor * cfac
+            conversion_factors[unit_name][self.name] = pow(factor * cfac, -1)
         # and for the other guy
         invFac = pow(factor, -1.0)
-        other._conversion_factor_to[self] = invFac
-        other._conversion_factor_to_by_name[self.name] = invFac
-        for (unit, cfac) in self._conversion_factor_to.items():
-            if unit is other: continue
-            if unit in other._conversion_factor_to: continue
-            other._conversion_factor_to[unit] = invFac * cfac
-            unit._conversion_factor_to[other] = pow(invFac * cfac, -1)
-            other._conversion_factor_to_by_name[unit.name] = invFac * cfac
-            unit._conversion_factor_to_by_name[other.name] = pow(invFac * cfac, -1)
+        conversion_factors_other[self.name] = invFac
+        for (unit_name, cfac) in conversion_factors_self.items():
+            if unit_name == other.name: continue
+            if unit_name in conversion_factors_other: continue
+            conversion_factors_other[unit_name] = invFac * cfac
+            conversion_factors[unit_name][other.name] = pow(invFac * cfac, -1)
 
     def conversion_factor_to(self, other):
         """Returns a conversion factor from this BaseUnit to another BaseUnit.
@@ -159,9 +169,11 @@ class BaseUnit(object):
         if self is other: return 1.0
         if self.dimension != other.dimension:
             raise TypeError('Cannot get conversion for BaseUnits with different dimensions.')
-        if not other.name in self._conversion_factor_to_by_name:
+        if self.name == other.name: return 1.0
+        conversion_factors_self = self._conversion_factors[self.dimension][self.name]
+        if not other.name in conversion_factors_self:
             raise LookupError('No conversion defined from BaseUnit "%s" to "%s".' % (self, other))
-        return self._conversion_factor_to_by_name[other.name]
+        return conversion_factors_self[other.name]
 
 # run module directly for testing
 if __name__=='__main__':

--- a/wrappers/python/openmm/unit/prefix.py
+++ b/wrappers/python/openmm/unit/prefix.py
@@ -64,7 +64,6 @@ class SiPrefix(object):
             symbol = self.symbol + unit.symbol
             name = self.prefix + unit.name
             factor = self.factor
-            # TODO - check for existing BaseUnit with same name, symbol, and factor
             new_base_unit = BaseUnit(unit.dimension, name, symbol)
             new_base_unit.define_conversion_factor_to(unit, factor)
             return new_base_unit
@@ -73,7 +72,6 @@ class SiPrefix(object):
             symbol = self.symbol + unit.symbol
             name = self.prefix + unit.name
             factor = self.factor * unit.factor
-            # TODO - check for existing BaseUnit with same name, symbol, and factor
             return ScaledUnit(factor, unit.master, name, symbol)
         elif isinstance(unit, Unit):
             base_units = list(unit.iter_base_or_scaled_units())


### PR DESCRIPTION
This addresses #4784.  Note that previously, the behavior of `BaseUnit` with respect to comparison of and interaction between different unit objects having the same name was ambiguous.  For instance, I would assume that after
```
import openmm.unit as unit
dim = unit.BaseDimension("test")
a = unit.BaseUnit(dim, "test_a", "test_a")
b = unit.BaseUnit(dim, "test_b", "test_b")
b.define_conversion_factor_to(a, 10)
b2 = unit.BaseUnit(dim, "test_b", "test_b")
```
either `b2` should behave equal to `b` and have conversion factor of `1` to `b` and `10` to `a`, or `b2` should not behave equal to `b` and refuse to be converted to `a` or `b`.  However,
```
for i in (a, b, b2):
    for j in (a, b, b2):
        try:
            print(f"{i.conversion_factor_to(j):4.1f}", end=" ")
        except Exception:
            print("????", end=" ")
    print()
```
prints
```
 1.0  0.1  0.1
10.0  1.0  1.0
????  1.0  1.0
```
so the behavior here is not transitive, which I think classifies as a bug.  In the new approach, the missing factor is reported as `10.0`.

In this new approach, if two `BaseUnit` objects have the same dimension and name, they compare equal and hash to the same value.  (I am assuming one is not supposed to modify `BaseUnit`s after they have been created.)  If we want different semantics than this, we can take a different approach.  The tables of conversion factors within `BaseUnit` objects has been changed to a global registry that keeps track of the conversion factors between them by their names.  If this change would break something that I missed, let me know so I can add a test case to catch it, as tests currently pass.

As for performance, in the old approach, `[unit.nano * unit.meter for _ in range(5000)]` takes 11 s, compared to the new approach in which it takes 0.047 s, and also doesn't eat up memory.