### PR TITLE
Add function parsing to custom multiparticle force

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -3298,6 +3298,7 @@ class CustomManyParticleGenerator(object):
             generator.typeFilters.append((int(param.attrib['index']), [int(x) for x in param.attrib['types'].split(',')]))
         generator.params = ForceField._AtomTypeParameters(ff, 'CustomManyParticleForce', 'Atom', generator.perParticleParams)
         generator.params.parseDefinitions(element)
+        generator.functions += _parseFunctions(element)
 
     def createForce(self, sys, data, nonbondedMethod, nonbondedCutoff, args):
         methodMap = {NoCutoff:mm.CustomManyParticleForce.NoCutoff,


### PR DESCRIPTION
Fixes #4985 

My change to the `CustomManyParticleGenerator`'s `parseElement` simply adds the function parsing line needed; compare to line 3007 in the `CustomNonbondedGenerator`'s corresponding `parseElement` function. You can run the test code in the issue to verify that this works.

Please let me know where I should add new tests to the package if the developers feel this is appropriate.