### PR TITLE
Uniform interface for FFTs

### DIFF
--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -37,6 +37,7 @@
 #include "openmm/common/ComputeForceInfo.h"
 #include "openmm/common/ComputeProgram.h"
 #include "openmm/common/ComputeVectorTypes.h"
+#include "openmm/common/FFT3D.h"
 #include "openmm/common/IntegrationUtilities.h"
 #include "openmm/common/NonbondedUtilities.h"
 #include "openmm/Vec3.h"
@@ -474,6 +475,16 @@ public:
      * when it is no longer needed.
      */
     virtual NonbondedUtilities* createNonbondedUtilities() = 0;
+    /**
+     * Create an object for performing 3D FFTs.  The caller is responsible for deleting
+     * the object when it is no longer needed.
+     *
+     * @param xsize   the first dimension of the data sets on which FFTs will be performed
+     * @param ysize   the second dimension of the data sets on which FFTs will be performed
+     * @param zsize   the third dimension of the data sets on which FFTs will be performed
+     * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
+     */
+    virtual FFT3D* createFFT(int xsize, int ysize, int zsize, bool realToComplex=false) = 0;
     /**
      * Get the smallest legal size for a dimension of the grid.
      */

--- a/platforms/common/include/openmm/common/FFT3D.h
+++ b/platforms/common/include/openmm/common/FFT3D.h
@@ -1,5 +1,5 @@
-#ifndef __OPENMM_CUDAFFT3D_H__
-#define __OPENMM_CUDAFFT3D_H__
+#ifndef __OPENMM_FFT3D_H__
+#define __OPENMM_FFT3D_H__
 
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
@@ -27,18 +27,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#include "openmm/common/FFT3D.h"
 #include "openmm/common/ArrayInterface.h"
-#include <cuda.h>
-#include <cufft.h>
 
 namespace OpenMM {
 
-class CudaContext;
-
 /**
- * This class performs three dimensional Fast Fourier Transforms.  It is implemented
- * using cuFFT.
+ * This class defines a uniform API for three dimensional Fast Fourier Transforms.
+ * Each platform provides its own implementation.  Instances can be created by
+ * calling createFFT() on a ComputeContext.
  *
  * FFTs tend to be most efficient when the size of each dimension is a product of
  * small prime factors.  You can call findLegalFFTDimension() on the ComputeContext
@@ -50,23 +46,10 @@ class CudaContext;
  * multiply every value of the original data set by the total number of data points.
  */
 
-class OPENMM_EXPORT_COMMON CudaFFT3D : public FFT3D {
+class OPENMM_EXPORT_COMMON FFT3D {
 public:
-    /**
-     * Create a CudaFFT3D object for performing transforms of a particular size.
-     *
-     * @param context the context in which to perform calculations
-     * @param xsize   the first dimension of the data sets on which FFTs will be performed
-     * @param ysize   the second dimension of the data sets on which FFTs will be performed
-     * @param zsize   the third dimension of the data sets on which FFTs will be performed
-     * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
-     */
-    CudaFFT3D(CudaContext& context, int xsize, int ysize, int zsize, bool realToComplex=false);
-    ~CudaFFT3D();
-    /**
-     * Set the stream to perform the FFT on.
-     */
-    void setStream(CUstream stream);
+    virtual ~FFT3D() {
+    }
     /**
      * Perform a Fourier transform.  The transform cannot be done in-place: the input and output
      * arrays must be different.  Also, the input array is used as workspace, so its contents
@@ -80,14 +63,9 @@ public:
      * @param out      on exit, this contains the transformed data
      * @param forward  true to perform a forward transform, false to perform an inverse transform
      */
-    void execFFT(ArrayInterface& in, ArrayInterface& out, bool forward = true);
-private:
-    CudaContext& context;
-    cufftHandle fftForward;
-    cufftHandle fftBackward;
-    bool realToComplex, hasInitialized;
+    virtual void execFFT(ArrayInterface& in, ArrayInterface& out, bool forward=true) = 0;
 };
 
 } // namespace OpenMM
 
-#endif // __OPENMM_CUDAFFT3D_H__
+#endif // __OPENMM_FFT3D_H__

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2023 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -42,6 +42,7 @@
 #include "CudaArray.h"
 #include "CudaBondedUtilities.h"
 #include "CudaExpressionUtilities.h"
+#include "CudaFFT3D.h"
 #include "CudaIntegrationUtilities.h"
 #include "CudaNonbondedUtilities.h"
 #include "CudaPlatform.h"
@@ -508,6 +509,16 @@ public:
     CudaNonbondedUtilities* createNonbondedUtilities() {
         return new CudaNonbondedUtilities(*this);
     }
+    /**
+     * Create an object for performing 3D FFTs.  The caller is responsible for deleting
+     * the object when it is no longer needed.
+     *
+     * @param xsize   the first dimension of the data sets on which FFTs will be performed
+     * @param ysize   the second dimension of the data sets on which FFTs will be performed
+     * @param zsize   the third dimension of the data sets on which FFTs will be performed
+     * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
+     */
+    CudaFFT3D* createFFT(int xsize, int ysize, int zsize, bool realToComplex=false);
     /**
      * This should be called by the Integrator from its own initialize() method.
      * It ensures all contexts are fully initialized.

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -35,7 +35,6 @@
 #include "openmm/kernels.h"
 #include "openmm/System.h"
 #include "openmm/common/CommonKernels.h"
-#include <cufft.h>
 
 namespace OpenMM {
 
@@ -189,11 +188,7 @@ private:
     CUstream pmeStream;
     CUevent pmeSyncEvent, paramsSyncEvent;
     CudaFFT3D* fft;
-    cufftHandle fftForward;
-    cufftHandle fftBackward;
     CudaFFT3D* dispersionFft;
-    cufftHandle dispersionFftForward;
-    cufftHandle dispersionFftBackward;
     CUfunction computeParamsKernel, computeExclusionParamsKernel, computePlasmaCorrectionKernel;
     CUfunction ewaldSumsKernel;
     CUfunction ewaldForcesKernel;
@@ -217,7 +212,7 @@ private:
     int interpolateForceThreads;
     int gridSizeX, gridSizeY, gridSizeZ;
     int dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ;
-    bool hasCoulomb, hasLJ, useFixedPointChargeSpreading, usePmeStream, useCudaFFT, doLJPME, usePosqCharges, recomputeParams, hasOffsets;
+    bool hasCoulomb, hasLJ, useFixedPointChargeSpreading, usePmeStream, doLJPME, usePosqCharges, recomputeParams, hasOffsets;
     NonbondedMethod nonbondedMethod;
     static const int PmeOrder = 5;
 };

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2024 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -435,6 +435,10 @@ void CudaContext::initialize() {
 
 void CudaContext::initializeContexts() {
     getPlatformData().initializeContexts(system);
+}
+
+CudaFFT3D* CudaContext::createFFT(int xsize, int ysize, int zsize, bool realToComplex) {
+    return new CudaFFT3D(*this, xsize, ysize, zsize, realToComplex);
 }
 
 void CudaContext::setAsCurrent() {

--- a/platforms/cuda/src/CudaFFT3D.cpp
+++ b/platforms/cuda/src/CudaFFT3D.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -26,326 +26,81 @@
 
 #include "CudaFFT3D.h"
 #include "CudaContext.h"
-#include "CudaKernelSources.h"
-#include "SimTKOpenMMRealType.h"
-#include <map>
-#include <sstream>
-#include <string>
 
 using namespace OpenMM;
-using namespace std;
 
 CudaFFT3D::CudaFFT3D(CudaContext& context, int xsize, int ysize, int zsize, bool realToComplex) :
-        context(context), xsize(xsize), ysize(ysize), zsize(zsize) {
-    packRealAsComplex = false;
-    int packedXSize = xsize;
-    int packedYSize = ysize;
-    int packedZSize = zsize;
+        context(context), realToComplex(realToComplex), hasInitialized(false) {
+    cufftType type1, type2;
     if (realToComplex) {
-        // If any axis size is even, we can pack the real values into a complex grid that is only half as large.
-        // Look for an appropriate axis.
-        
-        packRealAsComplex = true;
-        int packedAxis, bufferSize;
-        if (xsize%2 == 0) {
-            packedAxis = 0;
-            packedXSize /= 2;
-            bufferSize = packedXSize;
+        if (context.getUseDoublePrecision()) {
+            type1 = CUFFT_D2Z;
+            type2 = CUFFT_Z2D;
         }
-        else if (ysize%2 == 0) {
-            packedAxis = 1;
-            packedYSize /= 2;
-            bufferSize = packedYSize;
+        else {
+            type1 = CUFFT_R2C;
+            type2 = CUFFT_C2R;
         }
-        else if (zsize%2 == 0) {
-            packedAxis = 2;
-            packedZSize /= 2;
-            bufferSize = packedZSize;
-        }
-        else
-            packRealAsComplex = false;
-        if (packRealAsComplex) {
-            // Build the kernels for packing and unpacking the data.
-            
-            map<string, string> defines;
-            defines["XSIZE"] = context.intToString(xsize);
-            defines["YSIZE"] = context.intToString(ysize);
-            defines["ZSIZE"] = context.intToString(zsize);
-            defines["PACKED_AXIS"] = context.intToString(packedAxis);
-            defines["PACKED_XSIZE"] = context.intToString(packedXSize);
-            defines["PACKED_YSIZE"] = context.intToString(packedYSize);
-            defines["PACKED_ZSIZE"] = context.intToString(packedZSize);
-            defines["M_PI"] = context.doubleToString(M_PI);
-            CUmodule module = context.createModule(CudaKernelSources::vectorOps+CudaKernelSources::fftR2C, defines);
-            packForwardKernel = context.getKernel(module, "packForwardData");
-            unpackForwardKernel = context.getKernel(module, "unpackForwardData");
-            packBackwardKernel = context.getKernel(module, "packBackwardData");
-            unpackBackwardKernel = context.getKernel(module, "unpackBackwardData");
-        }
-    }
-    bool inputIsReal = (realToComplex && !packRealAsComplex);
-    zkernel = createKernel(packedXSize, packedYSize, packedZSize, zthreads, 0, true, inputIsReal);
-    xkernel = createKernel(packedYSize, packedZSize, packedXSize, xthreads, 1, true, inputIsReal);
-    ykernel = createKernel(packedZSize, packedXSize, packedYSize, ythreads, 2, true, inputIsReal);
-    invzkernel = createKernel(packedXSize, packedYSize, packedZSize, zthreads, 0, false, inputIsReal);
-    invxkernel = createKernel(packedYSize, packedZSize, packedXSize, xthreads, 1, false, inputIsReal);
-    invykernel = createKernel(packedZSize, packedXSize, packedYSize, ythreads, 2, false, inputIsReal);
-}
-
-void CudaFFT3D::execFFT(CudaArray& in, CudaArray& out, bool forward) {
-    CUfunction kernel1 = (forward ? zkernel : invzkernel);
-    CUfunction kernel2 = (forward ? xkernel : invxkernel);
-    CUfunction kernel3 = (forward ? ykernel : invykernel);
-    void* args1[] = {&in.getDevicePointer(), &out.getDevicePointer()};
-    void* args2[] = {&out.getDevicePointer(), &in.getDevicePointer()};
-    if (packRealAsComplex) {
-        CUfunction packKernel = (forward ? packForwardKernel : packBackwardKernel);
-        CUfunction unpackKernel = (forward ? unpackForwardKernel : unpackBackwardKernel);
-        int gridSize = xsize*ysize*zsize/2;
-
-        // Pack the data into a half sized grid.
-        
-        context.executeKernel(packKernel, args1, gridSize, 128);
-        
-        // Perform the FFT.
-        
-        context.executeKernel(kernel1, args2, gridSize, zthreads);
-        context.executeKernel(kernel2, args1, gridSize, xthreads);
-        context.executeKernel(kernel3, args2, gridSize, ythreads);
-        
-        // Unpack the data.
-        
-        context.executeKernel(unpackKernel, args1, gridSize, 128);
     }
     else {
-        context.executeKernel(kernel1, args1, xsize*ysize*zsize, zthreads);
-        context.executeKernel(kernel2, args2, xsize*ysize*zsize, xthreads);
-        context.executeKernel(kernel3, args1, xsize*ysize*zsize, ythreads);
-    }
-}
-
-int CudaFFT3D::findLegalDimension(int minimum) {
-    if (minimum < 1)
-        return 1;
-    while (true) {
-        // Attempt to factor the current value.
-
-        int unfactored = minimum;
-        for (int factor = 2; factor < 8; factor++) {
-            while (unfactored > 1 && unfactored%factor == 0)
-                unfactored /= factor;
-        }
-        if (unfactored == 1)
-            return minimum;
-        minimum++;
-    }
-}
-
-
-static int getSmallestRadix(int size) {
-    int minRadix = 1;
-    int unfactored = size;
-    while (unfactored%7 == 0) {
-        minRadix = 7;
-        unfactored /= 7;
-    }
-    while (unfactored%5 == 0) {
-        minRadix = 5;
-        unfactored /= 5;
-    }
-    while (unfactored%4 == 0) {
-        minRadix = 4;
-        unfactored /= 4;
-    }
-    while (unfactored%3 == 0) {
-        minRadix = 3;
-        unfactored /= 3;
-    }
-    while (unfactored%2 == 0) {
-        minRadix = 2;
-        unfactored /= 2;
-    }
-    return minRadix;
-}
-
-CUfunction CudaFFT3D::createKernel(int xsize, int ysize, int zsize, int& threads, int axis, bool forward, bool inputIsReal) {
-    int maxThreads = (context.getUseDoublePrecision() ? 128 : 256);
-//    while (maxThreads > 128 && maxThreads-64 >= zsize)
-//        maxThreads -= 64;
-    int threadsPerBlock = zsize/getSmallestRadix(zsize);
-    stringstream source;
-    int blocksPerGroup = max(1, maxThreads/threadsPerBlock);
-    int stage = 0;
-    int L = zsize;
-    int m = 1;
-
-    // Factor zsize, generating an appropriate block of code for each factor.
-
-    while (L > 1) {
-        int input = stage%2;
-        int output = 1-input;
-        int radix;
-        if (L%7 == 0)
-            radix = 7;
-        else if (L%5 == 0)
-            radix = 5;
-        else if (L%4 == 0)
-            radix = 4;
-        else if (L%3 == 0)
-            radix = 3;
-        else if (L%2 == 0)
-            radix = 2;
+        if (context.getUseDoublePrecision())
+            type1 = type2 = CUFFT_Z2Z;
         else
-            throw OpenMMException("Illegal size for FFT: "+context.intToString(zsize));
-        source<<"{\n";
-        L = L/radix;
-        source<<"// Pass "<<(stage+1)<<" (radix "<<radix<<")\n";
-        if (L*m < threadsPerBlock)
-            source<<"if (threadIdx.x < "<<(blocksPerGroup*L*m)<<") {\n";
-        else
-            source<<"{\n";
-        source<<"int block = threadIdx.x/"<<(L*m)<<";\n";
-        source<<"int i = threadIdx.x-block*"<<(L*m)<<";\n";
-        source<<"int base = i+block*"<<zsize<<";\n";
-        source<<"int j = i/"<<m<<";\n";
-        if (radix == 7) {
-            source<<"real2 c0 = data"<<input<<"[base];\n";
-            source<<"real2 c1 = data"<<input<<"[base+"<<(L*m)<<"];\n";
-            source<<"real2 c2 = data"<<input<<"[base+"<<(2*L*m)<<"];\n";
-            source<<"real2 c3 = data"<<input<<"[base+"<<(3*L*m)<<"];\n";
-            source<<"real2 c4 = data"<<input<<"[base+"<<(4*L*m)<<"];\n";
-            source<<"real2 c5 = data"<<input<<"[base+"<<(5*L*m)<<"];\n";
-            source<<"real2 c6 = data"<<input<<"[base+"<<(6*L*m)<<"];\n";
-            source<<"real2 d0 = c1+c6;\n";
-            source<<"real2 d1 = c1-c6;\n";
-            source<<"real2 d2 = c2+c5;\n";
-            source<<"real2 d3 = c2-c5;\n";
-            source<<"real2 d4 = c4+c3;\n";
-            source<<"real2 d5 = c4-c3;\n";
-            source<<"real2 d6 = d2+d0;\n";
-            source<<"real2 d7 = d5+d3;\n";
-            source<<"real2 b0 = c0+d6+d4;\n";
-            source<<"real2 b1 = "<<context.doubleToString((cos(2*M_PI/7)+cos(4*M_PI/7)+cos(6*M_PI/7))/3-1)<<"*(d6+d4);\n";
-            source<<"real2 b2 = "<<context.doubleToString((2*cos(2*M_PI/7)-cos(4*M_PI/7)-cos(6*M_PI/7))/3)<<"*(d0-d4);\n";
-            source<<"real2 b3 = "<<context.doubleToString((cos(2*M_PI/7)-2*cos(4*M_PI/7)+cos(6*M_PI/7))/3)<<"*(d4-d2);\n";
-            source<<"real2 b4 = "<<context.doubleToString((cos(2*M_PI/7)+cos(4*M_PI/7)-2*cos(6*M_PI/7))/3)<<"*(d2-d0);\n";
-            source<<"real2 b5 = -(SIGN)*"<<context.doubleToString((sin(2*M_PI/7)+sin(4*M_PI/7)-sin(6*M_PI/7))/3)<<"*(d7+d1);\n";
-            source<<"real2 b6 = -(SIGN)*"<<context.doubleToString((2*sin(2*M_PI/7)-sin(4*M_PI/7)+sin(6*M_PI/7))/3)<<"*(d1-d5);\n";
-            source<<"real2 b7 = -(SIGN)*"<<context.doubleToString((sin(2*M_PI/7)-2*sin(4*M_PI/7)-sin(6*M_PI/7))/3)<<"*(d5-d3);\n";
-            source<<"real2 b8 = -(SIGN)*"<<context.doubleToString((sin(2*M_PI/7)+sin(4*M_PI/7)+2*sin(6*M_PI/7))/3)<<"*(d3-d1);\n";
-            source<<"real2 t0 = b0+b1;\n";
-            source<<"real2 t1 = b2+b3;\n";
-            source<<"real2 t2 = b4-b3;\n";
-            source<<"real2 t3 = -b2-b4;\n";
-            source<<"real2 t4 = b6+b7;\n";
-            source<<"real2 t5 = b8-b7;\n";
-            source<<"real2 t6 = -b8-b6;\n";
-            source<<"real2 t7 = t0+t1;\n";
-            source<<"real2 t8 = t0+t2;\n";
-            source<<"real2 t9 = t0+t3;\n";
-            source<<"real2 t10 = make_real2(t4.y+b5.y, -(t4.x+b5.x));\n";
-            source<<"real2 t11 = make_real2(t5.y+b5.y, -(t5.x+b5.x));\n";
-            source<<"real2 t12 = make_real2(t6.y+b5.y, -(t6.x+b5.x));\n";
-            source<<"data"<<output<<"[base+6*j*"<<m<<"] = b0;\n";
-            source<<"data"<<output<<"[base+(6*j+1)*"<<m<<"] = multiplyComplex(w[j*"<<zsize<<"/"<<(7*L)<<"], t7-t10);\n";
-            source<<"data"<<output<<"[base+(6*j+2)*"<<m<<"] = multiplyComplex(w[j*"<<(2*zsize)<<"/"<<(7*L)<<"], t9-t12);\n";
-            source<<"data"<<output<<"[base+(6*j+3)*"<<m<<"] = multiplyComplex(w[j*"<<(3*zsize)<<"/"<<(7*L)<<"], t8+t11);\n";
-            source<<"data"<<output<<"[base+(6*j+4)*"<<m<<"] = multiplyComplex(w[j*"<<(4*zsize)<<"/"<<(7*L)<<"], t8-t11);\n";
-            source<<"data"<<output<<"[base+(6*j+5)*"<<m<<"] = multiplyComplex(w[j*"<<(5*zsize)<<"/"<<(7*L)<<"], t9+t12);\n";
-            source<<"data"<<output<<"[base+(6*j+6)*"<<m<<"] = multiplyComplex(w[j*"<<(6*zsize)<<"/"<<(7*L)<<"], t7+t10);\n";
-        }
-        else if (radix == 5) {
-            source<<"real2 c0 = data"<<input<<"[base];\n";
-            source<<"real2 c1 = data"<<input<<"[base+"<<(L*m)<<"];\n";
-            source<<"real2 c2 = data"<<input<<"[base+"<<(2*L*m)<<"];\n";
-            source<<"real2 c3 = data"<<input<<"[base+"<<(3*L*m)<<"];\n";
-            source<<"real2 c4 = data"<<input<<"[base+"<<(4*L*m)<<"];\n";
-            source<<"real2 d0 = c1+c4;\n";
-            source<<"real2 d1 = c2+c3;\n";
-            source<<"real2 d2 = "<<context.doubleToString(sin(0.4*M_PI))<<"*(c1-c4);\n";
-            source<<"real2 d3 = "<<context.doubleToString(sin(0.4*M_PI))<<"*(c2-c3);\n";
-            source<<"real2 d4 = d0+d1;\n";
-            source<<"real2 d5 = "<<context.doubleToString(0.25*sqrt(5.0))<<"*(d0-d1);\n";
-            source<<"real2 d6 = c0-0.25f*d4;\n";
-            source<<"real2 d7 = d6+d5;\n";
-            source<<"real2 d8 = d6-d5;\n";
-            string coeff = context.doubleToString(sin(0.2*M_PI)/sin(0.4*M_PI));
-            source<<"real2 d9 = (SIGN)*make_real2(d2.y+"<<coeff<<"*d3.y, -d2.x-"<<coeff<<"*d3.x);\n";
-            source<<"real2 d10 = (SIGN)*make_real2("<<coeff<<"*d2.y-d3.y, d3.x-"<<coeff<<"*d2.x);\n";
-            source<<"data"<<output<<"[base+4*j*"<<m<<"] = c0+d4;\n";
-            source<<"data"<<output<<"[base+(4*j+1)*"<<m<<"] = multiplyComplex(w[j*"<<zsize<<"/"<<(5*L)<<"], d7+d9);\n";
-            source<<"data"<<output<<"[base+(4*j+2)*"<<m<<"] = multiplyComplex(w[j*"<<(2*zsize)<<"/"<<(5*L)<<"], d8+d10);\n";
-            source<<"data"<<output<<"[base+(4*j+3)*"<<m<<"] = multiplyComplex(w[j*"<<(3*zsize)<<"/"<<(5*L)<<"], d8-d10);\n";
-            source<<"data"<<output<<"[base+(4*j+4)*"<<m<<"] = multiplyComplex(w[j*"<<(4*zsize)<<"/"<<(5*L)<<"], d7-d9);\n";
-        }
-        else if (radix == 4) {
-            source<<"real2 c0 = data"<<input<<"[base];\n";
-            source<<"real2 c1 = data"<<input<<"[base+"<<(L*m)<<"];\n";
-            source<<"real2 c2 = data"<<input<<"[base+"<<(2*L*m)<<"];\n";
-            source<<"real2 c3 = data"<<input<<"[base+"<<(3*L*m)<<"];\n";
-            source<<"real2 d0 = c0+c2;\n";
-            source<<"real2 d1 = c0-c2;\n";
-            source<<"real2 d2 = c1+c3;\n";
-            source<<"real2 d3 = (SIGN)*make_real2(c1.y-c3.y, c3.x-c1.x);\n";
-            source<<"data"<<output<<"[base+3*j*"<<m<<"] = d0+d2;\n";
-            source<<"data"<<output<<"[base+(3*j+1)*"<<m<<"] = multiplyComplex(w[j*"<<zsize<<"/"<<(4*L)<<"], d1+d3);\n";
-            source<<"data"<<output<<"[base+(3*j+2)*"<<m<<"] = multiplyComplex(w[j*"<<(2*zsize)<<"/"<<(4*L)<<"], d0-d2);\n";
-            source<<"data"<<output<<"[base+(3*j+3)*"<<m<<"] = multiplyComplex(w[j*"<<(3*zsize)<<"/"<<(4*L)<<"], d1-d3);\n";
-        }
-        else if (radix == 3) {
-            source<<"real2 c0 = data"<<input<<"[base];\n";
-            source<<"real2 c1 = data"<<input<<"[base+"<<(L*m)<<"];\n";
-            source<<"real2 c2 = data"<<input<<"[base+"<<(2*L*m)<<"];\n";
-            source<<"real2 d0 = c1+c2;\n";
-            source<<"real2 d1 = c0-0.5f*d0;\n";
-            source<<"real2 d2 = (SIGN)*"<<context.doubleToString(sin(M_PI/3.0))<<"*make_real2(c1.y-c2.y, c2.x-c1.x);\n";
-            source<<"data"<<output<<"[base+2*j*"<<m<<"] = c0+d0;\n";
-            source<<"data"<<output<<"[base+(2*j+1)*"<<m<<"] = multiplyComplex(w[j*"<<zsize<<"/"<<(3*L)<<"], d1+d2);\n";
-            source<<"data"<<output<<"[base+(2*j+2)*"<<m<<"] = multiplyComplex(w[j*"<<(2*zsize)<<"/"<<(3*L)<<"], d1-d2);\n";
-        }
-        else if (radix == 2) {
-            source<<"real2 c0 = data"<<input<<"[base];\n";
-            source<<"real2 c1 = data"<<input<<"[base+"<<(L*m)<<"];\n";
-            source<<"data"<<output<<"[base+j*"<<m<<"] = c0+c1;\n";
-            source<<"data"<<output<<"[base+(j+1)*"<<m<<"] = multiplyComplex(w[j*"<<zsize<<"/"<<(2*L)<<"], c0-c1);\n";
-        }
-        source<<"}\n";
-        m = m*radix;
-        source<<"__syncthreads();\n";
-        source<<"}\n";
-        ++stage;
+            type1 = type2 = CUFFT_C2C;
     }
+    cufftResult result = cufftPlan3d(&fftForward, xsize, ysize, zsize, type1);
+    if (result != CUFFT_SUCCESS)
+        throw OpenMMException("Error initializing FFT: "+context.intToString(result));
+    result = cufftPlan3d(&fftBackward, xsize, ysize, zsize, type2);
+    if (result != CUFFT_SUCCESS)
+        throw OpenMMException("Error initializing FFT: "+context.intToString(result));
+    hasInitialized = true;
+}
 
-    // Create the kernel.
+CudaFFT3D::~CudaFFT3D() {
+    if (hasInitialized) {
+        cufftDestroy(fftForward);
+        cufftDestroy(fftBackward);
+    }
+}
 
-    bool outputIsReal = (inputIsReal && axis == 2 && !forward);
-    bool outputIsPacked = (inputIsReal && axis == 2 && forward);
-    string outputSuffix = (outputIsReal ? ".x" : "");
-    if (outputIsPacked)
-        source<<"if (index < XSIZE*YSIZE && x < XSIZE/2+1)\n";
-    else
-        source<<"if (index < XSIZE*YSIZE)\n";
-    source<<"for (int i = threadIdx.x-block*THREADS_PER_BLOCK; i < ZSIZE; i += THREADS_PER_BLOCK)\n";
-    if (outputIsPacked)
-        source<<"out[y*(ZSIZE*(XSIZE/2+1))+i*(XSIZE/2+1)+x] = data"<<(stage%2)<<"[i+block*ZSIZE]"<<outputSuffix<<";\n";
-    else
-            source<<"out[y*(ZSIZE*XSIZE)+i*XSIZE+x] = data"<<(stage%2)<<"[i+block*ZSIZE]"<<outputSuffix<<";\n";
-    map<string, string> replacements;
-    replacements["XSIZE"] = context.intToString(xsize);
-    replacements["YSIZE"] = context.intToString(ysize);
-    replacements["ZSIZE"] = context.intToString(zsize);
-    replacements["BLOCKS_PER_GROUP"] = context.intToString(blocksPerGroup);
-    replacements["THREADS_PER_BLOCK"] = context.intToString(threadsPerBlock);
-    replacements["M_PI"] = context.doubleToString(M_PI);
-    replacements["COMPUTE_FFT"] = source.str();
-    replacements["SIGN"] = (forward ? "1" : "-1");
-    replacements["INPUT_TYPE"] = (inputIsReal && axis == 0 && forward ? "real" : "real2");
-    replacements["OUTPUT_TYPE"] = (outputIsReal ? "real" : "real2");
-    replacements["INPUT_IS_REAL"] = (inputIsReal && axis == 0 && forward ? "1" : "0");
-    replacements["INPUT_IS_PACKED"] = (inputIsReal && axis == 0 && !forward ? "1" : "0");
-    replacements["OUTPUT_IS_PACKED"] = (outputIsPacked ? "1" : "0");
-    CUmodule module = context.createModule(CudaKernelSources::vectorOps+context.replaceStrings(CudaKernelSources::fft, replacements));
-    CUfunction kernel = context.getKernel(module, "execFFT");
-    threads = blocksPerGroup*threadsPerBlock;
-    return kernel;
+void CudaFFT3D::setStream(CUstream stream) {
+    cufftSetStream(fftForward, stream);
+    cufftSetStream(fftBackward, stream);
+}
+
+void CudaFFT3D::execFFT(ArrayInterface& in, ArrayInterface& out, bool forward) {
+    CUdeviceptr in2 = context.unwrap(in).getDevicePointer();
+    CUdeviceptr out2 = context.unwrap(out).getDevicePointer();
+    cufftResult result;
+    if (forward) {
+        if (realToComplex) {
+            if (context.getUseDoublePrecision())
+                result = cufftExecD2Z(fftForward, (double*) in2, (double2*) out2);
+            else
+                result = cufftExecR2C(fftForward, (float*) in2, (float2*) out2);
+        }
+        else {
+            if (context.getUseDoublePrecision())
+                result = cufftExecZ2Z(fftForward, (double2*) in2, (double2*) out2, CUFFT_FORWARD);
+            else
+                result = cufftExecC2C(fftForward, (float2*) in2, (float2*) out2, CUFFT_FORWARD);
+        }
+    }
+    else {
+        if (realToComplex) {
+            if (context.getUseDoublePrecision())
+                result = cufftExecZ2D(fftBackward, (double2*) in2, (double*) out2);
+            else
+                result = cufftExecC2R(fftBackward, (float2*) in2, (float*) out2);
+        }
+        else {
+            if (context.getUseDoublePrecision())
+                result = cufftExecZ2Z(fftBackward, (double2*) in2, (double2*) out2, CUFFT_INVERSE);
+            else
+                result = cufftExecC2C(fftBackward, (float2*) in2, (float2*) out2, CUFFT_INVERSE);
+        }
+    }
+    if (result != CUFFT_SUCCESS)
+        throw OpenMMException("Error executing FFT: "+context.intToString(result));
 }

--- a/platforms/hip/include/HipContext.h
+++ b/platforms/hip/include/HipContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2024 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
  * Portions copyright (c) 2020-2023 Advanced Micro Devices, Inc.              *
  * Authors: Peter Eastman, Nicholas Curtis                                    *
  * Contributors:                                                              *
@@ -51,6 +51,7 @@
 #include "HipArray.h"
 #include "HipBondedUtilities.h"
 #include "HipExpressionUtilities.h"
+#include "HipFFT3D.h"
 #include "HipIntegrationUtilities.h"
 #include "HipNonbondedUtilities.h"
 #include "HipPlatform.h"
@@ -182,9 +183,19 @@ public:
      */
     ComputeEvent createEvent();
     /**
-     * Get the smallest legal size for a dimension of the grid supported by the FFT.
+     * Create an object for performing 3D FFTs.  The caller is responsible for deleting
+     * the object when it is no longer needed.
+     *
+     * @param xsize   the first dimension of the data sets on which FFTs will be performed
+     * @param ysize   the second dimension of the data sets on which FFTs will be performed
+     * @param zsize   the third dimension of the data sets on which FFTs will be performed
+     * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
      */
-    virtual int findLegalFFTDimension(int minimum);
+    HipFFT3D* createFFT(int xsize, int ysize, int zsize, bool realToComplex=false);
+    /**
+     * Get the smallest legal size for a dimension of the grid.
+     */
+    int findLegalFFTDimension(int minimum);
     /**
      * Compile source code to create a ComputeProgram.
      *

--- a/platforms/hip/include/HipFFT3D.h
+++ b/platforms/hip/include/HipFFT3D.h
@@ -32,6 +32,8 @@
 
 #define VKFFT_BACKEND 2 // HIP
 #include "vkFFT.h"
+#include "openmm/common/FFT3D.h"
+#include "openmm/common/ArrayInterface.h"
 
 namespace OpenMM {
 
@@ -40,22 +42,22 @@ class HipContext;
 /**
  * This class performs three dimensional Fast Fourier Transforms using VkFFT by
  * Dmitrii Tolmachev (https://github.com/DTolm/VkFFT).
- * <p>
+ *
  * Note that this class performs an unnormalized transform.  That means that if you perform
  * a forward transform followed immediately by an inverse transform, the effect is to
  * multiply every value of the original data set by the total number of data points.
  */
 
-class OPENMM_EXPORT_COMMON HipFFT3D {
+class OPENMM_EXPORT_COMMON HipFFT3D : public FFT3D {
 public:
     /**
      * Create an HipFFT3D object for performing transforms of a particular size.
-     * <p>
+     *
      * The transform cannot be done in-place: the input and output
      * arrays must be different.  Also, the input array is used as workspace, so its contents
      * are destroyed.  This also means that both arrays must be large enough to hold complex values,
      * even when performing a real-to-complex transform.
-     * <p>
+     *
      * When performing a real-to-complex transform, the output data is of size xsize*ysize*(zsize/2+1)
      * and contains only the non-redundant elements.
      *
@@ -64,18 +66,23 @@ public:
      * @param ysize   the second dimension of the data sets on which FFTs will be performed
      * @param zsize   the third dimension of the data sets on which FFTs will be performed
      * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
-     * @param stream  HIP stream
-     * @param in      the data to transform, ordered such that in[x*ysize*zsize + y*zsize + z] contains element (x, y, z)
-     * @param out     on exit, this contains the transformed data
      */
-    HipFFT3D(HipContext& context, int xsize, int ysize, int zsize, bool realToComplex, hipStream_t stream, HipArray& in, HipArray& out);
+    HipFFT3D(HipContext& context, int xsize, int ysize, int zsize, bool realToComplex);
     ~HipFFT3D();
     /**
-     * Perform a Fourier transform.
+     * Perform a Fourier transform.  The transform cannot be done in-place: the input and output
+     * arrays must be different.  Also, the input array is used as workspace, so its contents
+     * are destroyed.  This also means that both arrays must be large enough to hold complex values,
+     * even when performing a real-to-complex transform.
      *
+     * When performing a real-to-complex transform, the output data is of size xsize*ysize*(zsize/2+1)
+     * and contains only the non-redundant elements.
+     *
+     * @param in       the data to transform, ordered such that in[x*ysize*zsize + y*zsize + z] contains element (x, y, z)
+     * @param out      on exit, this contains the transformed data
      * @param forward  true to perform a forward transform, false to perform an inverse transform
      */
-    void execFFT(bool forward);
+    void execFFT(ArrayInterface& in, ArrayInterface& out, bool forward=true);
     /**
      * Get the smallest legal size for a dimension of the grid (that is, a size with no prime
      * factors other than 2, 3, 5, 7, 11, 13).  VkFFT supports arbitrary sizes but they may work

--- a/platforms/hip/src/HipContext.cpp
+++ b/platforms/hip/src/HipContext.cpp
@@ -696,6 +696,10 @@ ComputeEvent HipContext::createEvent() {
     return shared_ptr<ComputeEventImpl>(new HipEvent(*this));
 }
 
+HipFFT3D* HipContext::createFFT(int xsize, int ysize, int zsize, bool realToComplex) {
+    return new HipFFT3D(*this, xsize, ysize, zsize, realToComplex);
+}
+
 int HipContext::findLegalFFTDimension(int minimum) {
     return HipFFT3D::findLegalDimension(minimum);
 }

--- a/platforms/hip/tests/TestHipFFT3D.cpp
+++ b/platforms/hip/tests/TestHipFFT3D.cpp
@@ -88,11 +88,11 @@ void testTransform(bool realToComplex, int xsize, int ysize, int zsize, double e
     HipArray grid1(context, original.size(), sizeof(Real2), "grid1");
     HipArray grid2(context, original.size(), sizeof(Real2), "grid2");
     grid1.upload(original);
-    HipFFT3D fft(context, xsize, ysize, zsize, realToComplex, context.getCurrentStream(), grid1, grid2);
+    HipFFT3D fft(context, xsize, ysize, zsize, realToComplex);
 
     // Perform a forward FFT, then verify the result is correct.
 
-    fft.execFFT(true);
+    fft.execFFT(grid1, grid2, true);
     vector<Real2> result;
     grid2.download(result);
     vector<size_t> shape = {(size_t) xsize, (size_t) ysize, (size_t) zsize};
@@ -113,7 +113,7 @@ void testTransform(bool realToComplex, int xsize, int ysize, int zsize, double e
 
     // Perform a backward transform and see if we get the original values.
 
-    fft.execFFT(false);
+    fft.execFFT(grid2, grid1, false);
     grid1.download(result);
     double scale = 1.0/(xsize*ysize*zsize);
     int valuesToCheck = (realToComplex ? original.size()/2 : original.size());

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -53,6 +53,7 @@
 #include "OpenCLArray.h"
 #include "OpenCLBondedUtilities.h"
 #include "OpenCLExpressionUtilities.h"
+#include "OpenCLFFT3D.h"
 #include "OpenCLIntegrationUtilities.h"
 #include "OpenCLNonbondedUtilities.h"
 #include "OpenCLPlatform.h"
@@ -632,6 +633,20 @@ public:
     OpenCLNonbondedUtilities* createNonbondedUtilities() {
         return new OpenCLNonbondedUtilities(*this);
     }
+    /**
+     * Create an object for performing 3D FFTs.  The caller is responsible for deleting
+     * the object when it is no longer needed.
+     *
+     * @param xsize   the first dimension of the data sets on which FFTs will be performed
+     * @param ysize   the second dimension of the data sets on which FFTs will be performed
+     * @param zsize   the third dimension of the data sets on which FFTs will be performed
+     * @param realToComplex  if true, a real-to-complex transform will be done.  Otherwise, it is complex-to-complex.
+     */
+    OpenCLFFT3D* createFFT(int xsize, int ysize, int zsize, bool realToComplex=false);
+    /**
+     * Get the smallest legal size for a dimension of the grid.
+     */
+    int findLegalFFTDimension(int minimum);
     /**
      * This should be called by the Integrator from its own initialize() method.
      * It ensures all contexts are fully initialized.

--- a/platforms/opencl/include/OpenCLFFT3D.h
+++ b/platforms/opencl/include/OpenCLFFT3D.h
@@ -98,7 +98,7 @@ public:
      * arrays must be different.  Also, the input array is used as workspace, so its contents
      * are destroyed.  This also means that both arrays must be large enough to hold complex values,
      * even when performing a real-to-complex transform.
-     * <p>
+     *
      * When performing a real-to-complex transform, the output data is of size xsize*ysize*(zsize/2+1)
      * and contains only the non-redundant elements.
      *
@@ -106,7 +106,7 @@ public:
      * @param out      on exit, this contains the transformed data
      * @param forward  true to perform a forward transform, false to perform an inverse transform
      */
-    void execFFT(ArrayInterface& in, ArrayInterface& out, bool forward = true);
+    void execFFT(ArrayInterface& in, ArrayInterface& out, bool forward=true);
     /**
      * Get the smallest legal size for a dimension of the grid (that is, a size with no unsupported
      * prime factors).

--- a/platforms/opencl/include/OpenCLFFT3D.h
+++ b/platforms/opencl/include/OpenCLFFT3D.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2023 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,20 +34,23 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include "vkFFT.h"
 #endif
-#include "OpenCLArray.h"
+#include "openmm/common/FFT3D.h"
+#include "openmm/common/ArrayInterface.h"
 
 namespace OpenMM {
+
+class OpenCLContext;
 
 #ifdef USE_VKFFT
 /**
  * This class performs three dimensional Fast Fourier Transforms.  It uses the
  * VkFFT library (https://github.com/DTolm/VkFFT).
- * <p>
+ *
  * This class is most efficient when the size of each dimension is a product of
  * small prime factors: 2, 3, 5, 7, 11, and 13.  You can call findLegalDimension()
  * to determine the smallest size that satisfies this requirement and is greater
  * than or equal to a specified minimum size.
- * <p>
+ *
  * Note that this class performs an unnormalized transform.  That means that if you perform
  * a forward transform followed immediately by an inverse transform, the effect is to
  * multiply every value of the original data set by the total number of data points.
@@ -56,11 +59,11 @@ namespace OpenMM {
 /**
  * This class performs three dimensional Fast Fourier Transforms.  It is based on the
  * mixed radix algorithm described in
- * <p>
+ *
  * Takahashi, D. and Kanada, Y., "High-Performance Radix-2, 3 and 5 Parallel 1-D Complex
  * FFT Algorithms for Distributed-Memory Parallel Computers."  Journal of Supercomputing,
  * 15, 207–228 (2000).
- * <p>
+ *
  * This class places certain restrictions on the allowed dimensions of the grid.  First,
  * the size of each dimension may have no prime factors other than 2, 3, 5, and 7.  You
  * can call findLegalDimension() to determine the smallest size that satisfies this
@@ -68,14 +71,14 @@ namespace OpenMM {
  * of each dimension must be small enough to compute each 1D transform entirely in local
  * memory with one work unit per data point.  This will vary between platforms, but is
  * typically at least 512.
- * <p>
+ *
  * Note that this class performs an unnormalized transform.  That means that if you perform
  * a forward transform followed immediately by an inverse transform, the effect is to
  * multiply every value of the original data set by the total number of data points.
  */
 #endif
 
-class OPENMM_EXPORT_COMMON OpenCLFFT3D {
+class OPENMM_EXPORT_COMMON OpenCLFFT3D : public FFT3D {
 public:
     /**
      * Create an OpenCLFFT3D object for performing transforms of a particular size.
@@ -103,10 +106,10 @@ public:
      * @param out      on exit, this contains the transformed data
      * @param forward  true to perform a forward transform, false to perform an inverse transform
      */
-    void execFFT(OpenCLArray& in, OpenCLArray& out, bool forward = true);
+    void execFFT(ArrayInterface& in, ArrayInterface& out, bool forward = true);
     /**
-     * Get the smallest legal size for a dimension of the grid (that is, a size with no prime
-     * factors other than 2, 3, 5, and 7).
+     * Get the smallest legal size for a dimension of the grid (that is, a size with no unsupported
+     * prime factors).
      *
      * @param minimum   the minimum size the return value must be greater than or equal to
      */

--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2024 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -574,6 +574,14 @@ void OpenCLContext::initialize() {
 
 void OpenCLContext::initializeContexts() {
     getPlatformData().initializeContexts(system);
+}
+
+OpenCLFFT3D* OpenCLContext::createFFT(int xsize, int ysize, int zsize, bool realToComplex) {
+    return new OpenCLFFT3D(*this, xsize, ysize, zsize, realToComplex);
+}
+
+int OpenCLContext::findLegalFFTDimension(int minimum) {
+    return OpenCLFFT3D::findLegalDimension(minimum);
 }
 
 void OpenCLContext::addForce(ComputeForceInfo* force) {

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -515,9 +515,9 @@ void OpenCLCalcNonbondedForceKernel::initialize(const System& system, const Nonb
                 pmeEnergyBuffer.initialize(cl, cl.getNumThreadBlocks()*OpenCLContext::ThreadBlockSize, energyElementSize, "pmeEnergyBuffer");
                 cl.clearBuffer(pmeEnergyBuffer);
                 sort = new OpenCLSort(cl, new SortTrait(), cl.getNumAtoms());
-                fft = new OpenCLFFT3D(cl, gridSizeX, gridSizeY, gridSizeZ, true);
+                fft = cl.createFFT(gridSizeX, gridSizeY, gridSizeZ, true);
                 if (doLJPME)
-                    dispersionFft = new OpenCLFFT3D(cl, dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true);
+                    dispersionFft = cl.createFFT(dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true);
                 string vendor = cl.getDevice().getInfo<CL_DEVICE_VENDOR>();
                 bool isNvidia = (vendor.size() >= 6 && vendor.substr(0, 6) == "NVIDIA");
                 usePmeQueue = (!cl.getPlatformData().disablePmeStream && !cl.getPlatformData().useCpuPme && isNvidia);

--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.h
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2025 Stanford University and the Authors.      *
  * Authors: Mark Friedrichs, Peter Eastman                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -32,6 +32,7 @@
 #include "openmm/System.h"
 #include "openmm/common/ComputeContext.h"
 #include "openmm/common/ComputeArray.h"
+#include "openmm/common/FFT3D.h"
 #include "openmm/common/NonbondedUtilities.h"
 
 namespace OpenMM {
@@ -153,10 +154,6 @@ public:
      */
     void getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
     /**
-     * Compute the FFT.
-     */
-    virtual void computeFFT(bool forward) = 0;
-    /**
      * Get whether charge spreading should be done in fixed point.
      */
     virtual bool useFixedPointChargeSpreading() const = 0;
@@ -238,6 +235,7 @@ protected:
     ComputeKernel pmeFixedPotentialKernel, pmeInducedPotentialKernel, pmeFixedForceKernel, pmeInducedForceKernel, pmeRecordInducedFieldDipolesKernel;
     ComputeKernel pmeTransformMultipolesKernel, pmeTransformPotentialKernel;
     ComputeEvent syncEvent;
+    FFT3D* fft;
     CommonCalcAmoebaGeneralizedKirkwoodForceKernel* gkKernel;
     static const int PmeOrder = 5;
     static const int MaxPrevDIISDipoles = 20;
@@ -424,6 +422,7 @@ private:
 class CommonCalcHippoNonbondedForceKernel : public CalcHippoNonbondedForceKernel {
 public:
     CommonCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, ComputeContext& cc, const System& system);
+    virtual ~CommonCalcHippoNonbondedForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -431,10 +430,6 @@ public:
      * @param force      the HippoNonbondedForce this kernel will be used for
      */
     void initialize(const System& system, const HippoNonbondedForce& force);
-    /**
-     * Compute the FFT.
-     */
-    virtual void computeFFT(bool forward, bool dispersion) = 0;
     /**
      * Get whether charge spreading should be done in fixed point.
      */
@@ -534,6 +529,8 @@ protected:
     ComputeArray lastPositions;
     ComputeArray exceptionScales[6];
     ComputeArray exceptionAtoms;
+    FFT3D* fft;
+    FFT3D* dfft;
     ComputeKernel computeMomentsKernel, recordInducedDipolesKernel, mapTorqueKernel;
     ComputeKernel fixedFieldKernel, fixedFieldExceptionKernel, mutualFieldKernel, mutualFieldExceptionKernel, computeExceptionsKernel;
     ComputeKernel pmeSpreadFixedMultipolesKernel, pmeSpreadInducedDipolesKernel, pmeFinishSpreadChargeKernel, pmeConvolutionKernel;

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2025 Stanford University and the Authors.      *
  * Authors: Peter Eastman, Mark Friedrichs                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -38,7 +38,6 @@
 #include "openmm/internal/AmoebaVdwForceImpl.h"
 #include "openmm/internal/NonbondedForceImpl.h"
 #include "CudaBondedUtilities.h"
-#include "CudaFFT3D.h"
 #include "CudaForceInfo.h"
 #include "CudaKernelSources.h"
 #include "SimTKOpenMMRealType.h"
@@ -80,44 +79,6 @@ static void setPeriodicBoxArgs(ComputeContext& cc, ComputeKernel kernel, int ind
 }
 
 /* -------------------------------------------------------------------------- *
- *                             AmoebaMultipole                                *
- * -------------------------------------------------------------------------- */
-
-CudaCalcAmoebaMultipoleForceKernel::~CudaCalcAmoebaMultipoleForceKernel() {
-    ContextSelector selector(cc);
-    if (hasInitializedFFT)
-        cufftDestroy(fft);
-}
-
-void CudaCalcAmoebaMultipoleForceKernel::initialize(const System& system, const AmoebaMultipoleForce& force) {
-    CommonCalcAmoebaMultipoleForceKernel::initialize(system, force);
-    if (usePME) {
-        ContextSelector selector(cc);
-        cufftResult result = cufftPlan3d(&fft, gridSizeX, gridSizeY, gridSizeZ, cc.getUseDoublePrecision() ? CUFFT_Z2Z : CUFFT_C2C);
-        if (result != CUFFT_SUCCESS)
-            throw OpenMMException("Error initializing FFT: "+cc.intToString(result));
-        hasInitializedFFT = true;
-    }
-}
-
-void CudaCalcAmoebaMultipoleForceKernel::computeFFT(bool forward) {
-    CudaArray& grid1 = dynamic_cast<CudaContext&>(cc).unwrap(pmeGrid1);
-    CudaArray& grid2 = dynamic_cast<CudaContext&>(cc).unwrap(pmeGrid2);
-    if (forward) {
-        if (cc.getUseDoublePrecision())
-            cufftExecZ2Z(fft, (double2*) grid1.getDevicePointer(), (double2*) grid2.getDevicePointer(), CUFFT_FORWARD);
-        else
-            cufftExecC2C(fft, (float2*) grid1.getDevicePointer(), (float2*) grid2.getDevicePointer(), CUFFT_FORWARD);
-    }
-    else {
-        if (cc.getUseDoublePrecision())
-            cufftExecZ2Z(fft, (double2*) grid2.getDevicePointer(), (double2*) grid1.getDevicePointer(), CUFFT_INVERSE);
-        else
-            cufftExecC2C(fft, (float2*) grid2.getDevicePointer(), (float2*) grid1.getDevicePointer(), CUFFT_INVERSE);
-    }
-}
-
-/* -------------------------------------------------------------------------- *
  *                           HippoNonbondedForce                              *
  * -------------------------------------------------------------------------- */
 
@@ -125,12 +86,6 @@ CudaCalcHippoNonbondedForceKernel::~CudaCalcHippoNonbondedForceKernel() {
     ContextSelector selector(cc);
     if (sort != NULL)
         delete sort;
-    if (hasInitializedFFT) {
-        cufftDestroy(fftForward);
-        cufftDestroy(fftBackward);
-        cufftDestroy(dfftForward);
-        cufftDestroy(dfftBackward);
-    }
 }
 
 void CudaCalcHippoNonbondedForceKernel::initialize(const System& system, const HippoNonbondedForce& force) {
@@ -139,38 +94,6 @@ void CudaCalcHippoNonbondedForceKernel::initialize(const System& system, const H
         ContextSelector selector(cc);
         CudaContext& cu = dynamic_cast<CudaContext&>(cc);
         sort = new CudaSort(cu, new SortTrait(), cc.getNumAtoms());
-        cufftResult result = cufftPlan3d(&fftForward, gridSizeX, gridSizeY, gridSizeZ, cc.getUseDoublePrecision() ? CUFFT_D2Z : CUFFT_R2C);
-        if (result != CUFFT_SUCCESS)
-            throw OpenMMException("Error initializing FFT: "+cc.intToString(result));
-        result = cufftPlan3d(&fftBackward, gridSizeX, gridSizeY, gridSizeZ, cc.getUseDoublePrecision() ? CUFFT_Z2D : CUFFT_C2R);
-        if (result != CUFFT_SUCCESS)
-            throw OpenMMException("Error initializing FFT: "+cc.intToString(result));
-        result = cufftPlan3d(&dfftForward, dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, cc.getUseDoublePrecision() ? CUFFT_D2Z : CUFFT_R2C);
-        if (result != CUFFT_SUCCESS)
-            throw OpenMMException("Error initializing FFT: "+cc.intToString(result));
-        result = cufftPlan3d(&dfftBackward, dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, cc.getUseDoublePrecision() ? CUFFT_Z2D : CUFFT_C2R);
-        if (result != CUFFT_SUCCESS)
-            throw OpenMMException("Error initializing FFT: "+cc.intToString(result));
-        hasInitializedFFT = true;
-    }
-}
-
-void CudaCalcHippoNonbondedForceKernel::computeFFT(bool forward, bool dispersion) {
-    CudaArray& grid1 = dynamic_cast<CudaContext&>(cc).unwrap(pmeGrid1);
-    CudaArray& grid2 = dynamic_cast<CudaContext&>(cc).unwrap(pmeGrid2);
-    if (forward) {
-        cufftHandle fft = dispersion ? dfftForward : fftForward;
-        if (cc.getUseDoublePrecision())
-            cufftExecD2Z(fft, (double*) grid1.getDevicePointer(), (double2*) grid2.getDevicePointer());
-        else
-            cufftExecR2C(fft, (float*) grid1.getDevicePointer(), (float2*) grid2.getDevicePointer());
-    }
-    else {
-        cufftHandle fft = dispersion ? dfftBackward : fftBackward;
-        if (cc.getUseDoublePrecision())
-            cufftExecZ2D(fft, (double2*) grid2.getDevicePointer(), (double*) grid1.getDevicePointer());
-        else
-            cufftExecC2R(fft, (float2*) grid2.getDevicePointer(), (float*) grid1.getDevicePointer());
     }
 }
 

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2025 Stanford University and the Authors.      *
  * Authors: Mark Friedrichs, Peter Eastman                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,7 +34,6 @@
 #include "CudaNonbondedUtilities.h"
 #include "CudaSort.h"
 #include "AmoebaCommonKernels.h"
-#include <cufft.h>
 
 namespace OpenMM {
 
@@ -44,29 +43,14 @@ namespace OpenMM {
 class CudaCalcAmoebaMultipoleForceKernel : public CommonCalcAmoebaMultipoleForceKernel {
 public:
     CudaCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
-            CommonCalcAmoebaMultipoleForceKernel(name, platform, cu, system), hasInitializedFFT(false) {
+            CommonCalcAmoebaMultipoleForceKernel(name, platform, cu, system) {
     }
-    ~CudaCalcAmoebaMultipoleForceKernel();
-    /**
-     * Initialize the kernel.
-     * 
-     * @param system     the System this kernel will be applied to
-     * @param force      the AmoebaMultipoleForce this kernel will be used for
-     */
-    void initialize(const System& system, const AmoebaMultipoleForce& force);
-    /**
-     * Compute the FFT.
-     */
-    void computeFFT(bool forward);
     /**
      * Get whether charge spreading should be done in fixed point.
      */
     bool useFixedPointChargeSpreading() const {
         return cc.getUseDoublePrecision();
     }
-private:
-    bool hasInitializedFFT;
-    cufftHandle fft;
 };
 
 /**
@@ -75,7 +59,7 @@ private:
 class CudaCalcHippoNonbondedForceKernel : public CommonCalcHippoNonbondedForceKernel {
 public:
     CudaCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, CudaContext& cu, const System& system) :
-            CommonCalcHippoNonbondedForceKernel(name, platform, cu, system), sort(NULL), hasInitializedFFT(false) {
+            CommonCalcHippoNonbondedForceKernel(name, platform, cu, system), sort(NULL) {
     }
     ~CudaCalcHippoNonbondedForceKernel();
     /**
@@ -85,10 +69,6 @@ public:
      * @param force      the HippoNonbondedForce this kernel will be used for
      */
     void initialize(const System& system, const HippoNonbondedForce& force);
-    /**
-     * Compute the FFT.
-     */
-    void computeFFT(bool forward, bool dispersion);
     /**
      * Get whether charge spreading should be done in fixed point.
      */
@@ -110,9 +90,7 @@ private:
         const char* getMaxValue() const {return "make_int2(2147483647, 2147483647)";}
         const char* getSortKey() const {return "value.y";}
     };
-    bool hasInitializedFFT;
     CudaSort* sort;
-    cufftHandle fftForward, fftBackward, dfftForward, dfftBackward;
 };
 
 } // namespace OpenMM

--- a/plugins/amoeba/platforms/hip/src/AmoebaHipKernels.h
+++ b/plugins/amoeba/platforms/hip/src/AmoebaHipKernels.h
@@ -34,7 +34,6 @@
 #include "HipContext.h"
 #include "HipNonbondedUtilities.h"
 #include "HipSort.h"
-#include "HipFFT3D.h"
 #include "AmoebaCommonKernels.h"
 
 namespace OpenMM {
@@ -45,20 +44,8 @@ namespace OpenMM {
 class HipCalcAmoebaMultipoleForceKernel : public CommonCalcAmoebaMultipoleForceKernel {
 public:
     HipCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, HipContext& cu, const System& system) :
-            CommonCalcAmoebaMultipoleForceKernel(name, platform, cu, system), cu(cu), fft(NULL) {
+            CommonCalcAmoebaMultipoleForceKernel(name, platform, cu, system), cu(cu) {
     }
-    ~HipCalcAmoebaMultipoleForceKernel();
-    /**
-     * Initialize the kernel.
-     *
-     * @param system     the System this kernel will be applied to
-     * @param force      the AmoebaMultipoleForce this kernel will be used for
-     */
-    void initialize(const System& system, const AmoebaMultipoleForce& force);
-    /**
-     * Compute the FFT.
-     */
-    void computeFFT(bool forward);
     /**
      * Get whether charge spreading should be done in fixed point.
      */
@@ -67,7 +54,6 @@ public:
     }
 private:
     HipContext& cu;
-    HipFFT3D* fft;
 };
 
 /**
@@ -76,7 +62,7 @@ private:
 class HipCalcHippoNonbondedForceKernel : public CommonCalcHippoNonbondedForceKernel {
 public:
     HipCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, HipContext& cu, const System& system) :
-            CommonCalcHippoNonbondedForceKernel(name, platform, cu, system), cu(cu), sort(NULL), fft(NULL), dfft(NULL) {
+            CommonCalcHippoNonbondedForceKernel(name, platform, cu, system), cu(cu), sort(NULL) {
     }
     ~HipCalcHippoNonbondedForceKernel();
     /**
@@ -86,10 +72,6 @@ public:
      * @param force      the HippoNonbondedForce this kernel will be used for
      */
     void initialize(const System& system, const HippoNonbondedForce& force);
-    /**
-     * Compute the FFT.
-     */
-    void computeFFT(bool forward, bool dispersion);
     /**
      * Get whether charge spreading should be done in fixed point.
      */
@@ -113,8 +95,6 @@ private:
     };
     HipContext& cu;
     HipSort* sort;
-    HipFFT3D* fft;
-    HipFFT3D* dfft;
 };
 
 } // namespace OpenMM

--- a/plugins/amoeba/platforms/opencl/src/AmoebaOpenCLKernels.cpp
+++ b/plugins/amoeba/platforms/opencl/src/AmoebaOpenCLKernels.cpp
@@ -41,7 +41,7 @@ OpenCLCalcAmoebaMultipoleForceKernel::~OpenCLCalcAmoebaMultipoleForceKernel() {
 void OpenCLCalcAmoebaMultipoleForceKernel::initialize(const System& system, const AmoebaMultipoleForce& force) {
     CommonCalcAmoebaMultipoleForceKernel::initialize(system, force);
     if (usePME)
-        fft = new OpenCLFFT3D(dynamic_cast<OpenCLContext&>(cc), gridSizeX, gridSizeY, gridSizeZ, false);
+        fft = (OpenCLFFT3D*) cc.createFFT(gridSizeX, gridSizeY, gridSizeZ, false);
 }
 
 void OpenCLCalcAmoebaMultipoleForceKernel::computeFFT(bool forward) {
@@ -71,8 +71,8 @@ void OpenCLCalcHippoNonbondedForceKernel::initialize(const System& system, const
     if (usePME) {
         OpenCLContext& cl = dynamic_cast<OpenCLContext&>(cc);
         sort = new OpenCLSort(cl, new SortTrait(), cc.getNumAtoms());
-        fftForward = new OpenCLFFT3D(cl, gridSizeX, gridSizeY, gridSizeZ, true);
-        dfftForward = new OpenCLFFT3D(cl, dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true);
+        fftForward = cl.createFFT(gridSizeX, gridSizeY, gridSizeZ, true);
+        dfftForward = cl.createFFT(dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true);
         hasInitializedFFT = true;
     }
 }

--- a/plugins/amoeba/platforms/opencl/src/AmoebaOpenCLKernels.cpp
+++ b/plugins/amoeba/platforms/opencl/src/AmoebaOpenCLKernels.cpp
@@ -30,40 +30,12 @@ using namespace OpenMM;
 using namespace std;
 
 /* -------------------------------------------------------------------------- *
- *                             AmoebaMultipole                                *
- * -------------------------------------------------------------------------- */
-
-OpenCLCalcAmoebaMultipoleForceKernel::~OpenCLCalcAmoebaMultipoleForceKernel() {
-    if (fft != NULL)
-        delete fft;
-}
-
-void OpenCLCalcAmoebaMultipoleForceKernel::initialize(const System& system, const AmoebaMultipoleForce& force) {
-    CommonCalcAmoebaMultipoleForceKernel::initialize(system, force);
-    if (usePME)
-        fft = (OpenCLFFT3D*) cc.createFFT(gridSizeX, gridSizeY, gridSizeZ, false);
-}
-
-void OpenCLCalcAmoebaMultipoleForceKernel::computeFFT(bool forward) {
-    OpenCLArray& grid1 = dynamic_cast<OpenCLContext&>(cc).unwrap(pmeGrid1);
-    OpenCLArray& grid2 = dynamic_cast<OpenCLContext&>(cc).unwrap(pmeGrid2);
-    if (forward)
-        fft->execFFT(grid1, grid2, true);
-    else
-        fft->execFFT(grid2, grid1, false);
-}
-
-/* -------------------------------------------------------------------------- *
  *                           HippoNonbondedForce                              *
  * -------------------------------------------------------------------------- */
 
 OpenCLCalcHippoNonbondedForceKernel::~OpenCLCalcHippoNonbondedForceKernel() {
     if (sort != NULL)
         delete sort;
-    if (hasInitializedFFT) {
-        delete fftForward;
-        delete dfftForward;
-    }
 }
 
 void OpenCLCalcHippoNonbondedForceKernel::initialize(const System& system, const HippoNonbondedForce& force) {
@@ -71,20 +43,7 @@ void OpenCLCalcHippoNonbondedForceKernel::initialize(const System& system, const
     if (usePME) {
         OpenCLContext& cl = dynamic_cast<OpenCLContext&>(cc);
         sort = new OpenCLSort(cl, new SortTrait(), cc.getNumAtoms());
-        fftForward = cl.createFFT(gridSizeX, gridSizeY, gridSizeZ, true);
-        dfftForward = cl.createFFT(dispersionGridSizeX, dispersionGridSizeY, dispersionGridSizeZ, true);
-        hasInitializedFFT = true;
     }
-}
-
-void OpenCLCalcHippoNonbondedForceKernel::computeFFT(bool forward, bool dispersion) {
-    OpenCLArray& grid1 = dynamic_cast<OpenCLContext&>(cc).unwrap(pmeGrid1);
-    OpenCLArray& grid2 = dynamic_cast<OpenCLContext&>(cc).unwrap(pmeGrid2);
-    OpenCLFFT3D* fft = (dispersion ? dfftForward : fftForward);
-    if (forward)
-        fft->execFFT(grid1, grid2, true);
-    else
-        fft->execFFT(grid2, grid1, false);
 }
 
 void OpenCLCalcHippoNonbondedForceKernel::sortGridIndex() {

--- a/plugins/amoeba/platforms/opencl/src/AmoebaOpenCLKernels.h
+++ b/plugins/amoeba/platforms/opencl/src/AmoebaOpenCLKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2021 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2025 Stanford University and the Authors.      *
  * Authors: Mark Friedrichs, Peter Eastman                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -32,7 +32,6 @@
 #include "openmm/System.h"
 #include "AmoebaCommonKernels.h"
 #include "OpenCLContext.h"
-#include "OpenCLFFT3D.h"
 #include "OpenCLSort.h"
 
 namespace OpenMM {
@@ -43,28 +42,14 @@ namespace OpenMM {
 class OpenCLCalcAmoebaMultipoleForceKernel : public CommonCalcAmoebaMultipoleForceKernel {
 public:
     OpenCLCalcAmoebaMultipoleForceKernel(const std::string& name, const Platform& platform, OpenCLContext& cl, const System& system) :
-            CommonCalcAmoebaMultipoleForceKernel(name, platform, cl, system), fft(NULL) {
+            CommonCalcAmoebaMultipoleForceKernel(name, platform, cl, system) {
     }
-    ~OpenCLCalcAmoebaMultipoleForceKernel();
-    /**
-     * Initialize the kernel.
-     * 
-     * @param system     the System this kernel will be applied to
-     * @param force      the AmoebaMultipoleForce this kernel will be used for
-     */
-    void initialize(const System& system, const AmoebaMultipoleForce& force);
-    /**
-     * Compute the FFT.
-     */
-    void computeFFT(bool forward);
     /**
      * Get whether charge spreading should be done in fixed point.
      */
     bool useFixedPointChargeSpreading() const {
         return true;
     }
-private:
-    OpenCLFFT3D* fft;
 };
 
 
@@ -74,7 +59,7 @@ private:
 class OpenCLCalcHippoNonbondedForceKernel : public CommonCalcHippoNonbondedForceKernel {
 public:
     OpenCLCalcHippoNonbondedForceKernel(const std::string& name, const Platform& platform, OpenCLContext& cl, const System& system) :
-            CommonCalcHippoNonbondedForceKernel(name, platform, cl, system), sort(NULL), hasInitializedFFT(false) {
+            CommonCalcHippoNonbondedForceKernel(name, platform, cl, system), sort(NULL) {
     }
     ~OpenCLCalcHippoNonbondedForceKernel();
     /**
@@ -84,10 +69,6 @@ public:
      * @param force      the HippoNonbondedForce this kernel will be used for
      */
     void initialize(const System& system, const HippoNonbondedForce& force);
-    /**
-     * Compute the FFT.
-     */
-    void computeFFT(bool forward, bool dispersion);
     /**
      * Get whether charge spreading should be done in fixed point.
      */
@@ -109,9 +90,7 @@ private:
         const char* getMaxValue() const {return "make_int2(2147483647, 2147483647)";}
         const char* getSortKey() const {return "value.y";}
     };
-    bool hasInitializedFFT;
     OpenCLSort* sort;
-    OpenCLFFT3D *fftForward, *fftBackward, *dfftForward, *dfftBackward;
 };
 
 } // namespace OpenMM


### PR DESCRIPTION
This is the first piece of a project to unify more of the code for NonbondedForce between the GPU platforms.  I created a generic FFT3D interface, with each platform providing an implementation.  You create an instance by calling `createFFT()` on the ComputeContext.  This allows a lot of code to be made more consistent.