### PR TITLE
Periodic molecules with AmoebaMultipoleForce and HippoNonbondedForce

### DIFF
--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
@@ -490,6 +490,10 @@ void CommonCalcAmoebaMultipoleForceKernel::initialize(const System& system, cons
     computeMomentsKernel->addArg(labQuadrupoles);
     computeMomentsKernel->addArg(sphericalDipoles);
     computeMomentsKernel->addArg(sphericalQuadrupoles);
+    if (usePME) {
+        for (int i = 0; i < 5; ++i)
+            computeMomentsKernel->addArg();
+    }
     recordInducedDipolesKernel = program->createKernel("recordInducedDipoles");
     recordInducedDipolesKernel->addArg(field);
     recordInducedDipolesKernel->addArg(fieldPolar);
@@ -504,6 +508,10 @@ void CommonCalcAmoebaMultipoleForceKernel::initialize(const System& system, cons
     mapTorqueKernel->addArg(torque);
     mapTorqueKernel->addArg(cc.getPosq());
     mapTorqueKernel->addArg(multipoleParticles);
+    if (usePME) {
+        for (int i = 0; i < 5; ++i)
+            mapTorqueKernel->addArg();
+    }
     computePotentialKernel = program->createKernel("computePotentialAtPoints");
     computePotentialKernel->addArg(cc.getPosq());
     computePotentialKernel->addArg(labDipoles);
@@ -1064,6 +1072,8 @@ double CommonCalcAmoebaMultipoleForceKernel::execute(ContextImpl& context, bool 
     
     // Compute the lab frame moments.
 
+    if (usePME)
+        setPeriodicBoxArgs(cc, computeMomentsKernel, 8);
     computeMomentsKernel->execute(cc.getNumAtoms());
     int startTileIndex = nb.getStartTileIndex();
     int numTileIndices = nb.getNumTiles();
@@ -1219,6 +1229,8 @@ double CommonCalcAmoebaMultipoleForceKernel::execute(ContextImpl& context, bool 
 
     // Map torques to force.
 
+    if (usePME)
+        setPeriodicBoxArgs(cc, mapTorqueKernel, 4);
     mapTorqueKernel->execute(cc.getNumAtoms());
     
     // Record the current atom positions so we can tell later if they have changed.
@@ -2625,6 +2637,10 @@ void CommonCalcHippoNonbondedForceKernel::initialize(const System& system, const
     computeMomentsKernel->addArg(labQuadrupoles[2]);
     computeMomentsKernel->addArg(labQuadrupoles[3]);
     computeMomentsKernel->addArg(labQuadrupoles[4]);
+    if (usePME) {
+        for (int i = 0; i < 5; ++i)
+            computeMomentsKernel->addArg();
+    }
     recordInducedDipolesKernel = program->createKernel("recordInducedDipoles");
     recordInducedDipolesKernel->addArg(field);
     recordInducedDipolesKernel->addArg(inducedDipole);
@@ -2634,6 +2650,10 @@ void CommonCalcHippoNonbondedForceKernel::initialize(const System& system, const
     mapTorqueKernel->addArg(torque);
     mapTorqueKernel->addArg(cc.getPosq());
     mapTorqueKernel->addArg(multipoleParticles);
+    if (usePME) {
+        for (int i = 0; i < 5; ++i)
+            mapTorqueKernel->addArg();
+    }
     program = cc.compileProgram(CommonAmoebaKernelSources::multipoleInducedField, defines);
     initExtrapolatedKernel = program->createKernel("initExtrapolatedDipoles");
     initExtrapolatedKernel->addArg(inducedDipole);
@@ -3236,6 +3256,8 @@ double CommonCalcHippoNonbondedForceKernel::execute(ContextImpl& context, bool i
 
     // Compute the lab frame moments.
 
+    if (usePME)
+        setPeriodicBoxArgs(cc, computeMomentsKernel, 10);
     computeMomentsKernel->execute(cc.getNumAtoms());
 
     if (usePME) {
@@ -3444,6 +3466,8 @@ void CommonCalcHippoNonbondedForceKernel::computeExtrapolatedDipoles() {
 }
 
 void CommonCalcHippoNonbondedForceKernel::addTorquesToForces() {
+    if (usePME)
+        setPeriodicBoxArgs(cc, mapTorqueKernel, 4);
     mapTorqueKernel->execute(cc.getNumAtoms());
 }
 

--- a/plugins/amoeba/platforms/common/src/kernels/multipoles.cc
+++ b/plugins/amoeba/platforms/common/src/kernels/multipoles.cc
@@ -2,7 +2,11 @@
 
 KERNEL void computeLabFrameMoments(GLOBAL real4* RESTRICT posq, GLOBAL int4* RESTRICT multipoleParticles, GLOBAL float* RESTRICT molecularDipoles,
         GLOBAL float* RESTRICT molecularQuadrupoles, GLOBAL real* RESTRICT labFrameDipoles, GLOBAL real* RESTRICT labFrameQuadrupoles,
-        GLOBAL real* RESTRICT sphericalDipoles, GLOBAL real* RESTRICT sphericalQuadrupoles) {
+        GLOBAL real* RESTRICT sphericalDipoles, GLOBAL real* RESTRICT sphericalQuadrupoles
+#ifdef USE_PERIODIC
+        ,real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ
+#endif
+         ) {
     for (int atom = GLOBAL_ID; atom < NUM_ATOMS; atom += GLOBAL_SIZE) {
         // Load the spherical multipoles.
         
@@ -29,7 +33,11 @@ KERNEL void computeLabFrameMoments(GLOBAL real4* RESTRICT posq, GLOBAL int4* RES
         if (particles.z >= 0) {
             real4 thisParticlePos = posq[atom];
             real4 posZ = posq[particles.z];
-            real3 vectorZ = normalize(make_real3(posZ.x-thisParticlePos.x, posZ.y-thisParticlePos.y, posZ.z-thisParticlePos.z));
+            real3 vectorZ = make_real3(posZ.x-thisParticlePos.x, posZ.y-thisParticlePos.y, posZ.z-thisParticlePos.z);
+#ifdef USE_PERIODIC
+            APPLY_PERIODIC_TO_DELTA(vectorZ)
+#endif
+            vectorZ = normalize(vectorZ);
             int axisType = particles.w; 
             real4 posX;
             real3 vectorX;
@@ -42,6 +50,9 @@ KERNEL void computeLabFrameMoments(GLOBAL real4* RESTRICT posq, GLOBAL int4* RES
             else {
                 posX = posq[particles.x];
                 vectorX = make_real3(posX.x-thisParticlePos.x, posX.y-thisParticlePos.y, posX.z-thisParticlePos.z);
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(vectorX)
+#endif
             }
     
             /*
@@ -102,6 +113,9 @@ KERNEL void computeLabFrameMoments(GLOBAL real4* RESTRICT posq, GLOBAL int4* RES
                 if (particles.y >= 0 && particles.y < NUM_ATOMS) {
                     real4 posY = posq[particles.y];
                     real3 vectorY = make_real3(posY.x-thisParticlePos.x, posY.y-thisParticlePos.y, posY.z-thisParticlePos.z);
+#ifdef USE_PERIODIC
+                    APPLY_PERIODIC_TO_DELTA(vectorY)
+#endif
                     vectorY = normalize(vectorY);
                     vectorX = normalize(vectorX);
                     if (axisType == 2) {
@@ -147,25 +161,37 @@ KERNEL void computeLabFrameMoments(GLOBAL real4* RESTRICT posq, GLOBAL int4* RES
             bool reverse = false;
             if (axisType == 0 && particles.x >= 0 && particles.y >=0 && particles.z >= 0) {
                 real4 posY = posq[particles.y];
-                real delta[4][3];
+                real3 delta[4];
 
-                delta[0][0] = thisParticlePos.x - posY.x;
-                delta[0][1] = thisParticlePos.y - posY.y;
-                delta[0][2] = thisParticlePos.z - posY.z;
+                delta[0].x = thisParticlePos.x - posY.x;
+                delta[0].y = thisParticlePos.y - posY.y;
+                delta[0].z = thisParticlePos.z - posY.z;
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(delta[0])
+#endif
 
-                delta[1][0] = posZ.x - posY.x;
-                delta[1][1] = posZ.y - posY.y;
-                delta[1][2] = posZ.z - posY.z;
+                delta[1].x = posZ.x - posY.x;
+                delta[1].y = posZ.y - posY.y;
+                delta[1].z = posZ.z - posY.z;
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(delta[1])
+#endif
 
-                delta[2][0] = posX.x - posY.x;
-                delta[2][1] = posX.y - posY.y;
-                delta[2][2] = posX.z - posY.z;
+                delta[2].x = posX.x - posY.x;
+                delta[2].y = posX.y - posY.y;
+                delta[2].z = posX.z - posY.z;
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(delta[2])
+#endif
 
-                delta[3][0] = delta[1][1]*delta[2][2] - delta[1][2]*delta[2][1];
-                delta[3][1] = delta[2][1]*delta[0][2] - delta[2][2]*delta[0][1];
-                delta[3][2] = delta[0][1]*delta[1][2] - delta[0][2]*delta[1][1];
+                delta[3].x = delta[1].y*delta[2].z - delta[1].z*delta[2].y;
+                delta[3].y = delta[2].y*delta[0].z - delta[2].z*delta[0].y;
+                delta[3].z = delta[0].y*delta[1].z - delta[0].z*delta[1].y;
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(delta[3])
+#endif
 
-                real volume = delta[3][0]*delta[0][0] + delta[3][1]*delta[1][0] + delta[3][2]*delta[2][0];
+                real volume = delta[3].x*delta[0].x + delta[3].y*delta[1].x + delta[3].z*delta[2].x;
                 reverse = (volume < 0);
             }
         
@@ -326,7 +352,11 @@ inline DEVICE real normVector(real3* v) {
  * Compute the force on each particle due to the torque.
  */
 KERNEL void mapTorqueToForce(GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL const mm_long* RESTRICT torqueBuffers,
-        GLOBAL const real4* RESTRICT posq, GLOBAL const int4* RESTRICT multipoleParticles) {
+        GLOBAL const real4* RESTRICT posq, GLOBAL const int4* RESTRICT multipoleParticles
+#ifdef USE_PERIODIC
+        ,real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ
+#endif
+         ) {
     const int U = 0;
     const int V = 1;
     const int W = 2;
@@ -362,9 +392,16 @@ KERNEL void mapTorqueToForce(GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL cons
         if (axisType < 5 && particles.z >= 0) {
             real3 atomPos = trimTo3(posq[atom]);
             vector[U] = atomPos - trimTo3(posq[axisAtom]);
+#ifdef USE_PERIODIC
+            APPLY_PERIODIC_TO_DELTA(vector[U])
+#endif
             norms[U] = normVector(&vector[U]);
-            if (axisType != 4 && particles.x >= 0)
+            if (axisType != 4 && particles.x >= 0) {
                 vector[V] = atomPos - trimTo3(posq[particles.x]);
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(vector[V])
+#endif
+            }
             else {
                 if (fabs(vector[U].x/norms[U]) < 0.866)
                     vector[V] = make_real3(1, 0, 0);
@@ -377,8 +414,12 @@ KERNEL void mapTorqueToForce(GLOBAL mm_ulong* RESTRICT forceBuffers, GLOBAL cons
         
             if (axisType < 2 || axisType > 3)
                 vector[W] = cross(vector[U], vector[V]);
-            else
+            else {
                 vector[W] = atomPos - trimTo3(posq[particles.y]);
+#ifdef USE_PERIODIC
+                APPLY_PERIODIC_TO_DELTA(vector[W])
+#endif
+            }
             norms[W] = normVector(&vector[W]);
         
             vector[UV] = cross(vector[V], vector[U]);

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceHippoNonbondedForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceHippoNonbondedForce.cpp
@@ -126,6 +126,12 @@ void AmoebaReferenceHippoNonbondedForce::checkChiralCenterAtParticle(MultipolePa
     Vec3 deltaBD   = particleZ.position - particleY.position;
     Vec3 deltaCD   = particleX.position - particleY.position;
 
+    if (_nonbondedMethod == HippoNonbondedForce::PME) {
+        getPeriodicDelta(deltaAD);
+        getPeriodicDelta(deltaBD);
+        getPeriodicDelta(deltaCD);
+    }
+
     Vec3 deltaC    = deltaBD.cross(deltaCD);
     double volume = deltaC.dot(deltaAD);
 
@@ -163,6 +169,8 @@ void AmoebaReferenceHippoNonbondedForce::applyRotationMatrixToParticle( Multipol
 
     Vec3 vectorX, vectorY;
     Vec3 vectorZ = particleZ->position - particleI.position;
+    if (_nonbondedMethod == HippoNonbondedForce::PME)
+        getPeriodicDelta(vectorZ);
     normalizeVec3(vectorZ);
 
     // branch based on axis type
@@ -178,6 +186,8 @@ void AmoebaReferenceHippoNonbondedForce::applyRotationMatrixToParticle( Multipol
     }
     else {
         vectorX = particleX->position - particleI.position;
+        if (_nonbondedMethod == HippoNonbondedForce::PME)
+            getPeriodicDelta(vectorX);
         if (axisType == HippoNonbondedForce::Bisector) {
 
             // bisector
@@ -197,6 +207,8 @@ void AmoebaReferenceHippoNonbondedForce::applyRotationMatrixToParticle( Multipol
             normalizeVec3(vectorX);
 
             vectorY  = particleY->position - particleI.position;
+            if (_nonbondedMethod == HippoNonbondedForce::PME)
+                getPeriodicDelta(vectorY);
             normalizeVec3(vectorY);
 
             vectorX += vectorY;
@@ -211,6 +223,8 @@ void AmoebaReferenceHippoNonbondedForce::applyRotationMatrixToParticle( Multipol
             normalizeVec3(vectorX);
 
             vectorY   = particleY->position - particleI.position;
+            if (_nonbondedMethod == HippoNonbondedForce::PME)
+                getPeriodicDelta(vectorY);
             normalizeVec3(vectorY);
 
             vectorZ  += vectorX +  vectorY;
@@ -1144,14 +1158,22 @@ void AmoebaReferenceHippoNonbondedForce::mapTorqueToForceForParticle(const Multi
         return;
 
     Vec3 vectorU = particleI.position - particleU.position;
+    if (_nonbondedMethod == HippoNonbondedForce::PME)
+        getPeriodicDelta(vectorU);
     norms[U] = normalizeVec3(vectorU);
     Vec3 vectorV = particleI.position - particleV.position;
+    if (_nonbondedMethod == HippoNonbondedForce::PME)
+        getPeriodicDelta(vectorV);
     norms[V] = normalizeVec3(vectorV);
     Vec3 vectorW;
-    if (particleW && (axisType == HippoNonbondedForce::ZBisect || axisType == HippoNonbondedForce::ThreeFold))
+    if (particleW && (axisType == HippoNonbondedForce::ZBisect || axisType == HippoNonbondedForce::ThreeFold)) {
         vectorW = particleW->position - particleI.position;
-    else
+        if (_nonbondedMethod == HippoNonbondedForce::PME)
+            getPeriodicDelta(vectorW);
+    }
+    else {
         vectorW = vectorU.cross(vectorV);
+    }
     norms[W]  = normalizeVec3(vectorW);
 
     Vec3 vectorUV, vectorUW, vectorVW;

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceMultipoleForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceMultipoleForce.cpp
@@ -369,6 +369,12 @@ void AmoebaReferenceMultipoleForce::checkChiralCenterAtParticle(MultipoleParticl
     Vec3 deltaBD   = particleZ.position - particleY.position;
     Vec3 deltaCD   = particleX.position - particleY.position;
 
+    if (_nonbondedMethod == NonbondedMethod::PME) {
+        getPeriodicDelta(deltaAD);
+        getPeriodicDelta(deltaBD);
+        getPeriodicDelta(deltaCD);
+    }
+
     Vec3 deltaC    = deltaBD.cross(deltaCD);
     double volume = deltaC.dot(deltaAD);
 
@@ -414,6 +420,8 @@ void AmoebaReferenceMultipoleForce::applyRotationMatrixToParticle(      Multipol
 
     Vec3 vectorX, vectorY;
     Vec3 vectorZ = particleZ->position - particleI.position;
+    if (_nonbondedMethod == NonbondedMethod::PME)
+        getPeriodicDelta(vectorZ);
     normalizeVec3(vectorZ);
 
     // branch based on axis type
@@ -429,6 +437,8 @@ void AmoebaReferenceMultipoleForce::applyRotationMatrixToParticle(      Multipol
     }
     else {
         vectorX = particleX->position - particleI.position;
+        if (_nonbondedMethod == NonbondedMethod::PME)
+            getPeriodicDelta(vectorX);
         if (axisType == AmoebaMultipoleForce::Bisector) {
 
             // bisector
@@ -448,6 +458,8 @@ void AmoebaReferenceMultipoleForce::applyRotationMatrixToParticle(      Multipol
             normalizeVec3(vectorX);
 
             vectorY  = particleY->position - particleI.position;
+            if (_nonbondedMethod == NonbondedMethod::PME)
+                getPeriodicDelta(vectorY);
             normalizeVec3(vectorY);
 
             vectorX += vectorY;
@@ -462,6 +474,8 @@ void AmoebaReferenceMultipoleForce::applyRotationMatrixToParticle(      Multipol
             normalizeVec3(vectorX);
 
             vectorY   = particleY->position - particleI.position;
+            if (_nonbondedMethod == NonbondedMethod::PME)
+                getPeriodicDelta(vectorY);
             normalizeVec3(vectorY);
 
             vectorZ  += vectorX +  vectorY;
@@ -1518,16 +1532,24 @@ void AmoebaReferenceMultipoleForce::mapTorqueToForceForParticle(const MultipoleP
     }
 
     Vec3 vectorU = particleU.position - particleI.position;
+    if (_nonbondedMethod == NonbondedMethod::PME)
+        getPeriodicDelta(vectorU);
     norms[U] = normalizeVec3(vectorU);
 
     Vec3 vectorV = particleV.position - particleI.position;
+    if (_nonbondedMethod == NonbondedMethod::PME)
+        getPeriodicDelta(vectorV);
     norms[V] = normalizeVec3(vectorV);
 
     Vec3 vectorW;
-    if (particleW && (axisType == AmoebaMultipoleForce::ZBisect || axisType == AmoebaMultipoleForce::ThreeFold))
+    if (particleW && (axisType == AmoebaMultipoleForce::ZBisect || axisType == AmoebaMultipoleForce::ThreeFold)) {
          vectorW = particleW->position - particleI.position;
-    else
+        if (_nonbondedMethod == NonbondedMethod::PME)
+            getPeriodicDelta(vectorW);
+    }
+    else {
          vectorW = vectorU.cross(vectorV);
+    }
     norms[W]  = normalizeVec3(vectorW);
 
     Vec3 vectorUV, vectorUW, vectorVW;

--- a/plugins/amoeba/tests/TestAmoebaMultipoleForce.h
+++ b/plugins/amoeba/tests/TestAmoebaMultipoleForce.h
@@ -440,7 +440,7 @@ static void testMultipoleAmmoniaMutualPolarization() {
 static void setupAndGetForcesEnergyMultipoleWater(AmoebaMultipoleForce::NonbondedMethod nonbondedMethod,
                                                    AmoebaMultipoleForce::PolarizationType polarizationType,
                                                    double cutoff, int inputPmeGridDimension, std::vector<Vec3>& forces,
-                                                   double& energy) {
+                                                   double& energy, int offsetIndex = -1) {
 
     // beginning of Multipole setup
 
@@ -578,6 +578,9 @@ static void setupAndGetForcesEnergyMultipoleWater(AmoebaMultipoleForce::Nonbonde
     positions[10]             = Vec3(  6.0459330e-01,   3.0620510e-01,   -7.0100130e-01);
     positions[11]             = Vec3(  5.0590640e-01,   1.8880920e-01,   -6.8813470e-01);
 
+    if (offsetIndex != -1)
+        positions[offsetIndex] += a + b + c;
+
     system.addForce(amoebaMultipoleForce);
 
     LangevinIntegrator integrator(0.0, 0.1, 0.01);
@@ -601,27 +604,31 @@ static void testMultipoleWaterPMEDirectPolarization() {
     std::vector<Vec3> forces;
     double energy;
 
-    setupAndGetForcesEnergyMultipoleWater(AmoebaMultipoleForce::PME, AmoebaMultipoleForce::Direct, 
-                                            cutoff, inputPmeGridDimension, forces, energy);
-    std::vector<Vec3> expectedForces(numberOfParticles);
+    // test periodic boundary conditions by moving individual atoms to a different periodic image
+    for (int offsetIndex = -1; offsetIndex < 12; ++offsetIndex) {
 
-    double expectedEnergy     = 6.4585115e-1;
+        setupAndGetForcesEnergyMultipoleWater(AmoebaMultipoleForce::PME, AmoebaMultipoleForce::Direct,
+                                               cutoff, inputPmeGridDimension, forces, energy, offsetIndex);
+        std::vector<Vec3> expectedForces(numberOfParticles);
 
-    expectedForces[0]         = Vec3( -1.2396731e+00,  -2.4231698e+01,   8.3348523e+00);
-    expectedForces[1]         = Vec3( -3.3737276e+00,   9.9304523e+00,  -6.3917827e+00);
-    expectedForces[2]         = Vec3(  4.4062247e+00,   1.9518971e+01,  -4.6552873e+00);
-    expectedForces[3]         = Vec3( -1.3128824e+00,  -1.2887339e+00,  -1.4473147e+00);
-    expectedForces[4]         = Vec3(  2.1137034e+00,   3.9457973e-01,   2.9269129e-01);
-    expectedForces[5]         = Vec3(  1.0271174e+00,   1.2039367e+00,   1.2112214e+00);
-    expectedForces[6]         = Vec3( -3.2082903e+00,   1.4979371e+01,  -1.0274832e+00);
-    expectedForces[7]         = Vec3( -1.1880320e+00,  -1.5177166e+01,   2.5525509e+00);
-    expectedForces[8]         = Vec3(  4.3607105e+00,  -7.0253274e+00,   2.9522580e-01);
-    expectedForces[9]         = Vec3( -3.0175134e+00,   1.3607102e+00,   6.6883370e+00);
-    expectedForces[10]        = Vec3(  9.2036949e-01,  -1.4717629e+00,  -3.3362339e+00);
-    expectedForces[11]        = Vec3(  1.2523841e+00,  -1.9794292e+00,  -3.4670129e+00);
+        double expectedEnergy     = 6.4585115e-1;
 
-    double tolerance          = 1.0e-3;
-    compareForcesEnergy(testName, expectedEnergy, energy, expectedForces, forces, tolerance);
+        expectedForces[0]         = Vec3( -1.2396731e+00,  -2.4231698e+01,   8.3348523e+00);
+        expectedForces[1]         = Vec3( -3.3737276e+00,   9.9304523e+00,  -6.3917827e+00);
+        expectedForces[2]         = Vec3(  4.4062247e+00,   1.9518971e+01,  -4.6552873e+00);
+        expectedForces[3]         = Vec3( -1.3128824e+00,  -1.2887339e+00,  -1.4473147e+00);
+        expectedForces[4]         = Vec3(  2.1137034e+00,   3.9457973e-01,   2.9269129e-01);
+        expectedForces[5]         = Vec3(  1.0271174e+00,   1.2039367e+00,   1.2112214e+00);
+        expectedForces[6]         = Vec3( -3.2082903e+00,   1.4979371e+01,  -1.0274832e+00);
+        expectedForces[7]         = Vec3( -1.1880320e+00,  -1.5177166e+01,   2.5525509e+00);
+        expectedForces[8]         = Vec3(  4.3607105e+00,  -7.0253274e+00,   2.9522580e-01);
+        expectedForces[9]         = Vec3( -3.0175134e+00,   1.3607102e+00,   6.6883370e+00);
+        expectedForces[10]        = Vec3(  9.2036949e-01,  -1.4717629e+00,  -3.3362339e+00);
+        expectedForces[11]        = Vec3(  1.2523841e+00,  -1.9794292e+00,  -3.4670129e+00);
+
+        double tolerance          = 1.0e-3;
+        compareForcesEnergy(testName, expectedEnergy, energy, expectedForces, forces, tolerance);
+    }
 }
 
 // test multipole mutual polarization using PME for box of water

--- a/plugins/amoeba/tests/TestHippoNonbondedForce.h
+++ b/plugins/amoeba/tests/TestHippoNonbondedForce.h
@@ -169,11 +169,14 @@ void testWaterDimer() {
     checkForceEnergyConsistency(context);
 }
 
-void testWaterBox() {
+void testWaterBox(int offsetIndex = -1) {
     System system;
     HippoNonbondedForce* hippo = new HippoNonbondedForce();
     buildWaterSystem(system, 216, hippo);
-    system.setDefaultPeriodicBoxVectors(Vec3(1.8643, 0, 0), Vec3(0, 1.8643, 0), Vec3(0, 0, 1.8643));
+    Vec3 a(1.8643, 0, 0);
+    Vec3 b(0, 1.8643, 0);
+    Vec3 c(0, 0, 1.8643);
+    system.setDefaultPeriodicBoxVectors(a, b, c);
     hippo->setNonbondedMethod(HippoNonbondedForce::PME);
     hippo->setCutoffDistance(0.7);
     hippo->setSwitchingDistance(0.6);
@@ -843,6 +846,11 @@ void testWaterBox() {
         Vec3(-0.8345957, 0.40272220000000003, 0.3589257),
         Vec3(-0.8130328000000001, 0.28452380000000005, 0.2577949)
     };
+
+    if (offsetIndex != -1) {
+        positions[offsetIndex] += a + b + c;
+    }
+
     context.setPositions(positions);
     State state = context.getState(State::Energy | State::Forces);
     
@@ -1603,6 +1611,8 @@ int main(int argc, char* argv[]) {
         }
         testWaterDimer();
         testWaterBox();
+        for (int offsetIndex = 0; offsetIndex < 30; offsetIndex += 4)
+            testWaterBox(offsetIndex);
         testChangingParameters();
         testNeutralizingPlasmaCorrection();
     }


### PR DESCRIPTION
In case you are interested in supporting periodic molecules with AMOEBA (and HIPPO).

I'm not sure there is a use case for using periodic boundary conditions while particles used for the rotation of the multipoles are separated by more than half the box length, so this change just applies the minimum image convention for all displacements if PME is used.

The tests might need to be improved, I just modified an existing test by moving different individual atoms to another periodic image, but it doesn't test all different types of multipoles I think.

I tested it for the Reference, CUDA and HIP platforms.

Fixes #4914.