### PR TITLE
API: Move definitions of getNum...() member functions to implementation files

### DIFF
--- a/openmmapi/include/openmm/ATMForce.h
+++ b/openmmapi/include/openmm/ATMForce.h
@@ -177,28 +177,20 @@ public:
      *
      * This should be the same number of particles as the System
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of Forces included in the ATMForce.
      */
-    int getNumForces() const {
-        return forces.size();
-    }
+    int getNumForces() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the algebraic expression that gives the energy of the system
      */

--- a/openmmapi/include/openmm/CMAPTorsionForce.h
+++ b/openmmapi/include/openmm/CMAPTorsionForce.h
@@ -61,15 +61,11 @@ public:
     /**
      * Get the number of maps that have been defined.
      */
-    int getNumMaps() const {
-        return maps.size();
-    }
+    int getNumMaps() const;
     /**
      * Get the number of CMAP torsion terms in the potential function
      */
-    int getNumTorsions() const {
-        return torsions.size();
-    }
+    int getNumTorsions() const;
     /**
      * Create a new map that can be used for torsion pairs.
      *

--- a/openmmapi/include/openmm/CustomAngleForce.h
+++ b/openmmapi/include/openmm/CustomAngleForce.h
@@ -94,28 +94,20 @@ public:
     /**
      * Get the number of angles for which force field parameters have been defined.
      */
-    int getNumAngles() const {
-        return angles.size();
-    }
+    int getNumAngles() const;
     /**
      * Get the number of per-angle parameters that the interaction depends on.
      */
-    int getNumPerAngleParameters() const {
-        return parameters.size();
-    }
+    int getNumPerAngleParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the algebraic expression that gives the interaction energy for each angle
      */

--- a/openmmapi/include/openmm/CustomBondForce.h
+++ b/openmmapi/include/openmm/CustomBondForce.h
@@ -94,28 +94,20 @@ public:
     /**
      * Get the number of bonds for which force field parameters have been defined.
      */
-    int getNumBonds() const {
-        return bonds.size();
-    }
+    int getNumBonds() const;
     /**
      * Get the number of per-bond parameters that the interaction depends on.
      */
-    int getNumPerBondParameters() const {
-        return parameters.size();
-    }
+    int getNumPerBondParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the algebraic expression that gives the interaction energy for each bond
      */

--- a/openmmapi/include/openmm/CustomCVForce.h
+++ b/openmmapi/include/openmm/CustomCVForce.h
@@ -84,28 +84,20 @@ public:
     /**
      * Get the number of collective variables that the interaction depends on.
      */
-    int getNumCollectiveVariables() const {
-        return variables.size();
-    }
+    int getNumCollectiveVariables() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the algebraic expression that gives the energy of the system
      */

--- a/openmmapi/include/openmm/CustomCentroidBondForce.h
+++ b/openmmapi/include/openmm/CustomCentroidBondForce.h
@@ -144,54 +144,38 @@ public:
     /**
      * Get the number of groups used to define each bond.
      */
-    int getNumGroupsPerBond() const {
-        return groupsPerBond;
-    }
+    int getNumGroupsPerBond() const;
     /**
      * Get the number of particle groups that have been defined.
      */
-    int getNumGroups() const {
-        return groups.size();
-    }
+    int getNumGroups() const;
     /**
      * Get the number of bonds for which force field parameters have been defined.
      */
-    int getNumBonds() const {
-        return bonds.size();
-    }
+    int getNumBonds() const;
     /**
      * Get the number of per-bond parameters that the interaction depends on.
      */
-    int getNumPerBondParameters() const {
-        return bondParameters.size();
-    }
+    int getNumPerBondParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the number of tabulated functions that have been defined.
      *
      * @deprecated This method exists only for backward compatibility.  Use getNumTabulatedFunctions() instead.
      */
-    int getNumFunctions() const {
-        return functions.size();
-    }
+    int getNumFunctions() const;
     /**
      * Get the algebraic expression that gives the interaction energy of each bond
      */

--- a/openmmapi/include/openmm/CustomCompoundBondForce.h
+++ b/openmmapi/include/openmm/CustomCompoundBondForce.h
@@ -138,48 +138,34 @@ public:
     /**
      * Get the number of particles used to define each bond.
      */
-    int getNumParticlesPerBond() const {
-        return particlesPerBond;
-    }
+    int getNumParticlesPerBond() const;
     /**
      * Get the number of bonds for which force field parameters have been defined.
      */
-    int getNumBonds() const {
-        return bonds.size();
-    }
+    int getNumBonds() const;
     /**
      * Get the number of per-bond parameters that the interaction depends on.
      */
-    int getNumPerBondParameters() const {
-        return bondParameters.size();
-    }
+    int getNumPerBondParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the number of tabulated functions that have been defined.
      *
      * @deprecated This method exists only for backward compatibility.  Use getNumTabulatedFunctions() instead.
      */
-    int getNumFunctions() const {
-        return functions.size();
-    }
+    int getNumFunctions() const;
     /**
      * Get the algebraic expression that gives the interaction energy of each bond
      */

--- a/openmmapi/include/openmm/CustomExternalForce.h
+++ b/openmmapi/include/openmm/CustomExternalForce.h
@@ -106,21 +106,15 @@ public:
     /**
      * Get the number of particles for which force field parameters have been defined.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of per-particle parameters that the force depends on
      */
-    int getNumPerParticleParameters() const {
-        return parameters.size();
-    }
+    int getNumPerParticleParameters() const;
     /**
      * Get the number of global parameters that the force depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the algebraic expression that gives the potential energy of each particle
      */

--- a/openmmapi/include/openmm/CustomGBForce.h
+++ b/openmmapi/include/openmm/CustomGBForce.h
@@ -193,60 +193,42 @@ public:
     /**
      * Get the number of particles for which force field parameters have been defined.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of particle pairs whose interactions should be excluded.
      */
-    int getNumExclusions() const {
-        return exclusions.size();
-    }
+    int getNumExclusions() const;
     /**
      * Get the number of per-particle parameters that the interaction depends on.
      */
-    int getNumPerParticleParameters() const {
-        return parameters.size();
-    }
+    int getNumPerParticleParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the number of tabulated functions that have been defined.
      *
      * @deprecated This method exists only for backward compatibility.  Use getNumTabulatedFunctions() instead.
      */
-    int getNumFunctions() const {
-        return functions.size();
-    }
+    int getNumFunctions() const;
     /**
      * Get the number of per-particle computed values the interaction depends on.
      */
-    int getNumComputedValues() const {
-        return computedValues.size();
-    }
+    int getNumComputedValues() const;
     /**
      * Get the number of terms in the energy computation.
      */
-    int getNumEnergyTerms() const {
-        return energyTerms.size();
-    }
+    int getNumEnergyTerms() const;
     /**
      * Get the method used for handling long range nonbonded interactions.
      */

--- a/openmmapi/include/openmm/CustomHbondForce.h
+++ b/openmmapi/include/openmm/CustomHbondForce.h
@@ -138,53 +138,37 @@ public:
     /**
      * Get the number of donors for which force field parameters have been defined.
      */
-    int getNumDonors() const {
-        return donors.size();
-    }
+    int getNumDonors() const;
     /**
      * Get the number of acceptors for which force field parameters have been defined.
      */
-    int getNumAcceptors() const {
-        return acceptors.size();
-    }
+    int getNumAcceptors() const;
     /**
      * Get the number of donor-acceptor pairs whose interactions should be excluded.
      */
-    int getNumExclusions() const {
-        return exclusions.size();
-    }
+    int getNumExclusions() const;
     /**
      * Get the number of per-donor parameters that the interaction depends on.
      */
-    int getNumPerDonorParameters() const {
-        return donorParameters.size();
-    }
+    int getNumPerDonorParameters() const;
     /**
      * Get the number of per-acceptor parameters that the interaction depends on.
      */
-    int getNumPerAcceptorParameters() const {
-        return acceptorParameters.size();
-    }
+    int getNumPerAcceptorParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the number of tabulated functions that have been defined.
      *
      * @deprecated This method exists only for backward compatibility.  Use getNumTabulatedFunctions() instead.
      */
-    int getNumFunctions() const {
-        return functions.size();
-    }
+    int getNumFunctions() const;
     /**
      * Get the algebraic expression that gives the interaction energy between a donor and an acceptor
      */

--- a/openmmapi/include/openmm/CustomIntegrator.h
+++ b/openmmapi/include/openmm/CustomIntegrator.h
@@ -389,27 +389,19 @@ public:
     /**
      * Get the number of global variables that have been defined.
      */
-    int getNumGlobalVariables() const {
-        return globalNames.size();
-    }
+    int getNumGlobalVariables() const;
     /**
      * Get the number of per-DOF variables that have been defined.
      */
-    int getNumPerDofVariables() const {
-        return perDofNames.size();
-    }
+    int getNumPerDofVariables() const;
     /**
      * Get the number of computation steps that have been added.
      */
-    int getNumComputations() const {
-        return computations.size();
-    }
+    int getNumComputations() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Define a new global variable.
      *

--- a/openmmapi/include/openmm/CustomManyParticleForce.h
+++ b/openmmapi/include/openmm/CustomManyParticleForce.h
@@ -240,39 +240,27 @@ public:
     /**
      * Get the number of particles in each set for which the energy is evaluated
      */
-    int getNumParticlesPerSet() const {
-        return particlesPerSet;
-    }
+    int getNumParticlesPerSet() const;
     /**
      * Get the number of particles for which force field parameters have been defined.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of particle pairs whose interactions should be excluded.
      */
-    int getNumExclusions() const {
-        return exclusions.size();
-    }
+    int getNumExclusions() const;
     /**
      * Get the number of per-particle parameters that the interaction depends on.
      */
-    int getNumPerParticleParameters() const {
-        return particleParameters.size();
-    }
+    int getNumPerParticleParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the algebraic expression that gives the interaction energy of each bond
      */

--- a/openmmapi/include/openmm/CustomNonbondedForce.h
+++ b/openmmapi/include/openmm/CustomNonbondedForce.h
@@ -195,60 +195,42 @@ public:
     /**
      * Get the number of particles for which force field parameters have been defined.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of particle pairs whose interactions should be excluded.
      */
-    int getNumExclusions() const {
-        return exclusions.size();
-    }
+    int getNumExclusions() const;
     /**
      * Get the number of per-particle parameters that the interaction depends on.
      */
-    int getNumPerParticleParameters() const {
-        return parameters.size();
-    }
+    int getNumPerParticleParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of tabulated functions that have been defined.
      */
-    int getNumTabulatedFunctions() const {
-        return functions.size();
-    }
+    int getNumTabulatedFunctions() const;
     /**
      * Get the number of tabulated functions that have been defined.
      *
      * @deprecated This method exists only for backward compatibility.  Use getNumTabulatedFunctions() instead.
      */
-    int getNumFunctions() const {
-        return functions.size();
-    }
+    int getNumFunctions() const;
     /**
      * Get the number of per-particle computed values the interaction depends on.
      */
-    int getNumComputedValues() const {
-        return computedValues.size();
-    }
+    int getNumComputedValues() const;
     /**
      * Get the number of interaction groups that have been defined.
      */
-    int getNumInteractionGroups() const {
-        return interactionGroups.size();
-    }
+    int getNumInteractionGroups() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the algebraic expression that gives the interaction energy between two particles
      */

--- a/openmmapi/include/openmm/CustomTorsionForce.h
+++ b/openmmapi/include/openmm/CustomTorsionForce.h
@@ -104,28 +104,20 @@ public:
     /**
      * Get the number of torsions for which force field parameters have been defined.
      */
-    int getNumTorsions() const {
-        return torsions.size();
-    }
+    int getNumTorsions() const;
     /**
      * Get the number of per-torsion parameters that the interaction depends on.
      */
-    int getNumPerTorsionParameters() const {
-        return parameters.size();
-    }
+    int getNumPerTorsionParameters() const;
     /**
      * Get the number of global parameters that the interaction depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of global parameters with respect to which the derivative of the energy
      * should be computed.
      */
-    int getNumEnergyParameterDerivatives() const {
-        return energyParameterDerivatives.size();
-    }
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the algebraic expression that gives the interaction energy for each torsion
      */

--- a/openmmapi/include/openmm/CustomVolumeForce.h
+++ b/openmmapi/include/openmm/CustomVolumeForce.h
@@ -77,9 +77,7 @@ public:
     /**
      * Get the number of global parameters that the energy depends on.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the algebraic expression that defines the energy.
      */

--- a/openmmapi/include/openmm/DPDIntegrator.h
+++ b/openmmapi/include/openmm/DPDIntegrator.h
@@ -133,9 +133,7 @@ public:
     /**
      * Get the number of type pairs that have been added to the integrator.
      */
-    int getNumTypePairs() const {
-        return pairs.size();
-    }
+    int getNumTypePairs() const;
     /**
      * Add a type pair.  This overrides the default friction and cutoff distance for interactions
      * between particles of two particular types.

--- a/openmmapi/include/openmm/GBSAOBCForce.h
+++ b/openmmapi/include/openmm/GBSAOBCForce.h
@@ -83,9 +83,7 @@ public:
     /**
      * Get the number of particles in the system.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Add the GBSA parameters for a particle.  This should be called once for each particle
      * in the System.  When it is called for the i'th time, it specifies the parameters for the i'th particle.

--- a/openmmapi/include/openmm/GayBerneForce.h
+++ b/openmmapi/include/openmm/GayBerneForce.h
@@ -106,15 +106,11 @@ public:
     /**
      * Get the number of particles for which force field parameters have been defined.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of special interactions that should be calculated differently from other interactions.
      */
-    int getNumExceptions() const {
-        return exceptions.size();
-    }
+    int getNumExceptions() const;
     /**
      * Get the method used for handling long range interactions.
      */

--- a/openmmapi/include/openmm/HarmonicAngleForce.h
+++ b/openmmapi/include/openmm/HarmonicAngleForce.h
@@ -56,9 +56,7 @@ public:
     /**
      * Get the number of harmonic bond angle terms in the potential function
      */
-    int getNumAngles() const {
-        return angles.size();
-    }
+    int getNumAngles() const;
     /**
      * Add an angle term to the force field.
      *

--- a/openmmapi/include/openmm/HarmonicBondForce.h
+++ b/openmmapi/include/openmm/HarmonicBondForce.h
@@ -56,9 +56,7 @@ public:
     /**
      * Get the number of harmonic bond stretch terms in the potential function
      */
-    int getNumBonds() const {
-        return bonds.size();
-    }
+    int getNumBonds() const;
     /**
      * Add a bond term to the force field.
      *

--- a/openmmapi/include/openmm/NonbondedForce.h
+++ b/openmmapi/include/openmm/NonbondedForce.h
@@ -153,33 +153,23 @@ public:
     /**
      * Get the number of particles for which force field parameters have been defined.
      */
-    int getNumParticles() const {
-        return particles.size();
-    }
+    int getNumParticles() const;
     /**
      * Get the number of special interactions that should be calculated differently from other interactions.
      */
-    int getNumExceptions() const {
-        return exceptions.size();
-    }
+    int getNumExceptions() const;
     /**
      * Get the number of global parameters that have been added.
      */
-    int getNumGlobalParameters() const {
-        return globalParameters.size();
-    }
+    int getNumGlobalParameters() const;
     /**
      * Get the number of particles parameter offsets that have been added.
      */
-    int getNumParticleParameterOffsets() const {
-        return particleOffsets.size();
-    }
+    int getNumParticleParameterOffsets() const;
     /**
      * Get the number of exception parameter offsets that have been added.
      */
-    int getNumExceptionParameterOffsets() const {
-        return exceptionOffsets.size();
-    }
+    int getNumExceptionParameterOffsets() const;
     /**
      * Get the method used for handling long range nonbonded interactions.
      */

--- a/openmmapi/include/openmm/PeriodicTorsionForce.h
+++ b/openmmapi/include/openmm/PeriodicTorsionForce.h
@@ -56,9 +56,7 @@ public:
     /**
      * Get the number of periodic torsion terms in the potential function
      */
-    int getNumTorsions() const {
-        return periodicTorsions.size();
-    }
+    int getNumTorsions() const;
     /**
      * Add a periodic torsion term to the force field.
      *

--- a/openmmapi/include/openmm/RBTorsionForce.h
+++ b/openmmapi/include/openmm/RBTorsionForce.h
@@ -56,9 +56,7 @@ public:
     /**
      * Get the number of Ryckaert-Bellemans torsion terms in the potential function
      */
-    int getNumTorsions() const {
-        return rbTorsions.size();
-    }
+    int getNumTorsions() const;
     /**
      * Add a Ryckaert-Bellemans torsion term to the force field.
      *

--- a/openmmapi/include/openmm/System.h
+++ b/openmmapi/include/openmm/System.h
@@ -73,9 +73,7 @@ public:
     /**
      * Get the number of particles in this System.
      */
-    int getNumParticles() const {
-        return masses.size();
-    }
+    int getNumParticles() const;
     /**
      * Add a particle to the System.  If the mass is 0, Integrators will ignore
      * the particle and not modify its position or velocity.  This is most often
@@ -136,9 +134,7 @@ public:
     /**
      * Get the number of distance constraints in this System.
      */
-    int getNumConstraints() const {
-        return constraints.size();
-    }
+    int getNumConstraints() const;
     /**
      * Add a constraint to the System.  Particles whose mass is 0 cannot participate
      * in constraints.
@@ -189,9 +185,7 @@ public:
     /**
      * Get the number of Force objects that have been added to the System.
      */
-    int getNumForces() const {
-        return forces.size();
-    }
+    int getNumForces() const;
     /**
      * Get a const reference to one of the Forces in this System.
      *

--- a/openmmapi/src/ATMForce.cpp
+++ b/openmmapi/src/ATMForce.cpp
@@ -176,3 +176,18 @@ void ATMForce::getPerturbationEnergy(OpenMM::Context& context, double& u0, doubl
     dynamic_cast<ATMForceImpl&>(getImplInContext(context)).getPerturbationEnergy(getContextImpl(context), u0, u1, energy);
 }
 
+int ATMForce::getNumParticles() const {
+    return particles.size();
+}
+
+int ATMForce::getNumForces() const {
+    return forces.size();
+}
+
+int ATMForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int ATMForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}

--- a/openmmapi/src/CMAPTorsionForce.cpp
+++ b/openmmapi/src/CMAPTorsionForce.cpp
@@ -107,3 +107,11 @@ void CMAPTorsionForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool CMAPTorsionForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int CMAPTorsionForce::getNumMaps() const {
+    return maps.size();
+}
+
+int CMAPTorsionForce::getNumTorsions() const {
+    return torsions.size();
+}

--- a/openmmapi/src/CustomAngleForce.cpp
+++ b/openmmapi/src/CustomAngleForce.cpp
@@ -159,3 +159,19 @@ void CustomAngleForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool CustomAngleForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int CustomAngleForce::getNumAngles() const {
+    return angles.size();
+}
+
+int CustomAngleForce::getNumPerAngleParameters() const {
+    return parameters.size();
+}
+
+int CustomAngleForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomAngleForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}

--- a/openmmapi/src/CustomBondForce.cpp
+++ b/openmmapi/src/CustomBondForce.cpp
@@ -157,3 +157,19 @@ void CustomBondForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool CustomBondForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int CustomBondForce::getNumBonds() const {
+    return bonds.size();
+}
+
+int CustomBondForce::getNumPerBondParameters() const {
+    return parameters.size();
+}
+
+int CustomBondForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomBondForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}

--- a/openmmapi/src/CustomCVForce.cpp
+++ b/openmmapi/src/CustomCVForce.cpp
@@ -162,3 +162,19 @@ bool CustomCVForce::usesPeriodicBoundaryConditions() const {
             return true;
     return false;
 }
+
+int CustomCVForce::getNumCollectiveVariables() const {
+    return variables.size();
+}
+
+int CustomCVForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomCVForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}
+
+int CustomCVForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}

--- a/openmmapi/src/CustomCentroidBondForce.cpp
+++ b/openmmapi/src/CustomCentroidBondForce.cpp
@@ -195,3 +195,35 @@ void CustomCentroidBondForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool CustomCentroidBondForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int CustomCentroidBondForce::getNumGroupsPerBond() const {
+    return groupsPerBond;
+}
+
+int CustomCentroidBondForce::getNumGroups() const {
+    return groups.size();
+}
+
+int CustomCentroidBondForce::getNumBonds() const {
+    return bonds.size();
+}
+
+int CustomCentroidBondForce::getNumPerBondParameters() const {
+    return bondParameters.size();
+}
+
+int CustomCentroidBondForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomCentroidBondForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}
+
+int CustomCentroidBondForce::getNumFunctions() const {
+    return functions.size();
+}
+
+int CustomCentroidBondForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}

--- a/openmmapi/src/CustomCompoundBondForce.cpp
+++ b/openmmapi/src/CustomCompoundBondForce.cpp
@@ -198,3 +198,31 @@ void CustomCompoundBondForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool CustomCompoundBondForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int CustomCompoundBondForce::getNumParticlesPerBond() const {
+    return particlesPerBond;
+}
+
+int CustomCompoundBondForce::getNumBonds() const {
+    return bonds.size();
+}
+
+int CustomCompoundBondForce::getNumPerBondParameters() const {
+    return bondParameters.size();
+}
+
+int CustomCompoundBondForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomCompoundBondForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}
+
+int CustomCompoundBondForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}
+
+int CustomCompoundBondForce::getNumFunctions() const {
+    return functions.size();
+}

--- a/openmmapi/src/CustomExternalForce.cpp
+++ b/openmmapi/src/CustomExternalForce.cpp
@@ -136,3 +136,15 @@ void CustomExternalForce::updateParametersInContext(Context& context) {
 bool CustomExternalForce::usesPeriodicBoundaryConditions() const {
     return (energyExpression.find("periodicdistance") != string::npos);
 }
+
+int CustomExternalForce::getNumParticles() const {
+    return particles.size();
+}
+
+int CustomExternalForce::getNumPerParticleParameters() const {
+    return parameters.size();
+}
+
+int CustomExternalForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}

--- a/openmmapi/src/CustomGBForce.cpp
+++ b/openmmapi/src/CustomGBForce.cpp
@@ -244,3 +244,39 @@ ForceImpl* CustomGBForce::createImpl() const {
 void CustomGBForce::updateParametersInContext(Context& context) {
     dynamic_cast<CustomGBForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
 }
+
+int CustomGBForce::getNumParticles() const {
+    return particles.size();
+}
+
+int CustomGBForce::getNumExclusions() const {
+    return exclusions.size();
+}
+
+int CustomGBForce::getNumPerParticleParameters() const {
+    return parameters.size();
+}
+
+int CustomGBForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomGBForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}
+
+int CustomGBForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}
+
+int CustomGBForce::getNumFunctions() const {
+    return functions.size();
+}
+
+int CustomGBForce::getNumComputedValues() const {
+    return computedValues.size();
+}
+
+int CustomGBForce::getNumEnergyTerms() const {
+    return energyTerms.size();
+}

--- a/openmmapi/src/CustomHbondForce.cpp
+++ b/openmmapi/src/CustomHbondForce.cpp
@@ -245,3 +245,35 @@ ForceImpl* CustomHbondForce::createImpl() const {
 void CustomHbondForce::updateParametersInContext(Context& context) {
     dynamic_cast<CustomHbondForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
 }
+
+int CustomHbondForce::getNumDonors() const {
+    return donors.size();
+}
+
+int CustomHbondForce::getNumAcceptors() const {
+    return acceptors.size();
+}
+
+int CustomHbondForce::getNumExclusions() const {
+    return exclusions.size();
+}
+
+int CustomHbondForce::getNumPerDonorParameters() const {
+    return donorParameters.size();
+}
+
+int CustomHbondForce::getNumPerAcceptorParameters() const {
+    return acceptorParameters.size();
+}
+
+int CustomHbondForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomHbondForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}
+
+int CustomHbondForce::getNumFunctions() const {
+    return functions.size();
+}

--- a/openmmapi/src/CustomIntegrator.cpp
+++ b/openmmapi/src/CustomIntegrator.cpp
@@ -378,3 +378,19 @@ void CustomIntegrator::deserializeParameters(const SerializationNode& node) {
         setPerDofVariableByName(var.getName(), perDofValues);
     }
 }
+
+int CustomIntegrator::getNumGlobalVariables() const {
+    return globalNames.size();
+}
+
+int CustomIntegrator::getNumPerDofVariables() const {
+    return perDofNames.size();
+}
+
+int CustomIntegrator::getNumComputations() const {
+    return computations.size();
+}
+
+int CustomIntegrator::getNumTabulatedFunctions() const {
+    return functions.size();
+}

--- a/openmmapi/src/CustomManyParticleForce.cpp
+++ b/openmmapi/src/CustomManyParticleForce.cpp
@@ -223,3 +223,27 @@ ForceImpl* CustomManyParticleForce::createImpl() const {
 void CustomManyParticleForce::updateParametersInContext(Context& context) {
     dynamic_cast<CustomManyParticleForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
 }
+
+int CustomManyParticleForce::getNumParticlesPerSet() const {
+    return particlesPerSet;
+}
+
+int CustomManyParticleForce::getNumParticles() const {
+    return particles.size();
+}
+
+int CustomManyParticleForce::getNumExclusions() const {
+    return exclusions.size();
+}
+
+int CustomManyParticleForce::getNumPerParticleParameters() const {
+    return particleParameters.size();
+}
+
+int CustomManyParticleForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomManyParticleForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}

--- a/openmmapi/src/CustomNonbondedForce.cpp
+++ b/openmmapi/src/CustomNonbondedForce.cpp
@@ -343,3 +343,39 @@ void CustomNonbondedForce::updateParametersInContext(Context& context) {
         lastChangedParticle = -1;
     }
 }
+
+int CustomNonbondedForce::getNumParticles() const {
+    return particles.size();
+}
+
+int CustomNonbondedForce::getNumExclusions() const {
+    return exclusions.size();
+}
+
+int CustomNonbondedForce::getNumPerParticleParameters() const {
+    return parameters.size();
+}
+
+int CustomNonbondedForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomNonbondedForce::getNumTabulatedFunctions() const {
+    return functions.size();
+}
+
+int CustomNonbondedForce::getNumFunctions() const {
+    return functions.size();
+}
+
+int CustomNonbondedForce::getNumComputedValues() const {
+    return computedValues.size();
+}
+
+int CustomNonbondedForce::getNumInteractionGroups() const {
+    return interactionGroups.size();
+}
+
+int CustomNonbondedForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}

--- a/openmmapi/src/CustomTorsionForce.cpp
+++ b/openmmapi/src/CustomTorsionForce.cpp
@@ -161,3 +161,19 @@ void CustomTorsionForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool CustomTorsionForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int CustomTorsionForce::getNumTorsions() const {
+    return torsions.size();
+}
+
+int CustomTorsionForce::getNumPerTorsionParameters() const {
+    return parameters.size();
+}
+
+int CustomTorsionForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int CustomTorsionForce::getNumEnergyParameterDerivatives() const {
+    return energyParameterDerivatives.size();
+}

--- a/openmmapi/src/CustomVolumeForce.cpp
+++ b/openmmapi/src/CustomVolumeForce.cpp
@@ -75,3 +75,7 @@ void CustomVolumeForce::setGlobalParameterDefaultValue(int index, double default
 ForceImpl* CustomVolumeForce::createImpl() const {
     return new CustomVolumeForceImpl(*this);
 }
+
+int CustomVolumeForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}

--- a/openmmapi/src/DPDIntegrator.cpp
+++ b/openmmapi/src/DPDIntegrator.cpp
@@ -138,3 +138,7 @@ void DPDIntegrator::step(int steps) {
         kernel.getAs<IntegrateDPDStepKernel>().execute(*context, *this);
     }
 }
+
+int DPDIntegrator::getNumTypePairs() const {
+    return pairs.size();
+}

--- a/openmmapi/src/GBSAOBCForce.cpp
+++ b/openmmapi/src/GBSAOBCForce.cpp
@@ -84,3 +84,7 @@ ForceImpl* GBSAOBCForce::createImpl() const {
 void GBSAOBCForce::updateParametersInContext(Context& context) {
     dynamic_cast<GBSAOBCForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
 }
+
+int GBSAOBCForce::getNumParticles() const {
+    return particles.size();
+}

--- a/openmmapi/src/GayBerneForce.cpp
+++ b/openmmapi/src/GayBerneForce.cpp
@@ -178,3 +178,11 @@ ForceImpl* GayBerneForce::createImpl() const {
 void GayBerneForce::updateParametersInContext(Context& context) {
     dynamic_cast<GayBerneForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
 }
+
+int GayBerneForce::getNumParticles() const {
+    return particles.size();
+}
+
+int GayBerneForce::getNumExceptions() const {
+    return exceptions.size();
+}

--- a/openmmapi/src/HarmonicAngleForce.cpp
+++ b/openmmapi/src/HarmonicAngleForce.cpp
@@ -95,3 +95,7 @@ void HarmonicAngleForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool HarmonicAngleForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int HarmonicAngleForce::getNumAngles() const {
+    return angles.size();
+}

--- a/openmmapi/src/HarmonicBondForce.cpp
+++ b/openmmapi/src/HarmonicBondForce.cpp
@@ -93,3 +93,7 @@ void HarmonicBondForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool HarmonicBondForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int HarmonicBondForce::getNumBonds() const {
+    return bonds.size();
+}

--- a/openmmapi/src/NonbondedForce.cpp
+++ b/openmmapi/src/NonbondedForce.cpp
@@ -381,3 +381,23 @@ bool NonbondedForce::getExceptionsUsePeriodicBoundaryConditions() const {
 void NonbondedForce::setExceptionsUsePeriodicBoundaryConditions(bool periodic) {
     exceptionsUsePeriodic = periodic;
 }
+
+int NonbondedForce::getNumParticles() const {
+    return particles.size();
+}
+
+int NonbondedForce::getNumExceptions() const {
+    return exceptions.size();
+}
+
+int NonbondedForce::getNumGlobalParameters() const {
+    return globalParameters.size();
+}
+
+int NonbondedForce::getNumParticleParameterOffsets() const {
+    return particleOffsets.size();
+}
+
+int NonbondedForce::getNumExceptionParameterOffsets() const {
+    return exceptionOffsets.size();
+}

--- a/openmmapi/src/PeriodicTorsionForce.cpp
+++ b/openmmapi/src/PeriodicTorsionForce.cpp
@@ -99,3 +99,7 @@ void PeriodicTorsionForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool PeriodicTorsionForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int PeriodicTorsionForce::getNumTorsions() const {
+    return periodicTorsions.size();
+}

--- a/openmmapi/src/RBTorsionForce.cpp
+++ b/openmmapi/src/RBTorsionForce.cpp
@@ -88,3 +88,7 @@ void RBTorsionForce::setUsesPeriodicBoundaryConditions(bool periodic) {
 bool RBTorsionForce::usesPeriodicBoundaryConditions() const {
     return usePeriodic;
 }
+
+int RBTorsionForce::getNumTorsions() const {
+    return rbTorsions.size();
+}

--- a/openmmapi/src/System.cpp
+++ b/openmmapi/src/System.cpp
@@ -154,3 +154,15 @@ bool System::usesPeriodicBoundaryConditions() const {
 
     return uses_pbc;
 }
+
+int System::getNumParticles() const {
+    return masses.size();
+}
+
+int System::getNumConstraints() const {
+    return constraints.size();
+}
+
+int System::getNumForces() const {
+    return forces.size();
+}


### PR DESCRIPTION
Fixes #5001.

As mentioned in the issue thread, referencing `std::vector<T>::size()` for an incomplete (e.g., forward-declared) `T` is ill-formed and fails to compile with Clang in C++20 mode.

This PR moves all problematic function definitions of this type from the header to the implementation files.

Note: Defining the functions as `inline` in the header like this
```cpp
class ATMForce {
public:
    ...
    int getNumParticles() const;
    ...
private:
    ...
    class ParticleInfo;
    std::vector<ParticleInfo> particles;
    ...
};

class ATMForce::ParticleInfo { ... };

inline int ATMForce::getNumParticles() const { return particles.size(); }
```
also passes the tests, but fails to link when using the API in a third-party project.