### PR TITLE
Tidying up the tests

### DIFF
--- a/wrappers/python/tests/TestAmberInpcrdFile.py
+++ b/wrappers/python/tests/TestAmberInpcrdFile.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from validateConstraints import *
 from openmm.app import *
@@ -15,13 +16,15 @@ def compareByElement(array1, array2, cmp):
         cmp(x, y)
 
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestAmberInpcrdFile(unittest.TestCase):
     """Test the Amber inpcrd file parser"""
 
     def test_CrdVelBox(self):
         """ Test parsing ASCII restarts with crds, vels, and box """
         cmp = self.assertAlmostEqual
-        inpcrd = AmberInpcrdFile('systems/crds_vels_box.rst7')
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'crds_vels_box.rst7'))
         self.assertEqual(len(inpcrd.positions), 2101)
         compareByElement(inpcrd.positions[-1].value_in_unit(angstroms),
                          [3.5958082, 8.4176792, -8.2954064], cmp)
@@ -35,7 +38,7 @@ class TestAmberInpcrdFile(unittest.TestCase):
         """ Test NetCDF restart file parsing """
         cmp = self.assertAlmostEqual
 
-        inpcrd = AmberInpcrdFile('systems/amber.ncrst')
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'amber.ncrst'))
         self.assertEqual(len(inpcrd.positions), 2101)
         compareByElement(inpcrd.positions[0].value_in_unit(angstroms),
                          [6.82122492718229, 6.6276250662042, -8.51668999892245],
@@ -48,24 +51,24 @@ class TestAmberInpcrdFile(unittest.TestCase):
 
     def test_CrdBox(self):
         """ Test parsing ASCII restarts with only crds and box """
-        inpcrd = AmberInpcrdFile('systems/crds_box.rst7')
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'crds_box.rst7'))
         self.assertEqual(len(inpcrd.positions), 18660)
         self.assertTrue(inpcrd.velocities is None)
         self.assertTrue(inpcrd.boxVectors is not None)
 
     def test_CrdVel(self):
-        inpcrd = AmberInpcrdFile('systems/crds_vels.rst7')
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'crds_vels.rst7'))
         self.assertTrue(inpcrd.boxVectors is None)
         self.assertTrue(inpcrd.velocities is not None)
 
     def test_CrdOnly(self):
-        inpcrd = AmberInpcrdFile('systems/crdsonly.rst7')
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'crdsonly.rst7'))
         self.assertTrue(inpcrd.boxVectors is None)
         self.assertTrue(inpcrd.velocities is None)
 
     def test_CrdBoxTruncoct(self):
         # Check that the box vectors come out correct.
-        inpcrd = AmberInpcrdFile('systems/tz2.truncoct.rst7')
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'tz2.truncoct.rst7'))
         ac = Vec3(42.4388485, 0.0, 0.0) * angstroms
         bc = Vec3(-14.146281691908937, 40.011730483685835, 0.0) * angstroms
         cc = Vec3(-14.146281691908937, -20.0058628205162, 34.651176446201672) * angstroms

--- a/wrappers/python/tests/TestAmberPrmtopFile.py
+++ b/wrappers/python/tests/TestAmberPrmtopFile.py
@@ -7,17 +7,19 @@ from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
 
-inpcrd1 = AmberInpcrdFile('systems/alanine-dipeptide-explicit.inpcrd')
-inpcrd3 = AmberInpcrdFile('systems/ff14ipq.rst7')
-inpcrd4 = AmberInpcrdFile('systems/Mg_water.inpcrd')
-inpcrd7 = AmberInpcrdFile('systems/18protein.rst7')
-prmtop1 = AmberPrmtopFile('systems/alanine-dipeptide-explicit.prmtop')
-prmtop2 = AmberPrmtopFile('systems/alanine-dipeptide-implicit.prmtop')
-prmtop3 = AmberPrmtopFile('systems/ff14ipq.parm7', periodicBoxVectors=inpcrd3.boxVectors)
-prmtop4 = AmberPrmtopFile('systems/Mg_water.prmtop', periodicBoxVectors=inpcrd4.boxVectors)
-prmtop5 = AmberPrmtopFile('systems/tz2.truncoct.parm7')
-prmtop6 = AmberPrmtopFile('systems/gaffwat.parm7')
-prmtop7 = AmberPrmtopFile('systems/18protein.parm7', periodicBoxVectors=inpcrd7.boxVectors)
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
+inpcrd1 = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.inpcrd'))
+inpcrd3 = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'ff14ipq.rst7'))
+inpcrd4 = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'Mg_water.inpcrd'))
+inpcrd7 = AmberInpcrdFile(os.path.join(curr_dir, 'systems', '18protein.rst7'))
+prmtop1 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.prmtop'))
+prmtop2 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.prmtop'))
+prmtop3 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'ff14ipq.parm7'), periodicBoxVectors=inpcrd3.boxVectors)
+prmtop4 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'Mg_water.prmtop'), periodicBoxVectors=inpcrd4.boxVectors)
+prmtop5 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'tz2.truncoct.parm7'))
+prmtop6 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'gaffwat.parm7'))
+prmtop7 = AmberPrmtopFile(os.path.join(curr_dir, 'systems', '18protein.parm7'), periodicBoxVectors=inpcrd7.boxVectors)
 
 class TestAmberPrmtopFile(unittest.TestCase):
 
@@ -307,14 +309,14 @@ class TestAmberPrmtopFile(unittest.TestCase):
         nonbondedMethod = [NoCutoff, CutoffNonPeriodic, CutoffNonPeriodic, NoCutoff, NoCutoff]
         salt = [0.0, 0.0, 0.5, 0.5, 0.0]*(moles/liter)
         file = ['HCT_NoCutoff', 'OBC1_NonPeriodic', 'OBC2_NonPeriodic_Salt', 'GBn_NoCutoff_Salt', 'GBn2_NoCutoff']
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         for i in range(5):
             system = prmtop2.createSystem(implicitSolvent=solventType[i], nonbondedMethod=nonbondedMethod[i], implicitSolventSaltConc=salt[i])
             integrator = VerletIntegrator(0.001)
             context = Context(system, integrator, Platform.getPlatform("Reference"))
             context.setPositions(pdb.positions)
             state1 = context.getState(getForces=True)
-            with open('systems/alanine-dipeptide-implicit-forces/'+file[i]+'.xml') as infile:
+            with open(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit-forces', file[i]+'.xml')) as infile:
                 state2 = XmlSerializer.deserialize(infile.read())
             for f1, f2, in zip(state1.getForces().value_in_unit(kilojoules_per_mole/nanometer), state2.getForces().value_in_unit(kilojoules_per_mole/nanometer)):
                 diff = norm(f1-f2)
@@ -375,8 +377,8 @@ class TestAmberPrmtopFile(unittest.TestCase):
 
     def testChamber(self):
         """Test a prmtop file created with Chamber."""
-        prmtop = AmberPrmtopFile('systems/ala3_solv.parm7')
-        crd = CharmmCrdFile('systems/ala3_solv.crd')
+        prmtop = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'ala3_solv.parm7'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv.crd'))
         system = prmtop.createSystem()
         for i,f in enumerate(system.getForces()):
             f.setForceGroup(i)
@@ -414,8 +416,8 @@ class TestAmberPrmtopFile(unittest.TestCase):
 
     def testNucleicGBParametes(self):
         """Test that correct GB parameters are used for nucleic acids."""
-        prmtop = AmberPrmtopFile('systems/DNA_mbondi3.prmtop')
-        inpcrd = AmberInpcrdFile('systems/DNA_mbondi3.inpcrd')
+        prmtop = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'DNA_mbondi3.prmtop'))
+        inpcrd = AmberInpcrdFile(os.path.join(curr_dir, 'systems', 'DNA_mbondi3.inpcrd'))
         sanderEnergy = [-19223.87993545, -19527.40433175, -19788.1070698]
         for solvent, expectedEnergy in zip([OBC2, GBn, GBn2], sanderEnergy):
             system = prmtop.createSystem(implicitSolvent=solvent, gbsaModel=None)
@@ -456,7 +458,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
 
     def testEPConstraints(self):
         """Test different types of constraints when using extra particles"""
-        prmtop = AmberPrmtopFile('systems/peptide_with_tip4p.prmtop')
+        prmtop = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'peptide_with_tip4p.prmtop'))
         for constraints in (HBonds, AllBonds):
             system = prmtop.createSystem(constraints=constraints)
             integrator = VerletIntegrator(0.001*picoseconds)

--- a/wrappers/python/tests/TestCharmmFiles.py
+++ b/wrappers/python/tests/TestCharmmFiles.py
@@ -14,6 +14,9 @@ if sys.version_info >= (3,0):
 else:
     from cStringIO import StringIO
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestCharmmFiles(unittest.TestCase):
 
     """Test the GromacsTopFile.createSystem() method."""
@@ -22,12 +25,13 @@ class TestCharmmFiles(unittest.TestCase):
         """Set up the tests by loading the input files."""
 
         # alanine tripeptide; no waters
-        self.psf_c = CharmmPsfFile('systems/ala_ala_ala.psf')
-        self.psf_x = CharmmPsfFile('systems/ala_ala_ala.xpsf')
-        self.psf_v = CharmmPsfFile('systems/ala_ala_ala.vpsf')
+        self.psf_c = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.psf'))
+        self.psf_x = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.xpsf'))
+        self.psf_v = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.vpsf'))
         self.params = CharmmParameterSet(
-                            'systems/charmm22.rtf', 'systems/charmm22.par')
-        self.pdb = PDBFile('systems/ala_ala_ala.pdb')
+                            os.path.join(curr_dir, 'systems', 'charmm22.rtf'),
+                            os.path.join(curr_dir, 'systems', 'charmm22.par'))
+        self.pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.pdb'))
 
     def test_NonbondedMethod(self):
         """Test both non-periodic methods for the systems"""
@@ -103,9 +107,9 @@ class TestCharmmFiles(unittest.TestCase):
     def test_DrudeMass(self):
         """Test that setting the mass of Drude particles works correctly."""
 
-        psf = CharmmPsfFile('systems/ala3_solv_drude.psf')
-        crd = CharmmCrdFile('systems/ala3_solv_drude.crd')
-        params = CharmmParameterSet('systems/toppar_drude_master_protein_2013e.str')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.psf'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'toppar_drude_master_protein_2013e.str'))
         system = psf.createSystem(params, drudeMass=0)
         trueMass = [system.getParticleMass(i) for i in range(system.getNumParticles())]
         drudeMass = 0.3*amu
@@ -130,10 +134,10 @@ class TestCharmmFiles(unittest.TestCase):
     def test_NBFIX(self):
         """Tests CHARMM systems with NBFIX Lennard-Jones modifications"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/ala3_solv.psf', unitCellDimensions=Vec3(32.7119500, 32.9959600, 33.0071500)*angstroms)
-        crd = CharmmCrdFile('systems/ala3_solv.crd')
-        params = CharmmParameterSet('systems/par_all36_prot.prm',
-                                    'systems/toppar_water_ions.str')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv.psf'), unitCellDimensions=Vec3(32.7119500, 32.9959600, 33.0071500)*angstroms)
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'par_all36_prot.prm'),
+                                    os.path.join(curr_dir, 'systems', 'toppar_water_ions.str'))
 
         # Turn off charges so we only test the Lennard-Jones energies
         for a in psf.atom_list:
@@ -154,9 +158,11 @@ class TestCharmmFiles(unittest.TestCase):
     def test_NBFIX14(self):
         """Tests CHARMM systems with NBFIX modifications to 1-4 interactions"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/chl1.psf')
-        crd = CharmmCrdFile('systems/chl1.crd')
-        params = CharmmParameterSet('systems/par_all36_lipid.prm', 'systems/par_all36_cgenff.prm', 'systems/toppar_all36_lipid_cholesterol.str')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'chl1.psf'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'chl1.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'par_all36_lipid.prm'),
+                                   os.path.join(curr_dir, 'systems', 'par_all36_cgenff.prm'),
+                                   os.path.join(curr_dir, 'systems', 'toppar_all36_lipid_cholesterol.str'))
 
         # Turn off charges so we only test the Lennard-Jones energies
         for a in psf.atom_list:
@@ -178,9 +184,10 @@ class TestCharmmFiles(unittest.TestCase):
     def test_NBThole(self):
         """Tests CHARMM system with NBTHole"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/cyt-gua-cyt.psf')
-        crd = CharmmCrdFile('systems/cyt-gua-cyt.crd')
-        params = CharmmParameterSet('systems/toppar_drude_master_protein_2013e.str','systems/toppar_drude_nucleic_acid_2017b.str')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'cyt-gua-cyt.psf'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'cyt-gua-cyt.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'toppar_drude_master_protein_2013e.str'),
+                                   os.path.join(curr_dir, 'systems', 'toppar_drude_nucleic_acid_2017b.str'))
         # Box dimensions (cubic box)
         psf.setBox(30.0*angstroms, 30.0*angstroms, 30.0*angstroms)
 
@@ -197,7 +204,7 @@ class TestCharmmFiles(unittest.TestCase):
 
     def test_PSFSetUnitCellDimensions(self):
         """Test that setting the box via unit cell dimensions works correctly."""
-        psf = CharmmPsfFile('systems/ala3_solv_drude.psf')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.psf'))
 
         # Orthorhombic
         psf.setBox(2.1*nanometer, 2.3*nanometer, 2.4*nanometer)
@@ -228,9 +235,9 @@ class TestCharmmFiles(unittest.TestCase):
     def test_Drude(self):
         """Test CHARMM systems with Drude force field"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/ala3_solv_drude.psf')
-        crd = CharmmCrdFile('systems/ala3_solv_drude.crd')
-        params = CharmmParameterSet('systems/toppar_drude_master_protein_2013e.str')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.psf'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'toppar_drude_master_protein_2013e.str'))
         # Box dimensions (cubic box)
         psf.setBox(33.2*angstroms, 33.2*angstroms, 33.2*angstroms)
 
@@ -248,10 +255,10 @@ class TestCharmmFiles(unittest.TestCase):
     def test_Lonepair(self):
         """Test the lonepair facilities, in particular the colinear type of lonepairs"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/chlb_cgenff.psf')
-        crd = CharmmCrdFile('systems/chlb_cgenff.crd')
-        params = CharmmParameterSet('systems/top_all36_cgenff.rtf',
-                                    'systems/par_all36_cgenff.prm')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'chlb_cgenff.psf'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'chlb_cgenff.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'top_all36_cgenff.rtf'),
+                                   os.path.join(curr_dir, 'systems', 'par_all36_cgenff.prm'))
         plat = Platform.getPlatform('Reference')
         system = psf.createSystem(params)
         con = Context(system, VerletIntegrator(2*femtoseconds), plat)
@@ -270,7 +277,7 @@ class TestCharmmFiles(unittest.TestCase):
 
     def test_InsCode(self):
         """ Test the parsing of PSF files that contain insertion codes in their residue numbers """
-        psf = CharmmPsfFile('systems/4TVP-dmj_wat-ion.psf')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', '4TVP-dmj_wat-ion.psf'))
         self.assertEqual(len(list(psf.topology.atoms())), 66264)
         self.assertEqual(len(list(psf.topology.residues())), 20169)
         self.assertEqual(len(list(psf.topology.bonds())), 46634)
@@ -278,11 +285,11 @@ class TestCharmmFiles(unittest.TestCase):
     def testSystemOptions(self):
         """ Test various options in CharmmPsfFile.createSystem """
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/ala3_solv.psf',
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv.psf'),
                             periodicBoxVectors=(Vec3(32.7119500, 0, 0)*angstroms, Vec3(0, 32.9959600, 0)*angstroms, Vec3(0, 0, 33.0071500)*angstroms))
-        crd = CharmmCrdFile('systems/ala3_solv.crd')
-        params = CharmmParameterSet('systems/par_all36_prot.prm',
-                                    'systems/toppar_water_ions.str')
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'par_all36_prot.prm'),
+                                   os.path.join(curr_dir, 'systems', 'toppar_water_ions.str'))
 
         # Check some illegal options
         self.assertRaises(ValueError, lambda:
@@ -314,10 +321,10 @@ class TestCharmmFiles(unittest.TestCase):
             context = Context(system, integrator, Platform.getPlatform("Reference"))
             context.setPositions(self.pdb.positions)
             state1 = context.getState(getForces=True)
-            #out = open('systems/ala-ala-ala-implicit-forces/'+file[i]+'.xml', 'w')
+            #out = open(os.path.join(curr_dir, 'systems', 'ala-ala-ala-implicit-forces', file[i]+'.xml'), 'w')
             #out.write(XmlSerializer.serialize(state1))
             #out.close()
-            with open('systems/ala-ala-ala-implicit-forces/'+file[i]+'.xml') as xml:
+            with open(os.path.join(curr_dir, 'systems', 'ala-ala-ala-implicit-forces', file[i]+'.xml')) as xml:
                 state2 = XmlSerializer.deserialize(xml.read())
             for f1, f2, in zip(state1.getForces().value_in_unit(kilojoules_per_mole/nanometer), state2.getForces().value_in_unit(kilojoules_per_mole/nanometer)):
                 diff = norm(f1-f2)
@@ -326,11 +333,11 @@ class TestCharmmFiles(unittest.TestCase):
     def test_PermissiveRead(self):
         """Compare permissive and strict reading of Charmm parameters"""
 
-        psf = CharmmPsfFile('systems/5dhfr_cube.psf')
-        pdb = PDBFile('systems/5dhfr_cube.pdb')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', '5dhfr_cube.psf'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', '5dhfr_cube.pdb'))
 
-        params_strict     = CharmmParameterSet('systems/par_all22_prot_with_mass.inp')
-        params_permissive = CharmmParameterSet('systems/par_all22_prot.inp', permissive=True)
+        params_strict     = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'par_all22_prot_with_mass.inp'))
+        params_permissive = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'par_all22_prot.inp'), permissive=True)
         # Box dimensions (found from bounding box)
         psf.setBox(62.23*angstroms, 62.23*angstroms, 62.23*angstroms)
 
@@ -361,7 +368,7 @@ class TestCharmmFiles(unittest.TestCase):
     
     def test_Impropers(self):
         """Test CHARMM improper torsions."""
-        psf = CharmmPsfFile('systems/improper.psf')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'improper.psf'))
         system = psf.createSystem(self.params)
         force = [f for f in system.getForces() if isinstance(f, CustomTorsionForce)][0]
         group = force.getForceGroup()
@@ -508,7 +515,7 @@ END""", file=prm_file)
         hoh = ["O", "H1", "H2"]
         pot = ["POT"]
         cla = ["CLA"]
-        psf = CharmmPsfFile('systems/charmm-solvated/isa_wat.3_kcl.m14.psf')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'charmm-solvated', 'isa_wat.3_kcl.m14.psf'))
         for residue in psf.topology.residues():
             atoms = [atom.name for atom in residue.atoms()]
             if residue.name == "M14":
@@ -525,11 +532,11 @@ END""", file=prm_file)
     def test_NoLongRangeCorrection(self):
         """Test that long range correction is disabled."""
         parameters = CharmmParameterSet(
-            'systems/charmm-solvated/envi.str',
-            'systems/charmm-solvated/m14.rtf',
-            'systems/charmm-solvated/m14.prm'
+            os.path.join(curr_dir, 'systems', 'charmm-solvated', 'envi.str'),
+            os.path.join(curr_dir, 'systems', 'charmm-solvated', 'm14.rtf'),
+            os.path.join(curr_dir, 'systems', 'charmm-solvated', 'm14.prm')
         )
-        psf = CharmmPsfFile('systems/charmm-solvated/isa_wat.3_kcl.m14.psf')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'charmm-solvated', 'isa_wat.3_kcl.m14.psf'))
         psf.setBox(3.0584*nanometers,3.0584*nanometers,3.0584*nanometers)
         system = psf.createSystem(parameters, nonbondedMethod=PME)
         for force in system.getForces():
@@ -541,20 +548,20 @@ END""", file=prm_file)
     def test_NoPsfWarning(self):
         """Test that PSF warning is not thrown."""
         parameters = CharmmParameterSet(
-            'systems/charmm-solvated/envi.str',
-            'systems/charmm-solvated/m14.rtf',
-            'systems/charmm-solvated/m14.prm'
+            os.path.join(curr_dir, 'systems', 'charmm-solvated', 'envi.str'),
+            os.path.join(curr_dir, 'systems', 'charmm-solvated', 'm14.rtf'),
+            os.path.join(curr_dir, 'systems', 'charmm-solvated', 'm14.prm')
         )
         with warnings.catch_warnings():
             warnings.simplefilter("error", CharmmPSFWarning)
-            psf = CharmmPsfFile('systems/charmm-solvated/isa_wat.3_kcl.m14.psf')
+            psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'charmm-solvated', 'isa_wat.3_kcl.m14.psf'))
             psf.setBox(3.0584*nanometers,3.0584*nanometers,3.0584*nanometers)
             psf.createSystem(parameters, nonbondedMethod=PME)
 
     def test_NBXMod(self):
         """Test that all values of NBXMod are interpreted correctly."""
-        crd = CharmmCrdFile('systems/ala_ala_ala.crd')
-        with open('systems/charmm22.par') as parfile:
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.crd'))
+        with open(os.path.join(curr_dir, 'systems', 'charmm22.par')) as parfile:
             par = parfile.read()
         # The following values were computed with CHARMM.
         modeEnergy = {0: 754318.20507, 1: 754318.20507, 2: 908.35224, 3: 59.65279, 4: -241.12856, 5: 39.13169}
@@ -562,7 +569,7 @@ END""", file=prm_file)
             with tempfile.NamedTemporaryFile(suffix='.par', mode='w', delete=False) as parfile:
                 parfile.write(par.replace('nbxmod  5', 'nbxmod %d' % nbxmod))
                 parfile.close()
-                params = CharmmParameterSet('systems/charmm22.rtf', parfile.name)
+                params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'charmm22.rtf'), parfile.name)
                 os.remove(parfile.name)
             system = self.psf_c.createSystem(params, nonbondedMethod=NoCutoff)
             context = Context(system, VerletIntegrator(1*femtoseconds), Platform.getPlatform('Reference'))
@@ -572,9 +579,9 @@ END""", file=prm_file)
 
     def test_Nonbonded_Exclusion(self):
         """Test that the 1-2, 1-3 and 1-4 pairs are correctly excluded or scaled."""
-        psf = CharmmPsfFile('systems/MoS2.psf')
-        pdb = PDBFile('systems/MoS2.pdb')
-        params = CharmmParameterSet('systems/MoS2.prm')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'MoS2.psf'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'MoS2.pdb'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'MoS2.prm'))
         system = psf.createSystem(params, nonbondedMethod=NoCutoff)
         context = Context(system, VerletIntegrator(1*femtoseconds), Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
@@ -584,8 +591,8 @@ END""", file=prm_file)
 
     def test_Constraints(self):
         """Test that bond and angles constraints are correctly added into the system"""
-        psf = CharmmPsfFile('systems/water_methanol.psf')
-        params = CharmmParameterSet('systems/water_methanol.prm')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'water_methanol.psf'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'water_methanol.prm'))
         # the system is made of one water molecule and one methanol molecule
         hBonds_water = [[0, 1], [1, 2]]
         hAngles_water = [[0, 2]]
@@ -619,11 +626,11 @@ END""", file=prm_file)
     def test_Constraints_charmm(self):
         """Tests that CHARMM and OpenMM implementation of CHARMM force field produce the same constraints and energy"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/ala3_solv.psf',
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv.psf'),
                             unitCellDimensions=Vec3(32.7119500, 32.9959600, 33.0071500) * angstroms)
-        crd = CharmmCrdFile('systems/ala3_solv.crd')
-        params = CharmmParameterSet('systems/par_all36_prot.prm',
-                                    'systems/toppar_water_ions.str')
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'par_all36_prot.prm'),
+                                   os.path.join(curr_dir, 'systems', 'toppar_water_ions.str'))
         plat = Platform.getPlatform('Reference')
         system_charmm = psf.createSystem(params, nonbondedMethod=PME,
                                   nonbondedCutoff=8 * angstroms)

--- a/wrappers/python/tests/TestCheckpointReporter.py
+++ b/wrappers/python/tests/TestCheckpointReporter.py
@@ -12,7 +12,7 @@ class TestCheckpointReporter(unittest.TestCase):
     def setUp(self):
         with open(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb')) as f:
             pdb = app.PDBFile(f)
-        forcefield = app.ForceField(os.path.join(curr_dir, 'systems', 'amber99sbildn.xml'))
+        forcefield = app.ForceField('amber99sbildn.xml')
         system = forcefield.createSystem(pdb.topology,
             nonbondedMethod=app.CutoffNonPeriodic, nonbondedCutoff=1.0*unit.nanometers,
             constraints=app.HBonds)

--- a/wrappers/python/tests/TestCheckpointReporter.py
+++ b/wrappers/python/tests/TestCheckpointReporter.py
@@ -5,12 +5,14 @@ from openmm import app
 import openmm as mm
 from openmm import unit
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 
 class TestCheckpointReporter(unittest.TestCase):
     def setUp(self):
-        with open('systems/alanine-dipeptide-implicit.pdb') as f:
+        with open(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb')) as f:
             pdb = app.PDBFile(f)
-        forcefield = app.ForceField('amber99sbildn.xml')
+        forcefield = app.ForceField(os.path.join(curr_dir, 'systems', 'amber99sbildn.xml'))
         system = forcefield.createSystem(pdb.topology,
             nonbondedMethod=app.CutoffNonPeriodic, nonbondedCutoff=1.0*unit.nanometers,
             constraints=app.HBonds)

--- a/wrappers/python/tests/TestDcdFile.py
+++ b/wrappers/python/tests/TestDcdFile.py
@@ -6,6 +6,8 @@ from openmm import unit
 from random import random
 import os
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 
 def _read_dcd_header(file):
     import struct
@@ -21,7 +23,7 @@ class TestDCDFile(unittest.TestCase):
     def test_dcd(self):
         """ Test the DCD file """
         fname = tempfile.mktemp(suffix='.dcd')
-        pdbfile = app.PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         natom = len(list(pdbfile.topology.atoms()))
         with open(fname, 'wb') as f:
             dcd = app.DCDFile(f, pdbfile.topology, 0.001)
@@ -32,7 +34,7 @@ class TestDCDFile(unittest.TestCase):
     def testLongTrajectory(self):
         """Test writing a trajectory that has more than 2^31 steps."""
         fname = tempfile.mktemp(suffix='.dcd')
-        pdbfile = app.PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         natom = len(list(pdbfile.topology.atoms()))
         with open(fname, 'wb') as f:
             dcd = app.DCDFile(f, pdbfile.topology, 0.001, interval=1000000000)
@@ -43,7 +45,7 @@ class TestDCDFile(unittest.TestCase):
     def testAppend(self):
         """Test appending to an existing trajectory."""
         fname = tempfile.mktemp(suffix='.dcd')
-        pdb = app.PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = app.ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         
@@ -87,7 +89,7 @@ class TestDCDFile(unittest.TestCase):
     def testAtomSubset(self):
         """Test writing a DCD file containing a subset of atoms"""
         fname = tempfile.mktemp(suffix='.dcd')
-        pdb = app.PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         ff = app.ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
 

--- a/wrappers/python/tests/TestDesmondDMSFile.py
+++ b/wrappers/python/tests/TestDesmondDMSFile.py
@@ -5,21 +5,23 @@ from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestDesmondDMSFile(unittest.TestCase):
     def setUp(self):
         """Set up the tests by loading the input files."""
 
         # alanine dipeptide with explicit water
-        path = os.path.join(os.path.dirname(__file__), 'systems/alanine-dipeptide-explicit-amber99SBILDN-tip3p.dms')
+        path = os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit-amber99SBILDN-tip3p.dms')
         self.dms = DesmondDMSFile(path)
 
         #nabumetone OPLS force field
-        path = os.path.join(os.path.dirname(__file__), 'systems/bcd-nabumetone_lig.dms')
+        path = os.path.join(curr_dir, 'systems', 'bcd-nabumetone_lig.dms')
         self.dms_opls1 = DesmondDMSFile(path)
         
         #beta-cyclodextrin/nabumetone complex OPLS force field
-        path1 = os.path.join(os.path.dirname(__file__), 'systems/bcd-nabumetone_lig.dms')
-        path2 = os.path.join(os.path.dirname(__file__), 'systems/bcd-nabumetone_rcpt.dms')
+        path1 = os.path.join(curr_dir, 'systems', 'bcd-nabumetone_lig.dms')
+        path2 = os.path.join(curr_dir, 'systems', 'bcd-nabumetone_rcpt.dms')
         self.dms_opls2 = DesmondDMSFile([path1,path2])
     
     def test_NonbondedMethod(self):

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -14,6 +14,9 @@ except ImportError:
 import os
 import warnings
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestForceField(unittest.TestCase):
     """Test the ForceField.createSystem() method."""
 
@@ -23,13 +26,13 @@ class TestForceField(unittest.TestCase):
 
         """
         # alanine dipeptide with explicit water
-        self.pdb1 = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.pdb1 = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         self.forcefield1 = ForceField('amber99sb.xml', 'tip3p.xml')
         self.topology1 = self.pdb1.topology
         self.topology1.setUnitCellDimensions(Vec3(2, 2, 2))
 
         # alanine dipeptide with implicit water
-        self.pdb2 = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        self.pdb2 = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         self.forcefield2 = ForceField('amber99sb.xml', 'amber99_obc.xml')
 
 
@@ -258,7 +261,7 @@ class TestForceField(unittest.TestCase):
         """Test that setting the mass of Drude particles works correctly."""
 
         forcefield = ForceField('charmm_polar_2013.xml')
-        pdb = PDBFile('systems/ala_ala_ala.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.pdb'))
         modeller = Modeller(pdb.topology, pdb.positions)
         modeller.addExtraParticles(forcefield)
         system = forcefield.createSystem(modeller.topology, drudeMass=0)
@@ -297,13 +300,13 @@ class TestForceField(unittest.TestCase):
     def test_Forces(self):
         """Compute forces and compare them to ones generated with a previous version of OpenMM to ensure they haven't changed."""
 
-        pdb = PDBFile('systems/lysozyme-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'lysozyme-implicit.pdb'))
         system = self.forcefield2.createSystem(pdb.topology)
         integrator = VerletIntegrator(0.001)
         context = Context(system, integrator)
         context.setPositions(pdb.positions)
         state1 = context.getState(getForces=True)
-        with open('systems/lysozyme-implicit-forces.xml') as input:
+        with open(os.path.join(curr_dir, 'systems', 'lysozyme-implicit-forces.xml')) as input:
             state2 = XmlSerializer.deserialize(input.read())
         numDifferences = 0
         for f1, f2, in zip(state1.getForces().value_in_unit(kilojoules_per_mole/nanometer), state2.getForces().value_in_unit(kilojoules_per_mole/nanometer)):
@@ -327,7 +330,7 @@ class TestForceField(unittest.TestCase):
             context.setPositions(self.pdb2.positions)
             state1 = context.getState(getForces=True)
             if file[i] is not None:
-                with open('systems/alanine-dipeptide-implicit-forces/'+file[i]+'.xml') as infile:
+                with open(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit-forces', file[i]+'.xml')) as infile:
                     state2 = XmlSerializer.deserialize(infile.read())
                 for f1, f2, in zip(state1.getForces().value_in_unit(kilojoules_per_mole/nanometer), state2.getForces().value_in_unit(kilojoules_per_mole/nanometer)):
                     diff = norm(f1-f2)
@@ -607,7 +610,7 @@ class TestForceField(unittest.TestCase):
         ff = ForceField(StringIO(xml))
 
         # Load a water box.
-        prmtop = AmberPrmtopFile('systems/water-box-216.prmtop')
+        prmtop = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'water-box-216.prmtop'))
         top = prmtop.topology
         
         # Building a System should fail, because two templates match each residue.
@@ -1103,10 +1106,9 @@ class TestForceField(unittest.TestCase):
     def test_LennardJonesGenerator(self):
         """ Test the LennardJones generator"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/ions.psf')
-        pdb = PDBFile('systems/ions.pdb')
-        params = CharmmParameterSet('systems/toppar_water_ions.str'
-                                    )
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ions.psf'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ions.pdb'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'toppar_water_ions.str'))
 
         # Box dimensions (found from bounding box)
         psf.setBox(12.009*angstroms,   12.338*angstroms,   11.510*angstroms)
@@ -1266,7 +1268,7 @@ class TestForceField(unittest.TestCase):
  </PeriodicTorsionForce>
 </ForceField>
 """
-        pdb = PDBFile('systems/impropers_ordering_tetrapeptide.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'impropers_ordering_tetrapeptide.pdb'))
         # ff1 uses default ordering of impropers, ff2 uses "amber" for the one
         # problematic improper
         ff1 = ForceField('amber99sbildn.xml')
@@ -1316,7 +1318,7 @@ class TestForceField(unittest.TestCase):
   </Residues>
 </ForceField>
 """
-        pdb = PDBFile('systems/formaldehyde.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'formaldehyde.pdb'))
         # ff1 uses default ordering of impropers, ff2 uses "amber" for the one
         # problematic improper
         ff = ForceField(StringIO(xml))
@@ -1335,7 +1337,7 @@ class TestForceField(unittest.TestCase):
 
     def test_Disulfides(self):
         """Test that various force fields handle disulfides correctly."""
-        pdb = PDBFile('systems/bpti.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'bpti.pdb'))
         for ff in ['amber99sb.xml', 'amber14-all.xml', 'charmm36.xml', 'amberfb15.xml', 'amoeba2013.xml']:
             forcefield = ForceField(ff)
             system = forcefield.createSystem(pdb.topology)
@@ -1370,7 +1372,7 @@ END"""))
 
     def test_CharmmPolar(self):
         """Test the CHARMM polarizable force field."""
-        pdb = PDBFile('systems/ala_ala_ala_drude.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala_drude.pdb'))
         pdb.topology.setUnitCellDimensions(Vec3(3, 3, 3))
         ff = ForceField('charmm_polar_2019.xml')
         system = ff.createSystem(pdb.topology, nonbondedMethod=PME, nonbondedCutoff=1.2*nanometers)
@@ -1452,7 +1454,7 @@ self.scriptExecuted = True
     def test_Glycam(self):
         """Test computing energy with GLYCAM."""
         ff = ForceField('amber14/protein.ff14SB.xml', 'amber14/GLYCAM_06j-1.xml')
-        pdb = PDBFile('systems/glycopeptide.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'glycopeptide.pdb'))
         system = ff.createSystem(pdb.topology)
         for i, f in enumerate(system.getForces()):
             f.setForceGroup(i)
@@ -1474,7 +1476,7 @@ self.scriptExecuted = True
 
     def test_CustomNonbondedGenerator(self):
         """ Test the CustomNonbondedForce generator"""
-        pdb = PDBFile('systems/ions.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ions.pdb'))
         xml = """
 <ForceField>
  <AtomTypes>
@@ -1520,7 +1522,7 @@ self.scriptExecuted = True
         self.assertAlmostEqual(energy1, energy2)
 
     def test_OpcEnergy(self):
-        pdb = PDBFile('systems/opcbox.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'opcbox.pdb'))
         topology, positions = pdb.topology, pdb.positions
         self.assertEqual(len(positions), 864)
         forcefield = ForceField('opc.xml')
@@ -1554,7 +1556,7 @@ self.scriptExecuted = True
         self.assertTrue(abs(energy1 - energy2) < energy_tolerance)
 
     def test_Opc3Energy(self):
-        pdb = PDBFile('systems/opc3box.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'opc3box.pdb'))
         topology, positions = pdb.topology, pdb.positions
         self.assertEqual(len(positions), 648)
         forcefield = ForceField('opc3.xml')
@@ -1596,7 +1598,7 @@ class AmoebaTestForceField(unittest.TestCase):
 
         """
 
-        self.pdb1 = PDBFile('systems/amoeba-ion-in-water.pdb')
+        self.pdb1 = PDBFile(os.path.join(curr_dir, 'systems', 'amoeba-ion-in-water.pdb'))
         self.forcefield1 = ForceField('amoeba2013.xml')
         self.topology1 = self.pdb1.topology
 
@@ -1670,14 +1672,14 @@ class AmoebaTestForceField(unittest.TestCase):
     def test_Forces(self):
         """Compute forces and compare them to ones generated with a previous version of OpenMM to ensure they haven't changed."""
 
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         forcefield = ForceField('amoeba2013.xml', 'amoeba2013_gk.xml')
         system = forcefield.createSystem(pdb.topology, polarization='direct')
         integrator = VerletIntegrator(0.001)
         context = Context(system, integrator, Platform.getPlatform('Reference'))
         context.setPositions(pdb.positions)
         state1 = context.getState(getForces=True)
-        with open('systems/alanine-dipeptide-amoeba-forces.xml') as input:
+        with open(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-amoeba-forces.xml')) as input:
             state2 = XmlSerializer.deserialize(input.read())
         for f1, f2, in zip(state1.getForces().value_in_unit(kilojoules_per_mole/nanometer), state2.getForces().value_in_unit(kilojoules_per_mole/nanometer)):
             diff = norm(f1-f2)
@@ -1700,7 +1702,7 @@ class AmoebaTestForceField(unittest.TestCase):
 
     def test_Amoeba18BPTI(self):
         """Test that AMOEBA18 computes energies correctly for BPTI."""
-        energies = self.computeAmoeba18Energies('systems/bpti.pdb')
+        energies = self.computeAmoeba18Energies(os.path.join(curr_dir, 'systems', 'bpti.pdb'))
 
         # Compare to values computed with Tinker.
 
@@ -1717,7 +1719,7 @@ class AmoebaTestForceField(unittest.TestCase):
 
     def test_Amoeba18Nucleic(self):
         """Test that AMOEBA18 computes energies correctly for DNA and RNA."""
-        energies = self.computeAmoeba18Energies('systems/nucleic.pdb')
+        energies = self.computeAmoeba18Energies(os.path.join(curr_dir, 'systems', 'nucleic.pdb'))
 
         # Compare to values computed with Tinker.
 

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -681,7 +681,7 @@ class TestForceField(unittest.TestCase):
         #
 
         # Load the PDB file.
-        pdb = PDBFile(os.path.join('systems', 'T4-lysozyme-L99A-p-xylene-implicit.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'T4-lysozyme-L99A-p-xylene-implicit.pdb'))
         # Create a ForceField object.
         forcefield = ForceField('amber99sb.xml', 'tip3p.xml', StringIO(simple_ffxml_contents))
         # Add the residue template generator.
@@ -703,7 +703,7 @@ class TestForceField(unittest.TestCase):
         # Test all systems with separate ForceField objects.
         for test in tests:
             # Load the PDB file.
-            pdb = PDBFile(os.path.join('systems', test['pdb_filename']))
+            pdb = PDBFile(os.path.join(curr_dir, 'systems', test['pdb_filename']))
             # Create a ForceField object.
             forcefield = ForceField(StringIO(simple_ffxml_contents))
             # Add the residue template generator.
@@ -719,7 +719,7 @@ class TestForceField(unittest.TestCase):
         forcefield.registerTemplateGenerator(simpleTemplateGenerator)
         for test in tests:
             # Load the PDB file.
-            pdb = PDBFile(os.path.join('systems', test['pdb_filename']))
+            pdb = PDBFile(os.path.join(curr_dir, 'systems', test['pdb_filename']))
             # Parameterize system.
             system = forcefield.createSystem(pdb.topology, nonbondedMethod=test['nonbondedMethod'])
             # TODO: Test energies are finite?
@@ -728,7 +728,7 @@ class TestForceField(unittest.TestCase):
         """Test retrieval of list of residues for which no templates are available."""
 
         # Load the PDB file.
-        pdb = PDBFile(os.path.join('systems', 'T4-lysozyme-L99A-p-xylene-implicit.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'T4-lysozyme-L99A-p-xylene-implicit.pdb'))
         # Create a ForceField object.
         forcefield = ForceField('amber99sb.xml', 'tip3p.xml')
         # Get list of unmatched residues.
@@ -739,7 +739,7 @@ class TestForceField(unittest.TestCase):
         self.assertEqual(unmatched_residues[0].id, '163')
 
         # Load the PDB file.
-        pdb = PDBFile(os.path.join('systems', 'ala_ala_ala.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.pdb'))
         # Create a ForceField object.
         forcefield = ForceField('tip3p.xml')
         # Get list of unmatched residues.
@@ -757,7 +757,7 @@ class TestForceField(unittest.TestCase):
         #
 
         # Load the PDB file.
-        pdb = PDBFile(os.path.join('systems', 'nacl-water.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'nacl-water.pdb'))
         # Create a ForceField object.
         forcefield = ForceField('tip3p.xml')
         # Get list of unmatched residues.
@@ -800,7 +800,7 @@ class TestForceField(unittest.TestCase):
         #
 
         # Load the PDB file.
-        pdb = PDBFile(os.path.join('systems', 'T4-lysozyme-L99A-p-xylene-implicit.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'T4-lysozyme-L99A-p-xylene-implicit.pdb'))
         # Create a ForceField object.
         forcefield = ForceField('amber99sb.xml', 'tip3p.xml', StringIO(simple_ffxml_contents))
         # Get list of unique unmatched residues.
@@ -820,7 +820,7 @@ class TestForceField(unittest.TestCase):
         """Test retrieval of list of templates that match residues in a topology."""
 
         # Load the PDB file.
-        pdb = PDBFile(os.path.join('systems', 'ala_ala_ala.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.pdb'))
         # Create a ForceField object.
         forcefield = ForceField('amber99sb.xml')
         # Get list of matching residue templates.
@@ -873,7 +873,7 @@ class TestForceField(unittest.TestCase):
 
     def test_ScalingFactorCombining(self):
         """ Tests that FFs can be combined if their scaling factors are very close """
-        forcefield = ForceField('amber99sb.xml', os.path.join('systems', 'test_amber_ff.xml'))
+        forcefield = ForceField('amber99sb.xml', os.path.join(curr_dir, 'systems', 'test_amber_ff.xml'))
         # This would raise an exception if it didn't work
 
     def test_MultipleFilesandForceTags(self):
@@ -1251,7 +1251,7 @@ class TestForceField(unittest.TestCase):
 
     def test_Includes(self):
         """Test using a ForceField that includes other files."""
-        forcefield = ForceField(os.path.join('systems', 'ff_with_includes.xml'))
+        forcefield = ForceField(os.path.join(curr_dir, 'systems', 'ff_with_includes.xml'))
         self.assertTrue(len(forcefield._atomTypes) > 10)
         self.assertTrue('spce-O' in forcefield._atomTypes)
         self.assertTrue('HOH' in forcefield._templates)

--- a/wrappers/python/tests/TestGenerators.py
+++ b/wrappers/python/tests/TestGenerators.py
@@ -13,12 +13,14 @@ except ImportError:
 import os
 import warnings
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestGenerators(unittest.TestCase):
     """Test the various generators found in forcefield.py."""
 
     def setUp(self):
         # alanine dipeptide with implicit water
-        self.pdb1 = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        self.pdb1 = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
 
 
     def test_CustomHbondGenerator(self):

--- a/wrappers/python/tests/TestGromacsGroFile.py
+++ b/wrappers/python/tests/TestGromacsGroFile.py
@@ -3,13 +3,16 @@ from openmm.app import *
 from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
+import os
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 class TestGromacsGroFile(unittest.TestCase):
     """Test the Gromacs GRO file parser"""
  
     def test_Triclinic(self):
         """Test parsing a file that describes a triclinic box."""
-        gro = GromacsGroFile('systems/triclinic.gro')
+        gro = GromacsGroFile(os.path.join(curr_dir, 'systems', 'triclinic.gro'))
         self.assertEqual(len(gro.positions), 8)
         expectedPositions = [
             Vec3(1.744, 2.788, 3.162),

--- a/wrappers/python/tests/TestGromacsTopFile.py
+++ b/wrappers/python/tests/TestGromacsTopFile.py
@@ -6,8 +6,12 @@ from openmm.unit import *
 from openmm.app.gromacstopfile import _defaultGromacsIncludeDir
 import openmm.app.element as elem
 from numpy.testing import assert_allclose
+import os
 
 GROMACS_INCLUDE = _defaultGromacsIncludeDir()
+
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 @unittest.skipIf(not os.path.exists(GROMACS_INCLUDE), 'GROMACS is not installed')
 class TestGromacsTopFile(unittest.TestCase):
@@ -18,7 +22,7 @@ class TestGromacsTopFile(unittest.TestCase):
         """Set up the tests by loading the input files."""
 
         # alanine dipeptide with explicit water
-        self.top1 = GromacsTopFile('systems/explicit.top', unitCellDimensions=Vec3(6.223, 6.223, 6.223)*nanometers)
+        self.top1 = GromacsTopFile(os.path.join(curr_dir, 'systems', 'explicit.top'), unitCellDimensions=Vec3(6.223, 6.223, 6.223)*nanometers)
 
     def test_NonbondedMethod(self):
         """Test all six options for the nonbondedMethod parameter."""
@@ -38,8 +42,8 @@ class TestGromacsTopFile(unittest.TestCase):
 
     def test_ff99SBILDN(self):
         """ Test Gromacs topology #define replacement as used in ff99SB-ILDN """
-        top = GromacsTopFile('systems/aidilnaaaaa.top')
-        gro = GromacsGroFile('systems/aidilnaaaaa.gro')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', 'aidilnaaaaa.top'))
+        gro = GromacsGroFile(os.path.join(curr_dir, 'systems', 'aidilnaaaaa.gro'))
         system = top.createSystem()
         for force in system.getForces():
             if isinstance(force, PeriodicTorsionForce):
@@ -52,8 +56,8 @@ class TestGromacsTopFile(unittest.TestCase):
 
     def test_SMOG(self):
         """ Test to ensure that SMOG models can be run without problems """
-        top = GromacsTopFile('systems/2ci2.pdb.top')
-        gro = GromacsGroFile('systems/2ci2.pdb.gro')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', '2ci2.pdb.top'))
+        gro = GromacsGroFile(os.path.join(curr_dir, 'systems', '2ci2.pdb.gro'))
         system = top.createSystem()
 
         context = Context(system, VerletIntegrator(1*femtosecond),
@@ -64,8 +68,8 @@ class TestGromacsTopFile(unittest.TestCase):
 
     def test_ionic(self):
         """Test simulating an ionic liquid"""
-        gro = GromacsGroFile('systems/ionic.gro')
-        top = GromacsTopFile('systems/ionic.top', periodicBoxVectors=gro.getPeriodicBoxVectors())
+        gro = GromacsGroFile(os.path.join(curr_dir, 'systems', 'ionic.gro'))
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', 'ionic.top'), periodicBoxVectors=gro.getPeriodicBoxVectors())
         system = top.createSystem(nonbondedMethod=PME, nonbondedCutoff=1.2)
         for f in system.getForces():
             if isinstance(f, CustomNonbondedForce):
@@ -94,7 +98,7 @@ class TestGromacsTopFile(unittest.TestCase):
 
     def test_SwitchingFunction(self):
         """Test using a switching function."""
-        top = GromacsTopFile('systems/ionic.top')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', 'ionic.top'))
         for distance in (None, 0.8*nanometers):
             system = top.createSystem(nonbondedMethod=CutoffNonPeriodic, switchDistance=distance)
             for f in system.getForces():
@@ -158,8 +162,8 @@ class TestGromacsTopFile(unittest.TestCase):
     def test_VirtualParticle(self):
         """Test virtual particle works correctly."""
 
-        top = GromacsTopFile('systems/bnz.top')
-        gro = GromacsGroFile('systems/bnz.gro')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', 'bnz.top'))
+        gro = GromacsGroFile(os.path.join(curr_dir, 'systems', 'bnz.gro'))
         for atom in top.topology.atoms():
             if atom.name.startswith('C'):
                 self.assertEqual(elem.carbon, atom.element)
@@ -182,7 +186,7 @@ class TestGromacsTopFile(unittest.TestCase):
 
     def test_Vsite3Func1(self):
         """Test a three particle virtual site."""
-        top = GromacsTopFile('systems/tip4pew.top')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', 'tip4pew.top'))
         system = top.createSystem()
         self.assertEqual(3, system.getNumConstraints())
         self.assertTrue(system.isVirtualSite(3))
@@ -197,7 +201,7 @@ class TestGromacsTopFile(unittest.TestCase):
 
     def test_Vsite3Func4(self):
         """Test a three particle virtual site."""
-        top = GromacsTopFile('systems/tip5p.top')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', 'tip5p.top'))
         system = top.createSystem()
         self.assertEqual(3, system.getNumConstraints())
         for i in (3, 4):
@@ -217,8 +221,8 @@ class TestGromacsTopFile(unittest.TestCase):
     def test_GROMOS(self):
         """Test a system using the GROMOS 54a7 force field."""
 
-        top = GromacsTopFile('systems/1ppt.top')
-        gro = GromacsGroFile('systems/1ppt.gro')
+        top = GromacsTopFile(os.path.join(curr_dir, 'systems', '1ppt.top'))
+        gro = GromacsGroFile(os.path.join(curr_dir, 'systems', '1ppt.gro'))
         system = top.createSystem()
         for i, f in enumerate(system.getForces()):
             f.setForceGroup(i)

--- a/wrappers/python/tests/TestIntegrators.py
+++ b/wrappers/python/tests/TestIntegrators.py
@@ -6,6 +6,10 @@ from openmm import *
 from openmm.app import *
 from openmm.unit import *
 import math, random
+import os
+
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 class TestIntegrators(unittest.TestCase):
     """Test Python Integrator classes"""
@@ -13,7 +17,7 @@ class TestIntegrators(unittest.TestCase):
     def testMTSIntegratorExplicit(self):
         """Test the MTS integrator on an explicit solvent system"""
         # Create a periodic solvated system with PME
-        pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         ff = ForceField('amber99sbildn.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology, nonbondedMethod=PME)
 
@@ -100,7 +104,7 @@ class TestIntegrators(unittest.TestCase):
     def testBadGroups(self):
         """Test the MTS integrator with bad force group substeps."""
         # Create a periodic solvated system with PME
-        pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         ff = ForceField('amber99sbildn.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology, nonbondedMethod=PME)
 
@@ -124,7 +128,7 @@ class TestIntegrators(unittest.TestCase):
     def testMTSLangevinIntegrator(self):
         """Test the MTSLangevinIntegrator on an explicit solvent system"""
         # Create a periodic solvated system with PME
-        pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         ff = ForceField('amber99sbildn.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology, nonbondedMethod=PME)
 
@@ -188,7 +192,7 @@ class TestIntegrators(unittest.TestCase):
 
     def testNoseHooverIntegrator(self):
         """Test partial thermostating in the NoseHooverIntegrator (only API)"""
-        pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         ff = ForceField('amber99sbildn.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology, nonbondedMethod=PME)
 
@@ -203,9 +207,9 @@ class TestIntegrators(unittest.TestCase):
     def testDrudeNoseHooverIntegrator(self):
         """Test the DrudeNoseHooverIntegrator"""
         warnings.filterwarnings('ignore', category=CharmmPSFWarning)
-        psf = CharmmPsfFile('systems/ala3_solv_drude.psf')
-        crd = CharmmCrdFile('systems/ala3_solv_drude.crd')
-        params = CharmmParameterSet('systems/toppar_drude_master_protein_2013e.str')
+        psf = CharmmPsfFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.psf'))
+        crd = CharmmCrdFile(os.path.join(curr_dir, 'systems', 'ala3_solv_drude.crd'))
+        params = CharmmParameterSet(os.path.join(curr_dir, 'systems', 'toppar_drude_master_protein_2013e.str'))
         # Box dimensions (cubic box)
         psf.setBox(33.2*angstroms, 33.2*angstroms, 33.2*angstroms)
 

--- a/wrappers/python/tests/TestModeller.py
+++ b/wrappers/python/tests/TestModeller.py
@@ -6,29 +6,33 @@ from validateModeller import *
 from openmm.app import *
 from openmm import *
 from openmm.unit import *
+import os
 
 if sys.version_info >= (3, 0):
     from io import StringIO
 else:
     from cStringIO import StringIO
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestModeller(unittest.TestCase):
     """ Test the Modeller class. """
 
     def setUp(self):
         # load the alanine dipeptide pdb file
-        self.pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         self.topology_start = self.pdb.topology
         self.positions = self.pdb.positions
         self.forcefield = ForceField('amber10.xml', 'tip3p.xml')
 
         # load the T4-lysozyme-L99A receptor pdb file
-        self.pdb2 = PDBFile('systems/lysozyme-implicit.pdb')
+        self.pdb2 = PDBFile(os.path.join(curr_dir, 'systems', 'lysozyme-implicit.pdb'))
         self.topology_start2 = self.pdb2.topology
         self.positions2 = self.pdb2.positions
 
         # load the metallothionein pdb file
-        self.pdb3 =  PDBFile('systems/1T2Y.pdb')
+        self.pdb3 =  PDBFile(os.path.join(curr_dir, 'systems', '1T2Y.pdb'))
         self.topology_start3 = self.pdb3.topology
         self.positions3 = self.pdb3.positions
 
@@ -134,7 +138,7 @@ class TestModeller(unittest.TestCase):
         """ Test the add() method. """
 
         # load the methanol-box pdb file
-        pdb2 = PDBFile('systems/methanol-box.pdb')
+        pdb2 = PDBFile(os.path.join(curr_dir, 'systems', 'methanol-box.pdb'))
         topology_toAdd = pdb2.topology
         positions_toAdd = pdb2.positions
 
@@ -969,7 +973,7 @@ class TestModeller(unittest.TestCase):
 
     def test_addHydrogensGlycam(self):
         """Test adding hydrogens for GLYCAM."""
-        pdb = PDBFile('systems/glycopeptide.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'glycopeptide.pdb'))
         Modeller.loadHydrogenDefinitions('glycam-hydrogens.xml')
         modeller = Modeller(pdb.topology, pdb.positions)
         hydrogens = [a for a in modeller.topology.atoms() if a.element == element.hydrogen]
@@ -987,7 +991,7 @@ class TestModeller(unittest.TestCase):
 
     def test_addSpecificHydrogens(self):
         """Test specifying exactly which hydrogens to add."""
-        pdb = PDBFile('systems/glycopeptide.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'glycopeptide.pdb'))
         variants = [None]*pdb.topology.getNumResidues()
         for residue in pdb.topology.residues():
             if residue.name != 'ALA':
@@ -1185,7 +1189,7 @@ class TestModeller(unittest.TestCase):
     def test_addMembrane(self):
         """Test adding a membrane to a realistic system."""
 
-        mol = PDBxFile('systems/gpcr.cif')
+        mol = PDBxFile(os.path.join(curr_dir, 'systems', 'gpcr.cif'))
         modeller = Modeller(mol.topology, mol.positions)
         ff = ForceField('amber14-all.xml', 'amber14/tip3p.xml')
 
@@ -1235,7 +1239,7 @@ class TestModeller(unittest.TestCase):
         """
 
         # Given: an isolated molecule
-        pdb = PDBFile("systems/alanine-dipeptide-implicit.pdb")
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         topology, positions = pdb.topology, pdb.positions
         topology.setUnitCellDimensions(Vec3(3.5, 3.5, 3.5) * nanometers)
         # with some bonds carrying type and order information
@@ -1282,7 +1286,7 @@ class TestModeller(unittest.TestCase):
         self.assertIn((Double, 2.0), [(b.type, b.order) for b in modeller.topology.bonds()])
 
         # When (6): add a modeller (which also bears some bond info)
-        to_add = PDBFile('systems/methanol-box.pdb')
+        to_add = PDBFile(os.path.join(curr_dir, 'systems', 'methanol-box.pdb'))
         topology_to_add = to_add.topology
         positions_to_add = to_add.positions
         # add a dummy bond to the "to_add" system to check that it also is preserved

--- a/wrappers/python/tests/TestNumpyCompatibility.py
+++ b/wrappers/python/tests/TestNumpyCompatibility.py
@@ -2,6 +2,7 @@ import unittest
 from openmm import app
 import openmm as mm
 from openmm import unit
+import os
 try:
     import numpy as np
     NUMPY_IMPORT_FAILED = False
@@ -9,11 +10,13 @@ except ImportError:
     NUMPY_IMPORT_FAILED = True
 
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 @unittest.skipIf(NUMPY_IMPORT_FAILED, 'Numpy is not installed')
 class TestNumpyCompatibility(unittest.TestCase):
 
     def setUp(self):
-        prmtop = app.AmberPrmtopFile('systems/water-box-216.prmtop')
+        prmtop = app.AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'water-box-216.prmtop'))
 
         system = prmtop.createSystem(nonbondedMethod=app.PME,
                                      nonbondedCutoff=0.9*unit.nanometers,

--- a/wrappers/python/tests/TestPatches.py
+++ b/wrappers/python/tests/TestPatches.py
@@ -10,6 +10,9 @@ except ImportError:
     from io import StringIO
 import os
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestPatches(unittest.TestCase):
     """Test ForceFields that use patches."""
 
@@ -260,7 +263,7 @@ class TestPatches(unittest.TestCase):
  </NonbondedForce>
 </ForceField>"""
         ff = ForceField(StringIO(xml))
-        pdb = PDBFile(os.path.join('systems', 'ala_ala_ala.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.pdb'))
         system = ff.createSystem(pdb.topology)
         nb = system.getForce(0)
         expectedCharges = [0.1414, 0.2719, 0.2719, 0.2719, 0.0337, 0.0823, 0.0337, 0.0603, 0.0603, 0.0603, 0.5973, -0.5679,
@@ -270,7 +273,7 @@ class TestPatches(unittest.TestCase):
             self.assertEqual(expectedCharges[i], nb.getParticleParameters(i)[0].value_in_unit(elementary_charge))
 
     def testDisulfidePatch(self):
-        pdb = PDBFile(os.path.join('systems', 'bpti.pdb'))
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'bpti.pdb'))
         ff = ForceField('amber99sb.xml')
         system1 = ff.createSystem(pdb.topology)
         

--- a/wrappers/python/tests/TestPdbFile.py
+++ b/wrappers/python/tests/TestPdbFile.py
@@ -5,6 +5,10 @@ from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
 from io import StringIO
+import os
+
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestPdbFile(unittest.TestCase):
@@ -12,7 +16,7 @@ class TestPdbFile(unittest.TestCase):
 
     def test_Triclinic(self):
         """Test parsing a file that describes a triclinic box."""
-        pdb = PDBFile('systems/triclinic.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'triclinic.pdb'))
         self.assertEqual(len(pdb.positions), 8)
         expectedPositions = [
             Vec3(1.744, 2.788, 3.162),
@@ -56,7 +60,7 @@ class TestPdbFile(unittest.TestCase):
                 self.assertEqual(atom1.name, atom2.name)
                 self.assertEqual(atom1.residue.name, atom2.residue.name)
 
-        pdb1 = PDBFile('systems/triclinic.pdb')
+        pdb1 = PDBFile(os.path.join(curr_dir, 'systems', 'triclinic.pdb'))
 
         # First try writing to an open file object.
 
@@ -78,13 +82,13 @@ class TestPdbFile(unittest.TestCase):
 
     def test_BinaryStream(self):
         """Test reading a stream that was opened in binary mode."""
-        with open('systems/triclinic.pdb', 'rb') as infile:
+        with open(os.path.join(curr_dir, 'systems', 'triclinic.pdb'), 'rb') as infile:
             pdb = PDBFile(infile)
         self.assertEqual(len(pdb.positions), 8)
 
     def test_ExtraParticles(self):
         """Test reading, and writing and re-reading of a file containing extra particle atoms."""
-        pdb = PDBFile('systems/tip5p.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'tip5p.pdb'))
         for atom in pdb.topology.atoms():
             if atom.index > 2:
                 self.assertEqual(None, atom.element)
@@ -99,7 +103,7 @@ class TestPdbFile(unittest.TestCase):
     def test_AltLocs(self):
         """Test reading a file that includes AltLocs"""
         for filename in ['altlocs.pdb', 'altlocs2.pdb']:
-            pdb = PDBFile(f'systems/{filename}')
+            pdb = PDBFile(os.path.join(curr_dir, 'systems', filename))
             self.assertEqual(1, pdb.topology.getNumResidues())
             self.assertEqual(19, pdb.topology.getNumAtoms())
             self.assertEqual(19, len(pdb.positions))
@@ -107,7 +111,7 @@ class TestPdbFile(unittest.TestCase):
 
     def test_FormalCharges(self):
         """Test reading, and writing and re-reading of a file containing formal charges."""
-        pdb = PDBFile('systems/formal-charges.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'formal-charges.pdb'))
         for atom in pdb.topology.atoms():
             if atom.index == 8:
                 self.assertEqual(+1, atom.formalCharge)

--- a/wrappers/python/tests/TestPdbReporter.py
+++ b/wrappers/python/tests/TestPdbReporter.py
@@ -7,6 +7,9 @@ from openmm.unit.unit_math import norm
 import os
 import gc
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 def assertVecAlmostEqual(p1, p2, tol=1e-7):
     unit = p1.unit
     p1 = p1.value_in_unit(unit)
@@ -19,7 +22,7 @@ def assertVecAlmostEqual(p1, p2, tol=1e-7):
 
 class TestPDBReporter(unittest.TestCase):
     def setUp(self):
-        self.pdb = app.PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         self.forcefield = app.ForceField('amber99sbildn.xml','tip3p.xml')
         self.system = self.forcefield.createSystem(self.pdb.topology, nonbondedMethod=app.CutoffNonPeriodic, constraints=app.HBonds)
 
@@ -117,7 +120,7 @@ class TestPDBReporter(unittest.TestCase):
 
         # use a testcase that has CONECT records in the input pdb file
         ff = app.ForceField('amber14/protein.ff14SB.xml', 'amber14/GLYCAM_06j-1.xml','amber14/tip3pfb.xml')
-        pdb = app.PDBFile('systems/glycopeptide.pdb')
+        pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'glycopeptide.pdb'))
 
         # add in water molecules
         modeller = app.Modeller(pdb.topology, pdb.positions)
@@ -157,7 +160,7 @@ class TestPDBReporter(unittest.TestCase):
 
 class TestPDBxReporter(unittest.TestCase):
     def setUp(self):
-        self.pdb = app.PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         self.forcefield = app.ForceField('amber99sbildn.xml','tip3p.xml')
         self.system = self.forcefield.createSystem(self.pdb.topology, nonbondedMethod=app.CutoffNonPeriodic, constraints=app.HBonds)
 
@@ -255,7 +258,7 @@ class TestPDBxReporter(unittest.TestCase):
 
         # use a testcase that has CONECT records in the input pdb file
         ff = app.ForceField('amber14/protein.ff14SB.xml', 'amber14/GLYCAM_06j-1.xml','amber14/tip3pfb.xml')
-        pdb = app.PDBFile('systems/glycopeptide.pdb')
+        pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'glycopeptide.pdb'))
 
         # add in water molecules
         modeller = app.Modeller(pdb.topology, pdb.positions)

--- a/wrappers/python/tests/TestPdbxFile.py
+++ b/wrappers/python/tests/TestPdbxFile.py
@@ -7,13 +7,16 @@ import openmm.app.element as elem
 import os
 from io import StringIO
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestPdbxFile(unittest.TestCase):
     """Test the PDBx/mmCIF file parser"""
 
     def test_FormatConversion(self):
         """Test conversion from PDB to PDBx"""
 
-        mol = PDBFile('systems/ala_ala_ala.pdb')
+        mol = PDBFile(os.path.join(curr_dir, 'systems', 'ala_ala_ala.pdb'))
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, 'temp.pdbx')
             PDBxFile.writeFile(mol.topology, mol.positions, filename, keepIds=True)
@@ -25,7 +28,7 @@ class TestPdbxFile(unittest.TestCase):
 
     def test_Triclinic(self):
         """Test parsing a file that describes a triclinic box."""
-        pdb = PDBxFile('systems/triclinic.pdbx')
+        pdb = PDBxFile(os.path.join(curr_dir, 'systems', 'triclinic.pdbx'))
         self.assertEqual(len(pdb.positions), 8)
         expectedPositions = [
             Vec3(1.744, 2.788, 3.162),
@@ -66,11 +69,11 @@ class TestPdbxFile(unittest.TestCase):
 
     def testReporterImplicit(self):
         """ Tests the PDBxReporter without PBC """
-        parm = AmberPrmtopFile('systems/alanine-dipeptide-implicit.prmtop')
+        parm = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.prmtop'))
         system = parm.createSystem()
         sim = Simulation(parm.topology, system, VerletIntegrator(1*femtoseconds),
                          Platform.getPlatform('Reference'))
-        sim.context.setPositions(PDBFile('systems/alanine-dipeptide-implicit.pdb').getPositions())
+        sim.context.setPositions(PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb')).getPositions())
         sim.reporters.append(PDBxReporter('test.cif', 1))
         sim.step(10)
         pdb = PDBxFile('test.cif')
@@ -98,11 +101,11 @@ class TestPdbxFile(unittest.TestCase):
 
     def testReporterExplicit(self):
         """ Tests the PDBxReporter with PBC """
-        parm = AmberPrmtopFile('systems/alanine-dipeptide-explicit.prmtop')
+        parm = AmberPrmtopFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.prmtop'))
         system = parm.createSystem(nonbondedCutoff=1.0, nonbondedMethod=PME)
         sim = Simulation(parm.topology, system, VerletIntegrator(1*femtoseconds),
                          Platform.getPlatform('Reference'))
-        orig_pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        orig_pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         sim.context.setPositions(orig_pdb.getPositions())
         sim.context.setPeriodicBoxVectors(*parm.topology.getPeriodicBoxVectors())
         sim.reporters.append(PDBxReporter('test.cif', 1))
@@ -132,7 +135,7 @@ class TestPdbxFile(unittest.TestCase):
 
     def testBonds(self):
         """Test reading and writing a file that includes bonds."""
-        pdb = PDBFile('systems/methanol_ions.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'methanol_ions.pdb'))
         output = StringIO()
         PDBxFile.writeFile(pdb.topology, pdb.positions, output)
         input = StringIO(output.getvalue())
@@ -146,7 +149,7 @@ class TestPdbxFile(unittest.TestCase):
 
     def testMultiChain(self):
         """Test reading and writing a file that includes multiple chains"""
-        cif_ori = PDBxFile('systems/multichain.pdbx')
+        cif_ori = PDBxFile(os.path.join(curr_dir, 'systems', 'multichain.pdbx'))
 
         output = StringIO()
         PDBxFile.writeFile(cif_ori.topology, cif_ori.positions, output, keepIds=True)
@@ -162,7 +165,7 @@ class TestPdbxFile(unittest.TestCase):
 
     def testInsertionCodes(self):
         """Test reading a file that uses insertion codes."""
-        pdbx = PDBxFile('systems/insertions.pdbx')
+        pdbx = PDBxFile(os.path.join(curr_dir, 'systems', 'insertions.pdbx'))
         residues = list(pdbx.topology.residues())
         self.assertEqual(7, len(residues))
         names = ['PHE', 'ASP', 'LYS', 'ILE', 'LYS', 'ASN', 'TRP']

--- a/wrappers/python/tests/TestPickle.py
+++ b/wrappers/python/tests/TestPickle.py
@@ -8,6 +8,10 @@ import openmm.app.element as elem
 import openmm.app.forcefield as forcefield
 import copy
 import pickle
+import os
+
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 class TestPickle(unittest.TestCase):
     """Pickling / deepcopy of OpenMM objects."""
@@ -18,13 +22,13 @@ class TestPickle(unittest.TestCase):
 
         """
         # alanine dipeptide with explicit water
-        self.pdb1 = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        self.pdb1 = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         self.forcefield1 = ForceField('amber99sb.xml', 'tip3p.xml')
         self.topology1 = self.pdb1.topology
         self.topology1.setUnitCellDimensions(Vec3(2, 2, 2))
 
         # alalnine dipeptide with implicit water
-        self.pdb2 = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        self.pdb2 = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         self.forcefield2 = ForceField('amber99sb.xml', 'amber99_obc.xml')
 
     def check_copy(self, object, object_copy):

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -4,13 +4,17 @@ from datetime import datetime, timedelta
 from openmm import *
 from openmm.app import *
 from openmm.unit import *
+import os
+
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 class TestSimulation(unittest.TestCase):
     """Test the Simulation class"""
 
     def testCheckpointing(self):
         """Test that checkpointing works correctly."""
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         integrator = VerletIntegrator(0.001*picoseconds)
@@ -44,7 +48,7 @@ class TestSimulation(unittest.TestCase):
 
     def testLoadFromXML(self):
         """ Test creating a Simulation from XML files """
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         integrator = VerletIntegrator(0.001*picoseconds)
@@ -67,7 +71,7 @@ class TestSimulation(unittest.TestCase):
 
     def testSaveState(self):
         """Test that saving States works correctly."""
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         integrator = VerletIntegrator(0.001*picoseconds)
@@ -100,7 +104,7 @@ class TestSimulation(unittest.TestCase):
 
     def testStep(self):
         """Test the step() method."""
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         integrator = VerletIntegrator(0.001*picoseconds)
@@ -123,7 +127,7 @@ class TestSimulation(unittest.TestCase):
 
     def testRunForClockTime(self):
         """Test the runForClockTime() method."""
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         integrator = VerletIntegrator(0.001*picoseconds)
@@ -167,7 +171,7 @@ class TestSimulation(unittest.TestCase):
 
     def testWrappedCoordinates(self):
         """Test generating reports with and without wrapped coordinates."""
-        pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology, nonbondedMethod=CutoffPeriodic, constraints=HBonds)
         integrator = LangevinIntegrator(300*kelvin, 1/picosecond, 0.002*picoseconds)
@@ -199,7 +203,7 @@ class TestSimulation(unittest.TestCase):
 
     def testMinimizationReporter(self):
         """Test invoking a reporter during minimization."""
-        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        pdb = PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         ff = ForceField('amber99sb.xml', 'tip3p.xml')
         system = ff.createSystem(pdb.topology)
         integrator = LangevinIntegrator(300*kelvin, 1/picosecond, 0.002*picoseconds)

--- a/wrappers/python/tests/TestStateDataReporter.py
+++ b/wrappers/python/tests/TestStateDataReporter.py
@@ -5,10 +5,11 @@ import openmm as mm
 from openmm import unit
 import os
 
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 class TestStateDataReporter(unittest.TestCase):
     def setUp(self):
-        self.pdb = app.PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        self.pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
         self.forcefield = app.ForceField('amber99sbildn.xml')
         self.system = self.forcefield.createSystem(self.pdb.topology, nonbondedMethod=app.CutoffNonPeriodic, constraints=app.HBonds)
 

--- a/wrappers/python/tests/TestTopology.py
+++ b/wrappers/python/tests/TestTopology.py
@@ -5,10 +5,14 @@ from openmm.app import *
 from openmm import *
 from openmm.unit import *
 import openmm.app.element as elem
+import os
 if sys.version_info >= (3, 0):
     from io import StringIO
 else:
     from cStringIO import StringIO
+
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestTopology(unittest.TestCase):
@@ -25,7 +29,7 @@ class TestTopology(unittest.TestCase):
 
     def test_getters(self):
         """Test getters for number of atoms, residues, chains."""
-        self.check_pdbfile('systems/1T2Y.pdb', 271, 25, 1)
+        self.check_pdbfile(os.path.join(curr_dir, 'systems', '1T2Y.pdb'), 271, 25, 1)
 
     def test_bondtype_singleton(self):
         """ Tests that the bond types are really singletons """

--- a/wrappers/python/tests/TestXtcFile.py
+++ b/wrappers/python/tests/TestXtcFile.py
@@ -10,12 +10,15 @@ import openmm as mm
 import numpy as np
 from openmm.app.internal.xtc_utils import read_xtc
 
+
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+
 class TestXtcFile(unittest.TestCase):
     def test_xtc_triclinic(self):
         """Test the XTC file by writing a trajectory and reading it back. Using a triclinic box"""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdbfile = app.PDBFile("systems/alanine-dipeptide-implicit.pdb")
+            pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
             # Set some arbitrary size for the unit cell so that a box is included in the trajectory
             pdbfile.topology.setUnitCellDimensions([10, 10, 10])
             natom = len(list(pdbfile.topology.atoms()))
@@ -57,7 +60,7 @@ class TestXtcFile(unittest.TestCase):
         """Test the XTC file by writing a trajectory and reading it back. Using a cubic box"""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdbfile = app.PDBFile("systems/alanine-dipeptide-implicit.pdb")
+            pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
             # Set some arbitrary size for the unit cell so that a box is included in the trajectory
             pdbfile.topology.setUnitCellDimensions([10, 10, 10])
             natom = len(list(pdbfile.topology.atoms()))
@@ -95,7 +98,7 @@ class TestXtcFile(unittest.TestCase):
         """Test the XTC file by writing a trajectory and reading it back. Letting the box be set from the topology"""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdbfile = app.PDBFile("systems/alanine-dipeptide-implicit.pdb")
+            pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
             # Set some arbitrary size for the unit cell so that a box is included in the trajectory
             unitCell = mm.Vec3(random(), random(), random()) * unit.nanometers
             pdbfile.topology.setUnitCellDimensions(unitCell)
@@ -139,7 +142,7 @@ class TestXtcFile(unittest.TestCase):
         """Test the XTC file by writing a trajectory and reading it back. Using a system size below the compression threshold"""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdbfile = app.PDBFile("systems/ions.pdb")
+            pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'ions.pdb'))
             # Set some arbitrary size for the unit cell so that a box is included in the trajectory
             pdbfile.topology.setUnitCellDimensions([10, 10, 10])
             natom = len(list(pdbfile.topology.atoms()))
@@ -181,7 +184,7 @@ class TestXtcFile(unittest.TestCase):
         """Test writing a trajectory that has more than 2^31 steps."""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdbfile = app.PDBFile("systems/alanine-dipeptide-implicit.pdb")
+            pdbfile = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
             natom = len(list(pdbfile.topology.atoms()))
             xtc = app.XTCFile(fname, pdbfile.topology, 0.001, interval=1000000000)
             for i in range(5):
@@ -196,7 +199,7 @@ class TestXtcFile(unittest.TestCase):
         """Test appending to an existing trajectory."""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdb = app.PDBFile("systems/alanine-dipeptide-implicit.pdb")
+            pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-implicit.pdb'))
             ff = app.ForceField("amber99sb.xml", "tip3p.xml")
             system = ff.createSystem(pdb.topology)
 
@@ -249,7 +252,7 @@ class TestXtcFile(unittest.TestCase):
         """Test writing an XTC file containing a subset of atoms"""
         with tempfile.TemporaryDirectory() as temp:
             fname = os.path.join(temp, 'traj.xtc')
-            pdb = app.PDBFile("systems/alanine-dipeptide-explicit.pdb")
+            pdb = app.PDBFile(os.path.join(curr_dir, 'systems', 'alanine-dipeptide-explicit.pdb'))
             ff = app.ForceField("amber99sb.xml", "tip3p.xml")
             system = ff.createSystem(pdb.topology)
 


### PR DESCRIPTION
I changed all `systems/` paths in the tests to be relative to the test files, so that the tests can be executed from any directory, not just from inside the tests directory. It's useful for some python tools which execute pytest from the main directory of the project like `cibuildwheel`, but it's also generally good practice I believe.