### PR TITLE
Attempting to fix XTC/DCD restarting

### DIFF
--- a/wrappers/python/openmm/app/dcdreporter.py
+++ b/wrappers/python/openmm/app/dcdreporter.py
@@ -115,7 +115,7 @@ class DCDReporter(object):
         positions = state.getPositions(asNumpy=True)
         if self._atomSubset is not None:
             positions = [positions[i] for i in self._atomSubset]
-        self._dcd.writeModel(positions, periodicBoxVectors=state.getPeriodicBoxVectors())
+        self._dcd.writeModel(positions, periodicBoxVectors=state.getPeriodicBoxVectors(), currentStep=simulation.currentStep)
 
     def __del__(self):
         self._out.close()

--- a/wrappers/python/openmm/app/xtcreporter.py
+++ b/wrappers/python/openmm/app/xtcreporter.py
@@ -107,11 +107,10 @@ class XTCReporter(object):
                 self._fileName,
                 topology,
                 simulation.integrator.getStepSize(),
-                simulation.currentStep,
                 self._reportInterval,
                 self._append,
             )
         positions = state.getPositions(asNumpy=True)
         if self._atomSubset is not None:
             positions = [positions[i] for i in self._atomSubset]
-        self._xtc.writeModel(positions, periodicBoxVectors=state.getPeriodicBoxVectors())
+        self._xtc.writeModel(positions, periodicBoxVectors=state.getPeriodicBoxVectors(), currentStep=simulation.currentStep)

--- a/wrappers/python/tests/TestDcdFile.py
+++ b/wrappers/python/tests/TestDcdFile.py
@@ -61,6 +61,7 @@ class TestDCDFile(unittest.TestCase):
 
         integrator = mm.VerletIntegrator(0.001*unit.picoseconds)
         simulation = app.Simulation(pdb.topology, system, integrator, mm.Platform.getPlatform('Reference'))
+        simulation.currentStep = 10
         dcd = app.DCDReporter(fname, 2, append=True)
         simulation.reporters.append(dcd)
         simulation.context.setPositions(pdb.positions)
@@ -99,6 +100,7 @@ class TestDCDFile(unittest.TestCase):
 
         integrator = mm.VerletIntegrator(0.001*unit.picoseconds)
         simulation = app.Simulation(pdb.topology, system, integrator, mm.Platform.getPlatform('Reference'))
+        simulation.currentStep = 10
         dcd = app.DCDReporter(fname, 2, append=True, atomSubset=atomSubset)
         simulation.reporters.append(dcd)
         simulation.context.setPositions(pdb.positions)

--- a/wrappers/python/tests/TestDcdFile.py
+++ b/wrappers/python/tests/TestDcdFile.py
@@ -22,7 +22,7 @@ class TestDCDFile(unittest.TestCase):
         with open(fname, 'wb') as f:
             dcd = app.DCDFile(f, pdbfile.topology, 0.001)
             for i in range(5):
-                dcd.writeModel([mm.Vec3(random(), random(), random()) for j in range(natom)]*unit.angstroms)
+                dcd.writeModel([mm.Vec3(random(), random(), random()) for j in range(natom)]*unit.angstroms, currentStep=i)
         os.remove(fname)
     
     def testLongTrajectory(self):
@@ -33,7 +33,7 @@ class TestDCDFile(unittest.TestCase):
         with open(fname, 'wb') as f:
             dcd = app.DCDFile(f, pdbfile.topology, 0.001, interval=1000000000)
             for i in range(5):
-                dcd.writeModel([mm.Vec3(random(), random(), random()) for j in range(natom)]*unit.angstroms)
+                dcd.writeModel([mm.Vec3(random(), random(), random()) for j in range(natom)]*unit.angstroms, currentStep=i)
         os.remove(fname)
     
     def testAppend(self):

--- a/wrappers/python/tests/TestDcdFile.py
+++ b/wrappers/python/tests/TestDcdFile.py
@@ -6,6 +6,13 @@ from openmm import unit
 from random import random
 import os
 
+def _readModelCount(file):
+    import struct
+
+    with open(file, "r+b") as f:
+        f.seek(8, os.SEEK_SET)
+        return struct.unpack('<i', f.read(4))[0]
+
 class TestDCDFile(unittest.TestCase):
     def test_dcd(self):
         """ Test the DCD file """
@@ -45,7 +52,7 @@ class TestDCDFile(unittest.TestCase):
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*unit.kelvin)
         simulation.step(10)
-        self.assertEqual(5, dcd._dcd._modelCount)
+        self.assertEqual(5, _readModelCount(fname))
         del simulation
         del dcd
         len1 = os.stat(fname).st_size
@@ -59,7 +66,7 @@ class TestDCDFile(unittest.TestCase):
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*unit.kelvin)
         simulation.step(10)
-        self.assertEqual(10, dcd._dcd._modelCount)
+        self.assertEqual(10, _readModelCount(fname))
         len2 = os.stat(fname).st_size
         self.assertTrue(len2-len1 > 3*4*5*system.getNumParticles())
         del simulation
@@ -83,7 +90,7 @@ class TestDCDFile(unittest.TestCase):
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*unit.kelvin)
         simulation.step(10)
-        self.assertEqual(5, dcd._dcd._modelCount)
+        self.assertEqual(5, _readModelCount(fname))
         del simulation
         del dcd
         len1 = os.stat(fname).st_size
@@ -97,7 +104,7 @@ class TestDCDFile(unittest.TestCase):
         simulation.context.setPositions(pdb.positions)
         simulation.context.setVelocitiesToTemperature(300*unit.kelvin)
         simulation.step(10)
-        self.assertEqual(10, dcd._dcd._modelCount)
+        self.assertEqual(10, _readModelCount(fname))
         len2 = os.stat(fname).st_size
         self.assertTrue(len2-len1 > 3*4*5*len(atomSubset))
         del simulation

--- a/wrappers/python/tests/TestXtcFile.py
+++ b/wrappers/python/tests/TestXtcFile.py
@@ -226,6 +226,7 @@ class TestXtcFile(unittest.TestCase):
                 integrator,
                 mm.Platform.getPlatform("Reference"),
             )
+            simulation.currentStep = 10
             xtc = app.XTCReporter(fname, 2, append=True)
             simulation.reporters.append(xtc)
             simulation.context.setPositions(pdb.positions)

--- a/wrappers/python/tests/TestXtcFile.py
+++ b/wrappers/python/tests/TestXtcFile.py
@@ -212,7 +212,6 @@ class TestXtcFile(unittest.TestCase):
             simulation.context.setPositions(pdb.positions)
             simulation.context.setVelocitiesToTemperature(300 * unit.kelvin)
             simulation.step(10)
-            self.assertEqual(5, xtc._xtc._modelCount)
             self.assertEqual(5, xtc._xtc._getNumFrames())
             del simulation
             del xtc
@@ -231,7 +230,6 @@ class TestXtcFile(unittest.TestCase):
             simulation.context.setPositions(pdb.positions)
             simulation.context.setVelocitiesToTemperature(300 * unit.kelvin)
             simulation.step(10)
-            self.assertEqual(10, xtc._xtc._modelCount)
             self.assertEqual(10, xtc._xtc._getNumFrames())
             del simulation
             del xtc
@@ -259,7 +257,6 @@ class TestXtcFile(unittest.TestCase):
             simulation.context.setPositions(pdb.positions)
             simulation.context.setVelocitiesToTemperature(300 * unit.kelvin)
             simulation.step(10)
-            self.assertEqual(5, xtc._xtc._modelCount)
             self.assertEqual(5, xtc._xtc._getNumFrames())
 
             # The  XTCFile class  does not  provide a  way to  read the

--- a/wrappers/python/tests/TestXtcFile.py
+++ b/wrappers/python/tests/TestXtcFile.py
@@ -34,7 +34,7 @@ class TestXtcFile(unittest.TestCase):
                     mm.Vec3(random(), random(), random()) * unit.nanometers,
                 )
                 box.append(np.array([[vec.x, vec.y, vec.z] for vec in box_i]))
-                xtc.writeModel(coords[i], periodicBoxVectors=box_i)
+                xtc.writeModel(coords[i], periodicBoxVectors=box_i, currentStep=i)
             # The  XTCFile class  does not  provide a  way to  read the
             # trajectory back, but the underlying XTC library does
             coords_read, box_read, time, step = read_xtc(fname.encode("utf-8"))
@@ -72,7 +72,7 @@ class TestXtcFile(unittest.TestCase):
                 )
                 box_i = mm.Vec3(random(), random(), random()) * unit.nanometers
                 box.append(np.diag(box_i[:3].value_in_unit(unit.nanometers)))
-                xtc.writeModel(coords[i], unitCellDimensions=box_i)
+                xtc.writeModel(coords[i], unitCellDimensions=box_i, currentStep=i)
             #The  XTCFile class  does not  provide a  way to  read the
             #trajectory back, but the underlying XTC library does
             coords_read, box_read, time, step = read_xtc(fname.encode("utf-8"))
@@ -108,7 +108,7 @@ class TestXtcFile(unittest.TestCase):
                     [mm.Vec3(random(), random(), random()) for j in range(natom)]
                     * unit.nanometers
                 )
-                xtc.writeModel(coords[i])
+                xtc.writeModel(coords[i], currentStep=i)
             # The  XTCFile class  does not  provide a  way to  read the
             # trajectory back, but the underlying XTC library does
             coords_read, box_read, time, step = read_xtc(fname.encode("utf-8"))
@@ -158,7 +158,7 @@ class TestXtcFile(unittest.TestCase):
                     mm.Vec3(random(), random(), random()) * unit.nanometers,
                 )
                 box.append(np.array([[vec.x, vec.y, vec.z] for vec in box_i]))
-                xtc.writeModel(coords[i], periodicBoxVectors=box_i)
+                xtc.writeModel(coords[i], periodicBoxVectors=box_i, currentStep=i)
             # The  XTCFile class  does not  provide a  way to  read the
             # trajectory back, but the underlying XTC library does
             coords_read, box_read, time, step = read_xtc(fname.encode("utf-8"))
@@ -187,7 +187,8 @@ class TestXtcFile(unittest.TestCase):
             for i in range(5):
                 xtc.writeModel(
                     [mm.Vec3(random(), random(), random()) for j in range(natom)]
-                    * unit.angstroms
+                    * unit.angstroms,
+                    currentStep=i
                 )
 
     def testAppend(self):


### PR DESCRIPTION
Fixes #4873 by writing directly the simulation.currentStep into the XTC and DCD files.

I'm making here some assumptions that the first step written in a file will be at `step=interval` but I think this is a valid assumption?

Also assuming that you would only append to an XTC/DCD file if you were resuming a previous simulation (i.e. via a checkpoint) and not creating a new Simulation from scratch which would set the currentStep to 0