### PR TITLE
Don't reinitialize CustomIntegrator on every step when no computations are present

### DIFF
--- a/platforms/reference/include/ReferenceCustomDynamics.h
+++ b/platforms/reference/include/ReferenceCustomDynamics.h
@@ -43,6 +43,7 @@ class ReferenceCustomDynamics : public ReferenceDynamics {
 private:
 
     class DerivFunction;
+    bool initialized;
     const OpenMM::CustomIntegrator& integrator;
     std::vector<double> inverseMasses;
     std::vector<OpenMM::Vec3> sumBuffer, oldPos;


### PR DESCRIPTION
Fixes #5010.  I wouldn't expect this to come up in practice, but it should prevent a CustomIntegrator with no computation steps from leaking memory.