### PR TITLE
Unified interface for queues

### DIFF
--- a/platforms/common/include/openmm/common/ComputeContext.h
+++ b/platforms/common/include/openmm/common/ComputeContext.h
@@ -36,6 +36,7 @@
 #include "openmm/common/ComputeEvent.h"
 #include "openmm/common/ComputeForceInfo.h"
 #include "openmm/common/ComputeProgram.h"
+#include "openmm/common/ComputeQueue.h"
 #include "openmm/common/ComputeVectorTypes.h"
 #include "openmm/common/FFT3D.h"
 #include "openmm/common/IntegrationUtilities.h"
@@ -143,6 +144,22 @@ public:
      * multiple devices.
      */
     virtual double& getEnergyWorkspace() = 0;
+    /**
+     * Create a new ComputeQueue for use with this context.
+     */
+    virtual ComputeQueue createQueue() = 0;
+    /**
+     * Get the ComputeQueue currently being used for execution.
+     */
+    ComputeQueue getCurrentQueue();
+    /**
+     * Set the ComputeQueue to use for execution.
+     */
+    void setCurrentQueue(ComputeQueue queue);
+    /**
+     * Reset the context to using the default queue for execution.
+     */
+    void restoreDefaultQueue();
     /**
      * Construct an uninitialized array of the appropriate class for this platform.  The returned
      * value should be created on the heap with the "new" operator.
@@ -560,6 +577,7 @@ protected:
     int numAtoms, paddedNumAtoms, computeForceCount, stepsSinceReorder;
     long long stepCount;
     bool forceNextReorder, atomsWereReordered, forcesValid;
+    ComputeQueue defaultQueue, currentQueue;
     std::vector<ComputeForceInfo*> forces;
     std::vector<Molecule> molecules;
     std::vector<MoleculeGroup> moleculeGroups;

--- a/platforms/common/include/openmm/common/ComputeQueue.h
+++ b/platforms/common/include/openmm/common/ComputeQueue.h
@@ -1,3 +1,6 @@
+#ifndef OPENMM_COMPUTEQUEUE_H_
+#define OPENMM_COMPUTEQUEUE_H_
+
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -6,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019-2025 Stanford University and the Authors.      *
+ * Portions copyright (c) 2025 Stanford University and the Authors.           *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -24,18 +27,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#include "OpenCLEvent.h"
-#include "OpenCLQueue.h"
+#include "openmm/common/windowsExportCommon.h"
+#include <memory>
 
-using namespace OpenMM;
+namespace OpenMM {
 
-OpenCLEvent::OpenCLEvent(OpenCLContext& context) : context(context) {
-}
+/**
+ * This abstract class represents a queue within which kernels can be executed.  Call
+ * createQueue() on a ComputeContext to create an instance of a platform-specific
+ * subclass.  You can then pass it to the ComputeContext's setQueue() method to cause
+ * kernels to be launched on it.
+ * 
+ * Instead of referring to this class directly, it is best to use ComputeQueue, which is
+ * a typedef for a shared_ptr to a ComputeQueueImpl.  This allows you to treat it as having
+ * value semantics, and frees you from having to manage memory.  
+ */
 
-void OpenCLEvent::enqueue() {
-    dynamic_cast<OpenCLQueue*>(context.getCurrentQueue().get())->getQueue().enqueueMarkerWithWaitList(NULL, &event);
-}
+class OPENMM_EXPORT_COMMON ComputeQueueImpl {
+public:
+    virtual ~ComputeQueueImpl() {
+    }
+};
 
-void OpenCLEvent::wait() {
-    event.wait();
-}
+typedef std::shared_ptr<ComputeQueueImpl> ComputeQueue;
+
+} // namespace OpenMM
+
+#endif /*OPENMM_COMPUTEQUEUE_H_*/

--- a/platforms/common/src/ComputeContext.cpp
+++ b/platforms/common/src/ComputeContext.cpp
@@ -52,6 +52,18 @@ ComputeContext::ComputeContext(const System& system) : system(system), time(0.0)
 ComputeContext::~ComputeContext() {
 }
 
+ComputeQueue ComputeContext::getCurrentQueue() {
+    return currentQueue;
+}
+
+void ComputeContext::setCurrentQueue(ComputeQueue queue) {
+    currentQueue = queue;
+}
+
+void ComputeContext::restoreDefaultQueue() {
+    currentQueue = defaultQueue;
+}
+
 void ComputeContext::addForce(ComputeForceInfo* force) {
     forces.push_back(force);
 }

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -584,7 +584,6 @@ private:
     std::map<std::string, std::string> compilationDefines;
     CUcontext context;
     CUdevice device;
-    CUstream currentStream;
     CUfunction clearBufferKernel;
     CUfunction clearTwoBuffersKernel;
     CUfunction clearThreeBuffersKernel;

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -46,6 +46,7 @@
 #include "CudaIntegrationUtilities.h"
 #include "CudaNonbondedUtilities.h"
 #include "CudaPlatform.h"
+#include "CudaQueue.h"
 #include "openmm/OpenMMException.h"
 #include "openmm/common/ComputeContext.h"
 #include "openmm/Kernel.h"
@@ -159,17 +160,13 @@ public:
      */
     double& getEnergyWorkspace();
     /**
+     * Create a new ComputeQueue for use with this context.
+     */
+    ComputeQueue createQueue();
+    /**
      * Get the stream currently being used for execution.
      */
     CUstream getCurrentStream();
-    /**
-     * Set the stream to use for execution.
-     */
-    void setCurrentStream(CUstream stream);
-    /**
-     * Reset the context to using the default stream for execution.
-     */
-    void restoreDefaultStream();
     /**
      * Construct an uninitialized array of the appropriate class for this platform.  The returned
      * value should be created on the heap with the "new" operator.

--- a/platforms/cuda/include/CudaFFT3D.h
+++ b/platforms/cuda/include/CudaFFT3D.h
@@ -64,10 +64,6 @@ public:
     CudaFFT3D(CudaContext& context, int xsize, int ysize, int zsize, bool realToComplex=false);
     ~CudaFFT3D();
     /**
-     * Set the stream to perform the FFT on.
-     */
-    void setStream(CUstream stream);
-    /**
      * Perform a Fourier transform.  The transform cannot be done in-place: the input and output
      * arrays must be different.  Also, the input array is used as workspace, so its contents
      * are destroyed.  This also means that both arrays must be large enough to hold complex values,

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -185,7 +185,7 @@ private:
     CudaSort* sort;
     Kernel cpuPme;
     PmeIO* pmeio;
-    CUstream pmeStream;
+    ComputeQueue pmeQueue;
     CUevent pmeSyncEvent, paramsSyncEvent;
     CudaFFT3D* fft;
     CudaFFT3D* dispersionFft;

--- a/platforms/cuda/include/CudaQueue.h
+++ b/platforms/cuda/include/CudaQueue.h
@@ -1,3 +1,6 @@
+#ifndef OPENMM_CUDAQUEUE_H_
+#define OPENMM_CUDAQUEUE_H_
+
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -6,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019-2025 Stanford University and the Authors.      *
+ * Portions copyright (c) 2025 Stanford University and the Authors.           *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -24,18 +27,37 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#include "OpenCLEvent.h"
-#include "OpenCLQueue.h"
+#include "openmm/common/ComputeQueue.h"
+#include <cuda.h>
 
-using namespace OpenMM;
+namespace OpenMM {
 
-OpenCLEvent::OpenCLEvent(OpenCLContext& context) : context(context) {
-}
+/**
+ * This is the CUDA implementation of the ComputeQueue interface.  It wraps a CUstream.
+ */
 
-void OpenCLEvent::enqueue() {
-    dynamic_cast<OpenCLQueue*>(context.getCurrentQueue().get())->getQueue().enqueueMarkerWithWaitList(NULL, &event);
-}
+class CudaQueue : public ComputeQueueImpl {
+public:
+    /**
+     * Create a CudaQueue that wraps an existing CUstream.
+     */
+    CudaQueue(CUstream);
+    /**
+     * Create a CudaQueue that create a new CUstream.
+     */
+    CudaQueue();
+    ~CudaQueue();
+    /**
+     * Get the CUstream.
+     */
+    CUstream getStream() {
+        return stream;
+    }
+private:
+    CUstream stream;
+    bool initialized;
+};
 
-void OpenCLEvent::wait() {
-    event.wait();
-}
+} // namespace OpenMM
+
+#endif /*OPENMM_CUDAQUEUE_H_*/

--- a/platforms/cuda/src/CudaFFT3D.cpp
+++ b/platforms/cuda/src/CudaFFT3D.cpp
@@ -64,16 +64,12 @@ CudaFFT3D::~CudaFFT3D() {
     }
 }
 
-void CudaFFT3D::setStream(CUstream stream) {
-    cufftSetStream(fftForward, stream);
-    cufftSetStream(fftBackward, stream);
-}
-
 void CudaFFT3D::execFFT(ArrayInterface& in, ArrayInterface& out, bool forward) {
     CUdeviceptr in2 = context.unwrap(in).getDevicePointer();
     CUdeviceptr out2 = context.unwrap(out).getDevicePointer();
     cufftResult result;
     if (forward) {
+        cufftSetStream(fftForward, context.getCurrentStream());
         if (realToComplex) {
             if (context.getUseDoublePrecision())
                 result = cufftExecD2Z(fftForward, (double*) in2, (double2*) out2);
@@ -88,6 +84,7 @@ void CudaFFT3D::execFFT(ArrayInterface& in, ArrayInterface& out, bool forward) {
         }
     }
     else {
+        cufftSetStream(fftBackward, context.getCurrentStream());
         if (realToComplex) {
             if (context.getUseDoublePrecision())
                 result = cufftExecZ2D(fftBackward, (double2*) in2, (double*) out2);

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -543,9 +543,6 @@ void CudaCalcNonbondedForceKernel::initialize(const System& system, const Nonbon
 
                 if (usePmeStream) {
                     pmeQueue = cu.createQueue();
-                    fft->setStream(dynamic_cast<CudaQueue*>(pmeQueue.get())->getStream());
-                    if (doLJPME)
-                        dispersionFft->setStream(dynamic_cast<CudaQueue*>(pmeQueue.get())->getStream());
                     CHECK_RESULT(cuEventCreate(&pmeSyncEvent, cu.getEventFlags()), "Error creating event for NonbondedForce");
                     CHECK_RESULT(cuEventCreate(&paramsSyncEvent, cu.getEventFlags()), "Error creating event for NonbondedForce");
                     int recipForceGroup = force.getReciprocalSpaceForceGroup();

--- a/platforms/hip/include/HipContext.h
+++ b/platforms/hip/include/HipContext.h
@@ -162,17 +162,13 @@ public:
      */
     double& getEnergyWorkspace();
     /**
+     * Create a new ComputeQueue for use with this context.
+     */
+    ComputeQueue createQueue();
+    /**
      * Get the stream currently being used for execution.
      */
     hipStream_t getCurrentStream();
-    /**
-     * Set the stream to use for execution.
-     */
-    void setCurrentStream(hipStream_t stream);
-    /**
-     * Reset the context to using the default stream for execution.
-     */
-    void restoreDefaultStream();
     /**
      * Construct an uninitialized array of the appropriate class for this platform.  The returned
      * value should be created on the heap with the "new" operator.
@@ -632,8 +628,6 @@ private:
     std::map<std::string, std::string> compilationDefines;
     std::vector<hipModule_t> loadedModules;
     hipDevice_t device;
-    hipStream_t currentStream;
-    hipStream_t defaultStream;
     hipFunction_t clearBufferKernel;
     hipFunction_t clearTwoBuffersKernel;
     hipFunction_t clearThreeBuffersKernel;

--- a/platforms/hip/include/HipKernels.h
+++ b/platforms/hip/include/HipKernels.h
@@ -186,7 +186,7 @@ private:
     HipSort* sort;
     Kernel cpuPme;
     PmeIO* pmeio;
-    hipStream_t pmeStream;
+    ComputeQueue pmeQueue;
     hipEvent_t pmeSyncEvent, paramsSyncEvent;
     HipFFT3D* fft;
     HipFFT3D* dispersionFft;

--- a/platforms/hip/include/HipQueue.h
+++ b/platforms/hip/include/HipQueue.h
@@ -1,5 +1,5 @@
-#ifndef OPENMM_CUDAQUEUE_H_
-#define OPENMM_CUDAQUEUE_H_
+#ifndef OPENMM_HIPQUEUE_H_
+#define OPENMM_HIPQUEUE_H_
 
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
@@ -28,36 +28,36 @@
  * -------------------------------------------------------------------------- */
 
 #include "openmm/common/ComputeQueue.h"
-#include <cuda.h>
+#include <hip/hip_runtime.h>
 
 namespace OpenMM {
 
 /**
- * This is the CUDA implementation of the ComputeQueue interface.  It wraps a CUstream.
+ * This is the HIP implementation of the ComputeQueue interface.  It wraps a hipStream_t.
  */
 
-class CudaQueue : public ComputeQueueImpl {
+class HipQueue : public ComputeQueueImpl {
 public:
     /**
-     * Create a CudaQueue that wraps an existing CUstream.
+     * Create a HipQueue that wraps an existing hipStream_t.
      */
-    CudaQueue(CUstream stream);
+    HipQueue(hipStream_t stream);
     /**
-     * Create a CudaQueue that create a new CUstream.
+     * Create a HipQueue that create a new hipStream_t.
      */
-    CudaQueue();
-    ~CudaQueue();
+    HipQueue();
+    ~HipQueue();
     /**
      * Get the CUstream.
      */
-    CUstream getStream() {
+    hipStream_t getStream() {
         return stream;
     }
 private:
-    CUstream stream;
+    hipStream_t stream;
     bool initialized;
 };
 
 } // namespace OpenMM
 
-#endif /*OPENMM_CUDAQUEUE_H_*/
+#endif /*OPENMM_HIPQUEUE_H_*/

--- a/platforms/opencl/include/OpenCLArray.h
+++ b/platforms/opencl/include/OpenCLArray.h
@@ -188,6 +188,10 @@ public:
      */
     ComputeContext& getContext();
     /**
+     * Get the queue in which to perform transfers.
+     */
+    cl::CommandQueue getQueue() const;
+    /**
      * Get the OpenCL Buffer object.
      */
     cl::Buffer& getDeviceBuffer() {

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -203,17 +203,13 @@ public:
      */
     double& getEnergyWorkspace();
     /**
+     * Create a new ComputeQueue for use with this context.
+     */
+    ComputeQueue createQueue();
+    /*
      * Get the cl::CommandQueue currently being used for execution.
      */
-    cl::CommandQueue& getQueue();
-    /**
-     * Set the cl::ComandQueue to use for execution.
-     */
-    void setQueue(cl::CommandQueue& queue);
-    /**
-     * Reset the context to using the default queue for execution.
-     */
-    void restoreDefaultQueue();
+    cl::CommandQueue getQueue();
     /**
      * Construct an uninitialized array of the appropriate class for this platform.  The returned
      * value should be created on the heap with the "new" operator.
@@ -706,7 +702,6 @@ private:
     std::map<std::string, std::string> compilationDefines;
     cl::Context context;
     cl::Device device;
-    cl::CommandQueue defaultQueue, currentQueue;
     cl::Kernel clearBufferKernel;
     cl::Kernel clearTwoBuffersKernel;
     cl::Kernel clearThreeBuffersKernel;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -185,7 +185,7 @@ private:
     OpenCLArray pmeEnergyBuffer;
     OpenCLArray chargeBuffer;
     OpenCLSort* sort;
-    cl::CommandQueue pmeQueue;
+    ComputeQueue pmeQueue;
     cl::Event pmeSyncEvent;
     OpenCLFFT3D* fft;
     OpenCLFFT3D* dispersionFft;

--- a/platforms/opencl/include/OpenCLQueue.h
+++ b/platforms/opencl/include/OpenCLQueue.h
@@ -1,3 +1,6 @@
+#ifndef OPENMM_OPENCLQUEUE_H_
+#define OPENMM_OPENCLQUEUE_H_
+
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -6,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2019-2025 Stanford University and the Authors.      *
+ * Portions copyright (c) 2025 Stanford University and the Authors.           *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -24,18 +27,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#include "OpenCLEvent.h"
-#include "OpenCLQueue.h"
+#include "openmm/common/ComputeQueue.h"
+#include "opencl.hpp"
 
-using namespace OpenMM;
+namespace OpenMM {
 
-OpenCLEvent::OpenCLEvent(OpenCLContext& context) : context(context) {
-}
+/**
+ * This is the OpenCL implementation of the ComputeQueue interface.  It wraps a cl::CommandQueue.
+ */
 
-void OpenCLEvent::enqueue() {
-    dynamic_cast<OpenCLQueue*>(context.getCurrentQueue().get())->getQueue().enqueueMarkerWithWaitList(NULL, &event);
-}
+class OpenCLQueue : public ComputeQueueImpl {
+public:
+    /**
+     * Create an OpenCLQueue that wraps a cl::CommandQueue.
+     */
+    OpenCLQueue(cl::CommandQueue queue) : queue(queue) {
+    }
+    /**
+     * Get the cl::CommandQueue.
+     */
+    cl::CommandQueue getQueue() {
+        return queue;
+    }
+private:
+    cl::CommandQueue queue;
+};
 
-void OpenCLEvent::wait() {
-    event.wait();
-}
+} // namespace OpenMM
+
+#endif /*OPENMM_OPENCLQUEUE_H_*/

--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -37,6 +37,7 @@
 #include "OpenCLKernelSources.h"
 #include "OpenCLNonbondedUtilities.h"
 #include "OpenCLProgram.h"
+#include "OpenCLQueue.h"
 #include "openmm/common/ComputeArray.h"
 #include "openmm/MonteCarloFlexibleBarostat.h"
 #include "openmm/Platform.h"
@@ -302,10 +303,10 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
         if (originalContext == NULL) {
             context = cl::Context(contextDevices, cprops, errorCallback);
 #ifdef ENABLE_PROFILING
-            defaultQueue = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE);
+            defaultQueue = shared_ptr<ComputeQueueImpl>(new OpenCLQueue(cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE)));
             printf("[ ");
 #else
-            defaultQueue = cl::CommandQueue(context, device);
+            defaultQueue = shared_ptr<ComputeQueueImpl>(new OpenCLQueue(cl::CommandQueue(context, device)));
 #endif
         }
         else {
@@ -559,7 +560,7 @@ void OpenCLContext::initialize() {
             energyBufferSize*energyBuffer.getElementSize()),
             (int) longForceBuffer.getSize()*longForceBuffer.getElementSize());
     pinnedBuffer = new cl::Buffer(context, CL_MEM_ALLOC_HOST_PTR, bufferBytes);
-    pinnedMemory = currentQueue.enqueueMapBuffer(*pinnedBuffer, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, bufferBytes);
+    pinnedMemory = getQueue().enqueueMapBuffer(*pinnedBuffer, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, bufferBytes);
     for (int i = 0; i < numAtoms; i++) {
         double mass = system.getParticleMass(i);
         if (useDoublePrecision || useMixedPrecision)
@@ -670,16 +671,12 @@ double& OpenCLContext::getEnergyWorkspace() {
     return platformData.contextEnergy[contextIndex];
 }
 
-cl::CommandQueue& OpenCLContext::getQueue() {
-    return currentQueue;
+ComputeQueue OpenCLContext::createQueue() {
+    return shared_ptr<ComputeQueueImpl>(new OpenCLQueue(cl::CommandQueue(context, device)));
 }
 
-void OpenCLContext::setQueue(cl::CommandQueue& queue) {
-    currentQueue = queue;
-}
-
-void OpenCLContext::restoreDefaultQueue() {
-    currentQueue = defaultQueue;
+cl::CommandQueue OpenCLContext::getQueue() {
+    return dynamic_cast<OpenCLQueue*>(currentQueue.get())->getQueue();
 }
 
 OpenCLArray* OpenCLContext::createArray() {
@@ -714,13 +711,13 @@ void OpenCLContext::executeKernel(cl::Kernel& kernel, int workUnits, int blockSi
     try {
 #ifdef ENABLE_PROFILING
     cl::Event event;
-    currentQueue.enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(size), cl::NDRange(blockSize), NULL, &event);
+    getQueue().enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(size), cl::NDRange(blockSize), NULL, &event);
     profilingEvents.push_back(event);
     profilingKernelNames.push_back(kernel.getInfo<CL_KERNEL_FUNCTION_NAME>());
     if (profilingEvents.size() >= 500)
         printProfilingEvents();
 #else
-        currentQueue.enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(size), cl::NDRange(blockSize));
+        getQueue().enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(size), cl::NDRange(blockSize));
 #endif
     }
     catch (cl::Error err) {


### PR DESCRIPTION
This is the second piece of unifying the NonbondedForce code.  I created an abstract ComputeQueue class.  Platform-specific subclasses wrap a cl::CommandQueue, CUstream, or hipStream_t.