### PR TITLE
Fix error message formatting for bonds to elements without atoms

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -1888,8 +1888,8 @@ def _findMatchErrors(forcefield, res):
 
     def formatBondDiff(key, diff):
         """Formats a string describing elements associated with a different number of bonds."""
-        name1 = elem.Element.getByAtomicNumber(key[0]).symbol if key else 'extra site'
-        name2 = elem.Element.getByAtomicNumber(key[1]).symbol if key else 'extra site'
+        name1 = elem.Element.getByAtomicNumber(key[0]).symbol if key[0] else 'extra site'
+        name2 = elem.Element.getByAtomicNumber(key[1]).symbol if key[1] else 'extra site'
         return f'{name1}-{name2} bond' + ('' if diff == 1 else 's')
 
     def pickBestMatch(bestMatches):

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -987,6 +987,18 @@ class TestForceField(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'No template found for residue.*HOH.*The force field contains no residue templates'):
             makeSystem(pdbLines)
 
+        # Make water with an extra site and an (invalid) bond to it.
+        pdbLines = [
+            'ATOM      0 O    HOH A   1       0       0       0                           O',
+            'ATOM      1 H1   HOH A   1       0       0       0                           H',
+            'ATOM      2 H2   HOH A   1       0       0       0                           H',
+            'ATOM      3 M    HOH A   1       0       0       0                          EP',
+            'CONECT    0    3'
+        ]
+        forcefield = ForceField('opc.xml')
+        with self.assertRaisesRegex(ValueError, 'No template found for residue.*HOH.*The set of atoms matches HOH, but the residue has 1 extra site-O bond too many'):
+            makeSystem(pdbLines)
+
     def test_Wildcard(self):
         """Test that PeriodicTorsionForces using wildcard ('') for atom types / classes in the ffxml are correctly registered"""
 


### PR DESCRIPTION
Fixes a minor bug in #5020 in which error messages for incorrect bonds to elements without atoms don't get formatted and an unrelated error gets shown instead.  Normally, there shouldn't be bonds to extra sites that would trigger this, but it can happen if one attempts to parameterize a topology with explicitly specified bonds to atoms for which OpenMM couldn't guess the elements.