### PR TITLE
Always safely overwrite checkpoint and state files

### DIFF
--- a/wrappers/python/openmm/app/checkpointreporter.py
+++ b/wrappers/python/openmm/app/checkpointreporter.py
@@ -32,10 +32,6 @@ from __future__ import absolute_import
 __author__ = "Robert McGibbon"
 __version__ = "1.0"
 
-import openmm as mm
-import os
-import os.path
-
 __all__ = ['CheckpointReporter']
 
 
@@ -126,29 +122,15 @@ class CheckpointReporter(object):
         state : State
             The current state of the simulation
         """
-        if isinstance(self._file, str):
-            # Do a safe save.
-
-            tempFilename1 = self._file+".backup1"
-            tempFilename2 = self._file+".backup2"
-            if self._writeState:
-                simulation.saveState(tempFilename1)
-            else:
-                simulation.saveCheckpoint(tempFilename1)
-            exists = os.path.exists(self._file)
-            if exists:
-                os.rename(self._file, tempFilename2)
-            os.rename(tempFilename1, self._file)
-            if exists:
-                os.remove(tempFilename2)
-        else:
-            # Replace the contents of the file.
-
+        isFileObj = not isinstance(self._file, str)
+        if isFileObj:
             self._file.seek(0)
-            if self._writeState:
-                state = simulation.context.getState(positions=True, velocities=True, parameters=True, integratorParameters=True)
-                self._file.write(mm.XmlSerializer.serialize(state))
-            else:
-                self._file.write(simulation.context.createCheckpoint())
+
+        if self._writeState:
+            simulation.saveState(self._file)
+        else:
+            simulation.saveCheckpoint(self._file)
+
+        if isFileObj:
             self._file.truncate()
             self._file.flush()

--- a/wrappers/python/openmm/app/internal/safesave.py
+++ b/wrappers/python/openmm/app/internal/safesave.py
@@ -1,0 +1,97 @@
+"""
+safesave.py: Helper module to ensure atomic overwrite/backup of existing files.
+
+This is part of the OpenMM molecular simulation toolkit originating from
+Simbios, the NIH National Center for Physics-Based Simulation of
+Biological Structures at Stanford, funded under the NIH Roadmap for
+Medical Research, grant U54 GM072970. See https://simtk.org.
+
+Portions copyright (c) 2025 Stanford University and the Authors.
+Authors: Evan Pretti
+Contributors:
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import itertools
+import os
+
+def _getTempFilename(prefix):
+    """
+    Returns the name of a temporary file starting with a given prefix that is
+    guaranteed not to exist already.  Upon successful return of this function,
+    an empty file with the name returned will have been created.
+
+    Parameters
+    ----------
+    prefix : str
+        The prefix of the temporary file name to create.  If a path with
+        multiple components, the directory in which to create the file must
+        exist.
+
+    Returns
+    -------
+    str
+        The temporary file name created.
+    """
+
+    for index in itertools.count():
+        name = f'{prefix}.{index}.tmp'
+        try:
+            with open(name, 'x'):
+                return name
+        except FileExistsError:
+            pass
+
+def save(data, filename):
+    """
+    Saves data to a specified file.  If the file exists, it will be overwritten
+    atomically, or if this is not possible, a backup copy of the existing data
+    will be created during overwriting and deleted once it is successful.
+
+    Parameters
+    ----------
+    data : bytes or str
+        The data to write.  If bytes, the file will be opened in binary mode; if
+        str, in text mode.
+    filename : str
+        The filename to write to.
+    """
+
+    if isinstance(data, bytes):
+        mode = 'wb'
+    elif isinstance(data, str):
+        mode = 'w'
+    else:
+        raise ValueError('Expected bytes or str')
+
+    tempFilename1 = _getTempFilename(filename)
+    with open(tempFilename1, mode) as file:
+        file.write(data)
+
+    try:
+        # If the target file already exists, rename() should overwrite
+        # atomically on POSIX and fail with a FileExistsError on Windows.
+        os.rename(tempFilename1, filename)
+    except FileExistsError:
+        # Make a backup copy since replace() on Windows may not be atomic.
+        tempFilename2 = _getTempFilename(filename)
+        os.replace(filename, tempFilename2)
+        os.replace(tempFilename1, filename)
+        os.remove(tempFilename2)

--- a/wrappers/python/openmm/app/simulation.py
+++ b/wrappers/python/openmm/app/simulation.py
@@ -34,6 +34,7 @@ __version__ = "1.0"
 
 import openmm as mm
 import openmm.unit as unit
+from openmm.app.internal import safesave
 import sys
 from datetime import datetime, timedelta
 try:
@@ -300,8 +301,7 @@ class Simulation(object):
             filename
         """
         if isinstance(file, str):
-            with open(file, 'wb') as f:
-                f.write(self.context.createCheckpoint())
+            safesave.save(self.context.createCheckpoint(), file)
         else:
             file.write(self.context.createCheckpoint())
 
@@ -341,8 +341,7 @@ class Simulation(object):
         state = self.context.getState(positions=True, velocities=True, parameters=True, integratorParameters=True)
         xml = mm.XmlSerializer.serialize(state)
         if isinstance(file, str):
-            with open(file, 'w') as f:
-                f.write(xml)
+            safesave.save(xml, file)
         else:
             file.write(xml)
 


### PR DESCRIPTION
Addresses the first of two items from https://github.com/openmm/openmm/issues/1645#issuecomment-3080876997.  `Simulation.saveCheckpoint()` and `Simulation.saveState()` should now ensure that if OpenMM is interrupted while overwriting an existing file, the existing checkpoint data will not be lost.  Previously, only `CheckpointReporter` did this, and there was a possibility to overwrite another file if one happened to have been manually created with the same name that `CheckpointReporter` would choose for a temporary file.