### PR TITLE
ATMForce: ignore invalid energy term when the energy expression does not depend on it 

### DIFF
--- a/openmmapi/src/ATMForceImpl.cpp
+++ b/openmmapi/src/ATMForceImpl.cpp
@@ -47,6 +47,7 @@
 #include "lepton/ParsedExpression.h"
 #include "lepton/Parser.h"
 #include <cmath>
+#include <limits>
 #include <map>
 #include <set>
 #include <sstream>
@@ -138,19 +139,31 @@ double ATMForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForce
     state0Energy = innerContextImpl0.calcForcesAndEnergy(includeForces, true);
     state1Energy = innerContextImpl1.calcForcesAndEnergy(includeForces, true);
 
-    // Compute the alchemical energy and forces.
+    // set global parameters for energy expression
 
     for (int i = 0; i < globalParameterNames.size(); i++)
         globalValues[i] = context.getParameter(globalParameterNames[i]);
+
+    // Protect against overflow when the hybrid potential function does
+    // not depend on u0 or u1 and their values are unbounded; typically at the endstates
+
+    double dEdu0 = u0DerivExpression.evaluate();
+    double dEdu1 = u1DerivExpression.evaluate();
+    double epsi = std::numeric_limits<float>::min();
+    double maxEnergy = std::numeric_limits<float>::max();
+    if(fabs(dEdu0) < epsi && ( isnan(state0Energy) || isinf(state0Energy)) ) state0Energy = maxEnergy;
+    if(fabs(dEdu1) < epsi && ( isnan(state1Energy) || isinf(state1Energy)) ) state1Energy = maxEnergy;
+
+    // Compute the alchemical energy and forces.
+
     combinedEnergy = energyExpression.evaluate();
     if (includeForces) {
-        double dEdu0 = u0DerivExpression.evaluate();
-        double dEdu1 = u1DerivExpression.evaluate();
         map<string, double> energyParamDerivs;
         for (int i = 0; i < paramDerivExpressions.size(); i++)
             energyParamDerivs[paramDerivNames[i]] += paramDerivExpressions[i].evaluate();
         kernel.getAs<CalcATMForceKernel>().applyForces(context, innerContextImpl0, innerContextImpl1, dEdu0, dEdu1, energyParamDerivs);
     }
+
     return (includeEnergy ? combinedEnergy : 0.0);
 }
 

--- a/openmmapi/src/ATMForceImpl.cpp
+++ b/openmmapi/src/ATMForceImpl.cpp
@@ -151,8 +151,10 @@ double ATMForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForce
     double dEdu1 = u1DerivExpression.evaluate();
     double epsi = std::numeric_limits<float>::min();
     double maxEnergy = std::numeric_limits<float>::max();
-    if(fabs(dEdu0) < epsi && ( isnan(state0Energy) || isinf(state0Energy)) ) state0Energy = maxEnergy;
-    if(fabs(dEdu1) < epsi && ( isnan(state1Energy) || isinf(state1Energy)) ) state1Energy = maxEnergy;
+    if(fabs(dEdu0) < epsi && (isnan(state0Energy) || isinf(state0Energy)))
+	state0Energy = maxEnergy;
+    if(fabs(dEdu1) < epsi && (isnan(state1Energy) || isinf(state1Energy)))
+	state1Energy = maxEnergy;
 
     // Compute the alchemical energy and forces.
 

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -2972,8 +2972,15 @@ void ReferenceCalcATMForceKernel::applyForces(ContextImpl& context, ContextImpl&
     vector<Vec3>& force = extractForces(context);
     vector<Vec3>& force0 = extractForces(innerContext0);
     vector<Vec3>& force1 = extractForces(innerContext1);
-    for (int i = 0; i < force.size(); i++)
-        force[i] += dEdu0*force0[i] + dEdu1*force1[i];
+
+    //protects from infinite forces when the hybrid potential does
+    //not depend on u1 or u0, typically at the endpoints
+    double epsi = std::numeric_limits<float>::min();
+    for (int i = 0; i < force.size(); i++) {
+	if ( fabs(dEdu0) > epsi ) force[i] += dEdu0*force0[i];
+	if ( fabs(dEdu1) > epsi ) force[i] += dEdu1*force1[i];
+    }
+
     map<string, double>& derivs = extractEnergyParameterDerivatives(context);
     for (auto deriv : energyParamDerivs)
         derivs[deriv.first] += deriv.second;

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -2978,7 +2978,7 @@ void ReferenceCalcATMForceKernel::applyForces(ContextImpl& context, ContextImpl&
     //not depend on u1 or u0, typically at the endpoints
     double epsi = std::numeric_limits<float>::min();
     for (int i = 0; i < force.size(); i++) {
-      if (fabs(dEdu0) > epsi)
+        if (fabs(dEdu0) > epsi)
 	    force[i] += dEdu0*force0[i];
 	if (fabs(dEdu1) > epsi)
 	    force[i] += dEdu1*force1[i];

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -2973,12 +2973,15 @@ void ReferenceCalcATMForceKernel::applyForces(ContextImpl& context, ContextImpl&
     vector<Vec3>& force0 = extractForces(innerContext0);
     vector<Vec3>& force1 = extractForces(innerContext1);
 
+    //update forces and
     //protects from infinite forces when the hybrid potential does
     //not depend on u1 or u0, typically at the endpoints
     double epsi = std::numeric_limits<float>::min();
     for (int i = 0; i < force.size(); i++) {
-	if ( fabs(dEdu0) > epsi ) force[i] += dEdu0*force0[i];
-	if ( fabs(dEdu1) > epsi ) force[i] += dEdu1*force1[i];
+      if (fabs(dEdu0) > epsi)
+	    force[i] += dEdu0*force0[i];
+	if (fabs(dEdu1) > epsi)
+	    force[i] += dEdu1*force1[i];
     }
 
     map<string, double>& derivs = extractEnergyParameterDerivatives(context);


### PR DESCRIPTION
Addresses #4805  