### PR TITLE
Allow empty loops to be parsed with `PdbxReader.py`

### DIFF
--- a/wrappers/python/openmm/app/internal/pdbx/reader/PdbxReader.py
+++ b/wrappers/python/openmm/app/internal/pdbx/reader/PdbxReader.py
@@ -259,6 +259,9 @@ class PdbxReader(object):
                     if reservedWord is not None:
                         if reservedWord == "stop":
                             return
+                         elif reservedWord == "loop":
+                            # If the category has no rows, we skip it
+                            continue
                         else:
                             self.__syntaxError("Unexpected reserved word after loop declaration: %s" % (reservedWord))
                     


### PR DESCRIPTION
* Adds support for skipping mmCIF categories with empty loops. Otherwise, a `SyntaxError` may be unnecessarily raised.