### PR TITLE
Fix GPU memory leak in context arrays

### DIFF
--- a/platforms/cuda/src/CudaArray.cpp
+++ b/platforms/cuda/src/CudaArray.cpp
@@ -41,7 +41,7 @@ CudaArray::CudaArray(CudaContext& context, size_t size, int elementSize, const s
 }
 
 CudaArray::~CudaArray() {
-    if (pointer != 0 && ownsMemory) {
+    if (pointer != 0 && ownsMemory && context->getContextIsValid()) {
         ContextSelector selector(*context);
         CUresult result = cuMemFree(pointer);
         if (result != CUDA_SUCCESS) {

--- a/platforms/cuda/src/CudaArray.cpp
+++ b/platforms/cuda/src/CudaArray.cpp
@@ -41,7 +41,7 @@ CudaArray::CudaArray(CudaContext& context, size_t size, int elementSize, const s
 }
 
 CudaArray::~CudaArray() {
-    if (pointer != 0 && ownsMemory && context->getContextIsValid()) {
+    if (pointer != 0 && ownsMemory) {
         ContextSelector selector(*context);
         CUresult result = cuMemFree(pointer);
         if (result != CUDA_SUCCESS) {

--- a/platforms/hip/src/HipArray.cpp
+++ b/platforms/hip/src/HipArray.cpp
@@ -42,7 +42,7 @@ HipArray::HipArray(HipContext& context, size_t size, int elementSize, const std:
 }
 
 HipArray::~HipArray() {
-    if (pointer != 0 && ownsMemory && context->getContextIsValid()) {
+    if (pointer != 0 && ownsMemory) {
         ContextSelector selector(*context);
         hipError_t result = hipFree(pointer);
         if (result != hipSuccess) {


### PR DESCRIPTION
This PR provides a potential fix for a GPU-side memory leak on CUDA/HIP platforms in the Context/Array destructors (issue #4939).