### PR TITLE
feature(forces): Use caching to speed up CustomCVForce and possibly the global variables too

### DIFF
--- a/openmmapi/include/openmm/Context.h
+++ b/openmmapi/include/openmm/Context.h
@@ -284,6 +284,14 @@ public:
      * belong to exactly one molecule.
      */
     const std::vector<std::vector<int> >& getMolecules() const;
+    /**
+     * If CustomCVForce is defined, it will return the time series of CollectiveVariables of size equal to the length of the last step (or size 0)
+     */
+    std::vector<std::vector<double>> getCVTimeSeries();
+    /**
+     * If CustomIntegrator is defined, it will return the time series of GlobalVariables of size equal to the length of the last step (or size 0)
+     */
+    std::vector<std::vector<double>> getGlobalVariableTimeSeries();
 private:
     friend class ContextImpl;
     friend class Force;

--- a/openmmapi/include/openmm/internal/ContextImpl.h
+++ b/openmmapi/include/openmm/internal/ContextImpl.h
@@ -39,6 +39,8 @@
 #include <map>
 #include <vector>
 
+using namespace std;
+
 namespace OpenMM {
 
 class ForceImpl;
@@ -52,6 +54,19 @@ class System;
 
 class OPENMM_EXPORT ContextImpl {
 public:
+
+    /**
+     * New buffering variables that allow saving collectiveVariables (CustomCVForce) and globalVariables (CustomIntegrator)
+     *   during the simulation run.  That way the user can run `simulation.step(5000)` in Python and obtain the time series
+     *   that has everything that they would need to evaluate for an aMD or Metadynamics configuration, while not stopping
+     *   every timestep (or 10 time steps) to read the individual data points.
+     */
+    vector<double> collectiveVariableValues;
+    vector<double> globalVariableValues;
+    vector<vector<double>> CVTimeSeriesBuffer;
+    vector<vector<double>> globalVariableTimeSeriesBuffer;
+    int lastUpdatedStep = -1;
+    void updateGlobalVariablesCache();
     /**
      * Create an ContextImpl for a Context;
      */
@@ -233,6 +248,15 @@ public:
      * to change, false otherwise
      */
     bool updateContextState();
+
+    vector<vector<double>> getCVTimeSeries() {
+        return CVTimeSeriesBuffer;
+    }
+
+    vector<vector<double>> getGlobalVariableTimeSeries() {
+        return globalVariableTimeSeriesBuffer;
+    }
+    
     /**
      * Get the list of ForceImpls belonging to this ContextImpl.
      */

--- a/openmmapi/include/openmm/internal/CustomCVForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomCVForceImpl.h
@@ -49,6 +49,8 @@ namespace OpenMM {
  */
 
 class OPENMM_EXPORT CustomCVForceImpl : public ForceImpl {
+private:
+    vector<double> cacheValues;
 public:
     CustomCVForceImpl(const CustomCVForce& owner);
     ~CustomCVForceImpl();

--- a/openmmapi/src/BrownianIntegrator.cpp
+++ b/openmmapi/src/BrownianIntegrator.cpp
@@ -89,10 +89,14 @@ bool BrownianIntegrator::kineticEnergyRequiresForce() const {
 
 void BrownianIntegrator::step(int steps) {
     if (context == NULL)
-        throw OpenMMException("This Integrator is not bound to a context!");  
+        throw OpenMMException("This Integrator is not bound to a context!");
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
     for (int i = 0; i < steps; ++i) {
         context->updateContextState();
         context->calcForcesAndEnergy(true, false, getIntegrationForceGroups());
         kernel.getAs<IntegrateBrownianStepKernel>().execute(*context, *this);
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }

--- a/openmmapi/src/Context.cpp
+++ b/openmmapi/src/Context.cpp
@@ -245,6 +245,14 @@ void Context::computeVirtualSites() {
     impl->computeVirtualSites();
 }
 
+std::vector<std::vector<double>> Context::getCVTimeSeries() {
+    return impl->getCVTimeSeries();
+}
+
+std::vector<std::vector<double>> Context::getGlobalVariableTimeSeries() {
+    return impl->getGlobalVariableTimeSeries();
+}
+
 void Context::reinitialize(bool preserveState) {
     const System& system = impl->getSystem();
     Integrator& integrator = impl->getIntegrator();

--- a/openmmapi/src/ContextImpl.cpp
+++ b/openmmapi/src/ContextImpl.cpp
@@ -209,6 +209,29 @@ ContextImpl::~ContextImpl() {
     platform->contextDestroyed(*this);
 }
 
+void ContextImpl::updateGlobalVariablesCache() {
+
+    // requires the cast to get the functions for Global Variables
+    if (CustomIntegrator* customIntegrator = dynamic_cast<CustomIntegrator*>(&getIntegrator())) {
+
+        int currentStep = getTime();
+
+        if (currentStep == lastUpdatedStep)
+            return;
+
+        lastUpdatedStep = currentStep;
+
+        globalVariableValues.resize(customIntegrator->getNumGlobalVariables());
+
+        for (int i = 0; i < customIntegrator->getNumGlobalVariables(); i++) {
+            globalVariableValues[i] = customIntegrator->getGlobalVariable(i);
+        }
+        globalVariableTimeSeriesBuffer.push_back(globalVariableValues);
+
+    }
+
+}
+
 double ContextImpl::getTime() const {
     return updateStateDataKernel.getAs<const UpdateStateDataKernel>().getTime(*this);
 }

--- a/openmmapi/src/CustomCVForceImpl.cpp
+++ b/openmmapi/src/CustomCVForceImpl.cpp
@@ -89,7 +89,7 @@ double CustomCVForceImpl::calcForcesAndEnergy(ContextImpl& context, bool include
         context.collectiveVariableValues.resize(innerSystem.getNumForces());
         for (int i = 0; i < innerSystem.getNumForces(); i++)
           context.collectiveVariableValues[i] = innerContext->getState(State::Energy, false, 1 << i).getPotentialEnergy();
-        
+
         return energy;
         
     }
@@ -121,12 +121,7 @@ map<string, double> CustomCVForceImpl::getDefaultParameters() {
 }
 
 void CustomCVForceImpl::getCollectiveVariableValues(ContextImpl& context, vector<double>& values) {
-    kernel.getAs<CalcCustomCVForceKernel>().copyState(context, getContextImpl(*innerContext));
-    values.clear();
-    for (int i = 0; i < innerSystem.getNumForces(); i++) {
-        double value = innerContext->getState(State::Energy, false, 1<<i).getPotentialEnergy();
-        values.push_back(value);
-    }
+    values = context.collectiveVariableValues;
 }
 
 Context& CustomCVForceImpl::getInnerContext() {

--- a/openmmapi/src/CustomIntegrator.cpp
+++ b/openmmapi/src/CustomIntegrator.cpp
@@ -143,8 +143,14 @@ void CustomIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");  
     globalsAreCurrent = false;
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
+    context->globalVariableTimeSeriesBuffer.clear();
     for (int i = 0; i < steps; ++i) {
+        context->updateGlobalVariablesCache();
         kernel.getAs<IntegrateCustomStepKernel>().execute(*context, *this, forcesAreValid);
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }
 

--- a/openmmapi/src/LangevinMiddleIntegrator.cpp
+++ b/openmmapi/src/LangevinMiddleIntegrator.cpp
@@ -90,9 +90,13 @@ bool LangevinMiddleIntegrator::kineticEnergyRequiresForce() const {
 void LangevinMiddleIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");  
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
     for (int i = 0; i < steps; ++i) {
         context->updateContextState();
         context->calcForcesAndEnergy(true, false, getIntegrationForceGroups());
         kernel.getAs<IntegrateLangevinMiddleStepKernel>().execute(*context, *this);
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }

--- a/openmmapi/src/NoseHooverIntegrator.cpp
+++ b/openmmapi/src/NoseHooverIntegrator.cpp
@@ -358,10 +358,14 @@ vector<string> NoseHooverIntegrator::getKernelNames() {
 void NoseHooverIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
     for (int i = 0; i < steps; ++i) {
         context->updateContextState();
         context->calcForcesAndEnergy(true, false, getIntegrationForceGroups());
         kernel.getAs<IntegrateNoseHooverStepKernel>().execute(*context, *this);
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }
 

--- a/openmmapi/src/VariableLangevinIntegrator.cpp
+++ b/openmmapi/src/VariableLangevinIntegrator.cpp
@@ -101,11 +101,15 @@ double VariableLangevinIntegrator::computeKineticEnergy() {
 
 void VariableLangevinIntegrator::step(int steps) {
     if (context == NULL)
-        throw OpenMMException("This Integrator is not bound to a context!");  
+        throw OpenMMException("This Integrator is not bound to a context!");
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
     for (int i = 0; i < steps; ++i) {
         context->updateContextState();
         context->calcForcesAndEnergy(true, false, getIntegrationForceGroups());
         setStepSize(kernel.getAs<IntegrateVariableLangevinStepKernel>().execute(*context, *this, std::numeric_limits<double>::infinity()));
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }
 

--- a/openmmapi/src/VariableVerletIntegrator.cpp
+++ b/openmmapi/src/VariableVerletIntegrator.cpp
@@ -84,10 +84,14 @@ double VariableVerletIntegrator::computeKineticEnergy() {
 void VariableVerletIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
     for (int i = 0; i < steps; ++i) {
         context->updateContextState();
         context->calcForcesAndEnergy(true, false, getIntegrationForceGroups());
         setStepSize(kernel.getAs<IntegrateVariableVerletStepKernel>().execute(*context, *this, std::numeric_limits<double>::infinity()));
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }
 

--- a/openmmapi/src/VerletIntegrator.cpp
+++ b/openmmapi/src/VerletIntegrator.cpp
@@ -71,9 +71,13 @@ double VerletIntegrator::computeKineticEnergy() {
 void VerletIntegrator::step(int steps) {
     if (context == NULL)
         throw OpenMMException("This Integrator is not bound to a context!");
+    context->CVTimeSeriesBuffer.clear();
+    context->collectiveVariableValues.clear();
     for (int i = 0; i < steps; ++i) {
         context->updateContextState();
         context->calcForcesAndEnergy(true, false, getIntegrationForceGroups());
         kernel.getAs<IntegrateVerletStepKernel>().execute(*context, *this);
+        if (context->collectiveVariableValues.size() > 0) 
+          context->CVTimeSeriesBuffer.push_back(context->collectiveVariableValues);
     }
 }

--- a/wrappers/python/src/swig_doxygen/OpenMM.i
+++ b/wrappers/python/src/swig_doxygen/OpenMM.i
@@ -11,6 +11,7 @@
 namespace std {
   %template(pairii) pair<int,int>;
   %template(vectord) vector<double>;
+  %template(vectordd) vector< vector<double> >;
   %template(vectorddd) vector< vector< vector<double> > >;
   %template(vectori) vector<int>;
   %template(vectorii) vector < vector<int> >;

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -324,6 +324,8 @@ UNITS = {
 ("HippoNonbondedForce",                 "getInducedDipoles")                             :  ( None, ()),
 ("HippoNonbondedForce",                 "getLabFramePermanentDipoles")                   :  ( None, ()),
     
+("Context", "getCVTimeSeries") : (None, ()),
+("Context", "getGlobalVariableTimeSeries") : (None, ()),
 ("Context", "getParameter") : (None, ()),
 ("Context", "getParameters") : (None, ()),
 ("Context", "getMolecules") : (None, ()),


### PR DESCRIPTION
The change proposed addresses the issue of speeding up simulations like aMD and Metadynamics by caching the global variables (of `CustomIntegrator`) and collective variables (of `CustomCVForce`).  It has a Python wrapper to add the new functions `getCVTimeSeries()` and `getGlobalVariableTimeSeries()` so that you can get this data and all of the Integrators consider the presence of the CVs and the `CustomIntegrator` will cache the global variables too.   The centralized `Context` provides these new functions.  
Everything seemed happy but HelloArgonInC.c, wasn't sure how to resolve this one but the explanation for why was very apparent.