### PR TITLE
Fixed bug in computing pressure

### DIFF
--- a/platforms/common/src/kernels/monteCarloBarostat.cc
+++ b/platforms/common/src/kernels/monteCarloBarostat.cc
@@ -79,7 +79,7 @@ KERNEL void computeMolecularKineticEnergy(int numMolecules, GLOBAL mixed4* RESTR
             molVel += mass*trimTo3(v);
             molMass += mass;
         }
-        molVel *= RECIP((mixed) numAtoms);
+        molVel *= RECIP((mixed) molMass);
 #if COMPONENTS == 1
         ke[0] += 0.5f*molMass*dot(molVel, molVel);
 #else

--- a/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
@@ -133,7 +133,7 @@ void ReferenceMonteCarloBarostat::computeMolecularKineticEnergy(const vector<Vec
             molVel += masses[atom]*velocities[atom];
             molMass += masses[atom];
         }
-        molVel /= molecule.size();
+        molVel /= molMass;
         if (components == 1)
             ke[0] += 0.5*molMass*molVel.dot(molVel);
         else {

--- a/tests/TestMonteCarloBarostat.h
+++ b/tests/TestMonteCarloBarostat.h
@@ -167,8 +167,8 @@ void testMolecularGas() {
     init_gen_rand(0, sfmt);
     for (int i = 0; i < numMolecules; ++i) {
         system.addParticle(1.0);
-        system.addParticle(1.0);
-        system.addParticle(1.0);
+        system.addParticle(2.0);
+        system.addParticle(3.0);
         Vec3 pos(initialLength*genrand_real2(sfmt), 0.5*initialLength*genrand_real2(sfmt), 2*initialLength*genrand_real2(sfmt));
         bonds->addBond(positions.size(), positions.size()+1, 0.1, 10.0);
         system.addConstraint(positions.size(), positions.size()+2, 0.1);


### PR DESCRIPTION
This fixes a bug that caused `computeCurrentPressure()` to return an incorrect value.  The tests were passing only because they happened to set all particle masses to 1.  See https://github.com/openmm/openmm/discussions/4926#discussioncomment-13503249.