### PR TITLE
Fix issues with virtual site handling

### DIFF
--- a/wrappers/python/openmm/app/charmmpsffile.py
+++ b/wrappers/python/openmm/app/charmmpsffile.py
@@ -1410,12 +1410,12 @@ class CharmmPsfFile(object):
                 idxa = pair[1]
                 parent_exclude_list[idx].append(idxa)
                 force.addException(idx, idxa, 0.0, 0.1, 0.0)
-            # If lonepairs and Drude particles are bonded to the same parent atom, add exception
-            for excludeterm in parent_exclude_list:
-                if(len(excludeterm) >= 2):
-                    for i in range(len(excludeterm)):
-                        for j in range(i):
-                            force.addException(excludeterm[j], excludeterm[i], 0.0, 0.1, 0.0)
+        # If lonepairs and Drude particles are bonded to the same parent atom, add exception
+        for excludeterm in parent_exclude_list:
+            if(len(excludeterm) >= 2):
+                for i in range(len(excludeterm)):
+                    for j in range(i):
+                        force.addException(excludeterm[j], excludeterm[i], 0.0, 0.1, 0.0)
         # Exclude 1-2 and 1-3 pairs as well as the lonepair/Drude attached onto them
         if nbxmod > 1:
             for ia1, ia2 in self.pair_12_list:

--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -871,6 +871,7 @@ class ForceField(object):
                         newSite = deepcopy(site)
                         newSite.index = indexMap[site.index]
                         newSite.atoms = [indexMap[i] for i in site.atoms]
+                        newSite.excludeWith = indexMap[site.excludeWith]
                         newTemplate.virtualSites.append(newSite)
 
                 # Build the lists of bonds and external bonds.


### PR DESCRIPTION
This fixes two problems with virtual site handling that came up during the CHARMMconversion.

1. In `CharmmPsfFile`, code to add exceptions between lone pairs and Drude particles bonded to the same parent was only executing when Drude particles were present.  It failed to run if multiple lone pairs were present but there were no Drude particles in the system, as is the case for TIP5P water.  Lone pairs repelling each other shouldn't be a problem for sampled configurations in this case of rigid water molecules, but it adds a constant offset to the energy that shouldn't be there.

2. In `ForceField`, virtual sites in a residue would not have their `excludeWith` atom indices updated during patching.  This could cause exclusions for virtual sites in patched residues to get computed based on nonsensical neighbors, leading to incorrect energies and forces.