### PR TITLE
Add Lipid21

### DIFF
--- a/docs-source/usersguide/application/02_running_sims.rst
+++ b/docs-source/usersguide/application/02_running_sims.rst
@@ -487,6 +487,7 @@ File                                 Parameters
 :file:`amber19/protein.ff19ipq.xml`  Protein (alternative)
 :file:`amber19/DNA.OL21.xml`         DNA\ :cite:`Zgarbova2021`
 :file:`amber14/RNA.OL3.xml`          RNA
+:file:`amber19/lipid21.xml`          Lipid
 :file:`amber14/GLYCAM_06j-1.xml`     Carbohydrates and glycosylated proteins\ :cite:`Kirschner2007`
 :file:`amber19/tip3p.xml`            TIP3P water model\ :cite:`Jorgensen1983` and ions
 :file:`amber19/tip3pfb.xml`          TIP3P-FB water model\ :cite:`Wang2014` and ions
@@ -498,8 +499,8 @@ File                                 Parameters
 ===================================  ===========================================
 
 As a convenience, the file :file:`amber19-all.xml` can be used as a shortcut to
-include :file:`amber19/protein.ff19SB.xml`, :file:`amber19/DNA.OL21.xml`, and
-:file:`amber14/RNA.OL3.xml`.  In most cases, you can simply include that file,
+include :file:`amber19/protein.ff19SB.xml`, :file:`amber19/DNA.OL21.xml`,
+:file:`amber14/RNA.OL3.xml`, and :file:`amber19/lipid21.xml`.  In most cases, you can simply include that file,
 plus one of the water models, such as :file:`amber19/tip3pfb.xml` for the
 TIP3P-FB water model and ions\ :cite:`Wang2014`:
 ::
@@ -529,15 +530,6 @@ to them.
          mistakenly specify :file:`tip3p.xml` instead of :file:`amber19/tip3p.xml`,
          you run the risk of having :class:`ForceField` throw an exception since
          :file:`tip3p.xml` will be missing parameters for ions in your system.
-
-.. warning::
-   The updated Lipid21 lipid force field is not yet supported in this port of
-   Amber19, as it makes use of Amber features not yet supported in
-   `ParmEd <https://github.com/parmed/parmed>`_.  Amber19 should be preferred
-   over Amber14 for simulations not requiring a lipid force field, but Amber14
-   should be used if the Lipid17 force field is desired.  Alternatively, to use
-   Amber19 with Lipid21, you can prepare your system with AmberTools_ before
-   loading it into OpenMM, as described in Section :numref:`using_amber_files`.
 
 The converted parameter sets come from the `AmberTools 24 release <http://ambermd.org/AmberTools.php>`_
 and were converted using the openmmforcefields_ package and `ParmEd <https://github.com/parmed/parmed>`_.

--- a/wrappers/python/openmm/app/data/amber19-all.xml
+++ b/wrappers/python/openmm/app/data/amber19-all.xml
@@ -2,4 +2,5 @@
  <Include file="amber19/protein.ff19SB.xml"/>
  <Include file="amber19/DNA.OL21.xml"/>
  <Include file="amber14/RNA.OL3.xml"/>
+ <Include file="amber19/lipid21.xml"/>
 </ForceField>

--- a/wrappers/python/openmm/app/data/amber19/lipid21.xml
+++ b/wrappers/python/openmm/app/data/amber19/lipid21.xml
@@ -1,0 +1,10312 @@
+<ForceField>
+  <Info>
+    <DateGenerated>2025-07-15</DateGenerated>
+    <Source Source="leaprc.lipid21" md5hash="e1c09d4e068913ba25e685b6887f50e3" sourcePackage="AmberTools" sourcePackageVersion="24.8">leaprc.lipid21</Source>
+    <Reference>Dickson, C.J.; Walker, R.C.; Gould, I.R. Lipid21: Complex Lipid Membrane Simulations with AMBER. J. Chem. Theory Comput., 2022, 18, 1726-1736.</Reference>
+  </Info>
+  <AtomTypes>
+    <Type element="C" name="cA" class="cA" mass="12.01" />
+    <Type element="C" name="cB" class="cB" mass="12.01" />
+    <Type element="C" name="cC" class="cC" mass="12.01" />
+    <Type element="C" name="cD" class="cD" mass="12.01" />
+    <Type element="H" name="hA" class="hA" mass="1.008" />
+    <Type element="H" name="hB" class="hB" mass="1.008" />
+    <Type element="H" name="hE" class="hE" mass="1.008" />
+    <Type element="H" name="hL" class="hL" mass="1.008" />
+    <Type element="H" name="hN" class="hN" mass="1.008" />
+    <Type element="H" name="hO" class="hO" mass="1.008" />
+    <Type element="H" name="hX" class="hX" mass="1.008" />
+    <Type element="N" name="nA" class="nA" mass="14.01" />
+    <Type element="N" name="nN" class="nN" mass="14.01" />
+    <Type element="O" name="oC" class="oC" mass="16.0" />
+    <Type element="O" name="oH" class="oH" mass="16.0" />
+    <Type element="O" name="oO" class="oO" mass="16.0" />
+    <Type element="O" name="oP" class="oP" mass="16.0" />
+    <Type element="O" name="oS" class="oS" mass="16.0" />
+    <Type element="O" name="oT" class="oT" mass="16.0" />
+    <Type element="P" name="pA" class="pA" mass="30.97" />
+  </AtomTypes>
+  <Residues>
+    <Residue name="DLPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.172159" name="C22" type="cD" />
+      <Atom charge="0.054419" name="H2R" type="hL" />
+      <Atom charge="0.054419" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.172159" name="C32" type="cD" />
+      <Atom charge="0.054419" name="H2X" type="hL" />
+      <Atom charge="0.054419" name="H2Y" type="hL" />
+      <Atom charge="0.00151" name="C23" type="cD" />
+      <Atom charge="0.019108" name="H3R" type="hL" />
+      <Atom charge="0.019108" name="H3S" type="hL" />
+      <Atom charge="-0.024078" name="C24" type="cD" />
+      <Atom charge="0.02058" name="H4R" type="hL" />
+      <Atom charge="0.02058" name="H4S" type="hL" />
+      <Atom charge="-0.015735" name="C25" type="cD" />
+      <Atom charge="0.009551" name="H5R" type="hL" />
+      <Atom charge="0.009551" name="H5S" type="hL" />
+      <Atom charge="-0.019631" name="C26" type="cD" />
+      <Atom charge="0.010236" name="H6R" type="hL" />
+      <Atom charge="0.010236" name="H6S" type="hL" />
+      <Atom charge="-0.019279" name="C27" type="cD" />
+      <Atom charge="0.011207" name="H7R" type="hL" />
+      <Atom charge="0.011207" name="H7S" type="hL" />
+      <Atom charge="-0.020879" name="C28" type="cD" />
+      <Atom charge="0.010385" name="H8R" type="hL" />
+      <Atom charge="0.010385" name="H8S" type="hL" />
+      <Atom charge="-0.021975" name="C29" type="cD" />
+      <Atom charge="0.005869" name="H9R" type="hL" />
+      <Atom charge="0.005869" name="H9S" type="hL" />
+      <Atom charge="-0.019575" name="C210" type="cD" />
+      <Atom charge="0.015163" name="H10R" type="hL" />
+      <Atom charge="0.015163" name="H10S" type="hL" />
+      <Atom charge="0.02332" name="C211" type="cD" />
+      <Atom charge="0.008276" name="H11R" type="hL" />
+      <Atom charge="0.008276" name="H11S" type="hL" />
+      <Atom charge="-0.118534" name="C212" type="cD" />
+      <Atom charge="0.025809" name="H12R" type="hL" />
+      <Atom charge="0.025809" name="H12S" type="hL" />
+      <Atom charge="0.025809" name="H12T" type="hL" />
+      <Atom charge="0.00151" name="C33" type="cD" />
+      <Atom charge="0.019108" name="H3X" type="hL" />
+      <Atom charge="0.019108" name="H3Y" type="hL" />
+      <Atom charge="-0.024078" name="C34" type="cD" />
+      <Atom charge="0.02058" name="H4X" type="hL" />
+      <Atom charge="0.02058" name="H4Y" type="hL" />
+      <Atom charge="-0.015735" name="C35" type="cD" />
+      <Atom charge="0.009551" name="H5X" type="hL" />
+      <Atom charge="0.009551" name="H5Y" type="hL" />
+      <Atom charge="-0.019631" name="C36" type="cD" />
+      <Atom charge="0.010236" name="H6X" type="hL" />
+      <Atom charge="0.010236" name="H6Y" type="hL" />
+      <Atom charge="-0.019279" name="C37" type="cD" />
+      <Atom charge="0.011207" name="H7X" type="hL" />
+      <Atom charge="0.011207" name="H7Y" type="hL" />
+      <Atom charge="-0.020879" name="C38" type="cD" />
+      <Atom charge="0.010385" name="H8X" type="hL" />
+      <Atom charge="0.010385" name="H8Y" type="hL" />
+      <Atom charge="-0.021975" name="C39" type="cD" />
+      <Atom charge="0.005869" name="H9X" type="hL" />
+      <Atom charge="0.005869" name="H9Y" type="hL" />
+      <Atom charge="-0.019575" name="C310" type="cD" />
+      <Atom charge="0.015163" name="H10X" type="hL" />
+      <Atom charge="0.015163" name="H10Y" type="hL" />
+      <Atom charge="0.02332" name="C311" type="cD" />
+      <Atom charge="0.008276" name="H11X" type="hL" />
+      <Atom charge="0.008276" name="H11Y" type="hL" />
+      <Atom charge="-0.118534" name="C312" type="cD" />
+      <Atom charge="0.025809" name="H12X" type="hL" />
+      <Atom charge="0.025809" name="H12Y" type="hL" />
+      <Atom charge="0.025809" name="H12Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="H12T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="H12Z" />
+      </Residue>
+    <Residue name="DLPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.172159" name="C22" type="cD" />
+      <Atom charge="0.054419" name="H2R" type="hL" />
+      <Atom charge="0.054419" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.172159" name="C32" type="cD" />
+      <Atom charge="0.054419" name="H2X" type="hL" />
+      <Atom charge="0.054419" name="H2Y" type="hL" />
+      <Atom charge="0.00151" name="C23" type="cD" />
+      <Atom charge="0.019108" name="H3R" type="hL" />
+      <Atom charge="0.019108" name="H3S" type="hL" />
+      <Atom charge="-0.024078" name="C24" type="cD" />
+      <Atom charge="0.02058" name="H4R" type="hL" />
+      <Atom charge="0.02058" name="H4S" type="hL" />
+      <Atom charge="-0.015735" name="C25" type="cD" />
+      <Atom charge="0.009551" name="H5R" type="hL" />
+      <Atom charge="0.009551" name="H5S" type="hL" />
+      <Atom charge="-0.019631" name="C26" type="cD" />
+      <Atom charge="0.010236" name="H6R" type="hL" />
+      <Atom charge="0.010236" name="H6S" type="hL" />
+      <Atom charge="-0.019279" name="C27" type="cD" />
+      <Atom charge="0.011207" name="H7R" type="hL" />
+      <Atom charge="0.011207" name="H7S" type="hL" />
+      <Atom charge="-0.020879" name="C28" type="cD" />
+      <Atom charge="0.010385" name="H8R" type="hL" />
+      <Atom charge="0.010385" name="H8S" type="hL" />
+      <Atom charge="-0.021975" name="C29" type="cD" />
+      <Atom charge="0.005869" name="H9R" type="hL" />
+      <Atom charge="0.005869" name="H9S" type="hL" />
+      <Atom charge="-0.019575" name="C210" type="cD" />
+      <Atom charge="0.015163" name="H10R" type="hL" />
+      <Atom charge="0.015163" name="H10S" type="hL" />
+      <Atom charge="0.02332" name="C211" type="cD" />
+      <Atom charge="0.008276" name="H11R" type="hL" />
+      <Atom charge="0.008276" name="H11S" type="hL" />
+      <Atom charge="-0.118534" name="C212" type="cD" />
+      <Atom charge="0.025809" name="H12R" type="hL" />
+      <Atom charge="0.025809" name="H12S" type="hL" />
+      <Atom charge="0.025809" name="H12T" type="hL" />
+      <Atom charge="0.00151" name="C33" type="cD" />
+      <Atom charge="0.019108" name="H3X" type="hL" />
+      <Atom charge="0.019108" name="H3Y" type="hL" />
+      <Atom charge="-0.024078" name="C34" type="cD" />
+      <Atom charge="0.02058" name="H4X" type="hL" />
+      <Atom charge="0.02058" name="H4Y" type="hL" />
+      <Atom charge="-0.015735" name="C35" type="cD" />
+      <Atom charge="0.009551" name="H5X" type="hL" />
+      <Atom charge="0.009551" name="H5Y" type="hL" />
+      <Atom charge="-0.019631" name="C36" type="cD" />
+      <Atom charge="0.010236" name="H6X" type="hL" />
+      <Atom charge="0.010236" name="H6Y" type="hL" />
+      <Atom charge="-0.019279" name="C37" type="cD" />
+      <Atom charge="0.011207" name="H7X" type="hL" />
+      <Atom charge="0.011207" name="H7Y" type="hL" />
+      <Atom charge="-0.020879" name="C38" type="cD" />
+      <Atom charge="0.010385" name="H8X" type="hL" />
+      <Atom charge="0.010385" name="H8Y" type="hL" />
+      <Atom charge="-0.021975" name="C39" type="cD" />
+      <Atom charge="0.005869" name="H9X" type="hL" />
+      <Atom charge="0.005869" name="H9Y" type="hL" />
+      <Atom charge="-0.019575" name="C310" type="cD" />
+      <Atom charge="0.015163" name="H10X" type="hL" />
+      <Atom charge="0.015163" name="H10Y" type="hL" />
+      <Atom charge="0.02332" name="C311" type="cD" />
+      <Atom charge="0.008276" name="H11X" type="hL" />
+      <Atom charge="0.008276" name="H11Y" type="hL" />
+      <Atom charge="-0.118534" name="C312" type="cD" />
+      <Atom charge="0.025809" name="H12X" type="hL" />
+      <Atom charge="0.025809" name="H12Y" type="hL" />
+      <Atom charge="0.025809" name="H12Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="H12T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="H12Z" />
+      </Residue>
+    <Residue name="DLPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.172159" name="C22" type="cD" />
+      <Atom charge="0.054419" name="H2R" type="hL" />
+      <Atom charge="0.054419" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.172159" name="C32" type="cD" />
+      <Atom charge="0.054419" name="H2X" type="hL" />
+      <Atom charge="0.054419" name="H2Y" type="hL" />
+      <Atom charge="0.00151" name="C23" type="cD" />
+      <Atom charge="0.019108" name="H3R" type="hL" />
+      <Atom charge="0.019108" name="H3S" type="hL" />
+      <Atom charge="-0.024078" name="C24" type="cD" />
+      <Atom charge="0.02058" name="H4R" type="hL" />
+      <Atom charge="0.02058" name="H4S" type="hL" />
+      <Atom charge="-0.015735" name="C25" type="cD" />
+      <Atom charge="0.009551" name="H5R" type="hL" />
+      <Atom charge="0.009551" name="H5S" type="hL" />
+      <Atom charge="-0.019631" name="C26" type="cD" />
+      <Atom charge="0.010236" name="H6R" type="hL" />
+      <Atom charge="0.010236" name="H6S" type="hL" />
+      <Atom charge="-0.019279" name="C27" type="cD" />
+      <Atom charge="0.011207" name="H7R" type="hL" />
+      <Atom charge="0.011207" name="H7S" type="hL" />
+      <Atom charge="-0.020879" name="C28" type="cD" />
+      <Atom charge="0.010385" name="H8R" type="hL" />
+      <Atom charge="0.010385" name="H8S" type="hL" />
+      <Atom charge="-0.021975" name="C29" type="cD" />
+      <Atom charge="0.005869" name="H9R" type="hL" />
+      <Atom charge="0.005869" name="H9S" type="hL" />
+      <Atom charge="-0.019575" name="C210" type="cD" />
+      <Atom charge="0.015163" name="H10R" type="hL" />
+      <Atom charge="0.015163" name="H10S" type="hL" />
+      <Atom charge="0.02332" name="C211" type="cD" />
+      <Atom charge="0.008276" name="H11R" type="hL" />
+      <Atom charge="0.008276" name="H11S" type="hL" />
+      <Atom charge="-0.118534" name="C212" type="cD" />
+      <Atom charge="0.025809" name="H12R" type="hL" />
+      <Atom charge="0.025809" name="H12S" type="hL" />
+      <Atom charge="0.025809" name="H12T" type="hL" />
+      <Atom charge="0.00151" name="C33" type="cD" />
+      <Atom charge="0.019108" name="H3X" type="hL" />
+      <Atom charge="0.019108" name="H3Y" type="hL" />
+      <Atom charge="-0.024078" name="C34" type="cD" />
+      <Atom charge="0.02058" name="H4X" type="hL" />
+      <Atom charge="0.02058" name="H4Y" type="hL" />
+      <Atom charge="-0.015735" name="C35" type="cD" />
+      <Atom charge="0.009551" name="H5X" type="hL" />
+      <Atom charge="0.009551" name="H5Y" type="hL" />
+      <Atom charge="-0.019631" name="C36" type="cD" />
+      <Atom charge="0.010236" name="H6X" type="hL" />
+      <Atom charge="0.010236" name="H6Y" type="hL" />
+      <Atom charge="-0.019279" name="C37" type="cD" />
+      <Atom charge="0.011207" name="H7X" type="hL" />
+      <Atom charge="0.011207" name="H7Y" type="hL" />
+      <Atom charge="-0.020879" name="C38" type="cD" />
+      <Atom charge="0.010385" name="H8X" type="hL" />
+      <Atom charge="0.010385" name="H8Y" type="hL" />
+      <Atom charge="-0.021975" name="C39" type="cD" />
+      <Atom charge="0.005869" name="H9X" type="hL" />
+      <Atom charge="0.005869" name="H9Y" type="hL" />
+      <Atom charge="-0.019575" name="C310" type="cD" />
+      <Atom charge="0.015163" name="H10X" type="hL" />
+      <Atom charge="0.015163" name="H10Y" type="hL" />
+      <Atom charge="0.02332" name="C311" type="cD" />
+      <Atom charge="0.008276" name="H11X" type="hL" />
+      <Atom charge="0.008276" name="H11Y" type="hL" />
+      <Atom charge="-0.118534" name="C312" type="cD" />
+      <Atom charge="0.025809" name="H12X" type="hL" />
+      <Atom charge="0.025809" name="H12Y" type="hL" />
+      <Atom charge="0.025809" name="H12Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="H12T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="H12Z" />
+      </Residue>
+    <Residue name="DLPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.172159" name="C22" type="cD" />
+      <Atom charge="0.054419" name="H2R" type="hL" />
+      <Atom charge="0.054419" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.172159" name="C32" type="cD" />
+      <Atom charge="0.054419" name="H2X" type="hL" />
+      <Atom charge="0.054419" name="H2Y" type="hL" />
+      <Atom charge="0.00151" name="C23" type="cD" />
+      <Atom charge="0.019108" name="H3R" type="hL" />
+      <Atom charge="0.019108" name="H3S" type="hL" />
+      <Atom charge="-0.024078" name="C24" type="cD" />
+      <Atom charge="0.02058" name="H4R" type="hL" />
+      <Atom charge="0.02058" name="H4S" type="hL" />
+      <Atom charge="-0.015735" name="C25" type="cD" />
+      <Atom charge="0.009551" name="H5R" type="hL" />
+      <Atom charge="0.009551" name="H5S" type="hL" />
+      <Atom charge="-0.019631" name="C26" type="cD" />
+      <Atom charge="0.010236" name="H6R" type="hL" />
+      <Atom charge="0.010236" name="H6S" type="hL" />
+      <Atom charge="-0.019279" name="C27" type="cD" />
+      <Atom charge="0.011207" name="H7R" type="hL" />
+      <Atom charge="0.011207" name="H7S" type="hL" />
+      <Atom charge="-0.020879" name="C28" type="cD" />
+      <Atom charge="0.010385" name="H8R" type="hL" />
+      <Atom charge="0.010385" name="H8S" type="hL" />
+      <Atom charge="-0.021975" name="C29" type="cD" />
+      <Atom charge="0.005869" name="H9R" type="hL" />
+      <Atom charge="0.005869" name="H9S" type="hL" />
+      <Atom charge="-0.019575" name="C210" type="cD" />
+      <Atom charge="0.015163" name="H10R" type="hL" />
+      <Atom charge="0.015163" name="H10S" type="hL" />
+      <Atom charge="0.02332" name="C211" type="cD" />
+      <Atom charge="0.008276" name="H11R" type="hL" />
+      <Atom charge="0.008276" name="H11S" type="hL" />
+      <Atom charge="-0.118534" name="C212" type="cD" />
+      <Atom charge="0.025809" name="H12R" type="hL" />
+      <Atom charge="0.025809" name="H12S" type="hL" />
+      <Atom charge="0.025809" name="H12T" type="hL" />
+      <Atom charge="0.00151" name="C33" type="cD" />
+      <Atom charge="0.019108" name="H3X" type="hL" />
+      <Atom charge="0.019108" name="H3Y" type="hL" />
+      <Atom charge="-0.024078" name="C34" type="cD" />
+      <Atom charge="0.02058" name="H4X" type="hL" />
+      <Atom charge="0.02058" name="H4Y" type="hL" />
+      <Atom charge="-0.015735" name="C35" type="cD" />
+      <Atom charge="0.009551" name="H5X" type="hL" />
+      <Atom charge="0.009551" name="H5Y" type="hL" />
+      <Atom charge="-0.019631" name="C36" type="cD" />
+      <Atom charge="0.010236" name="H6X" type="hL" />
+      <Atom charge="0.010236" name="H6Y" type="hL" />
+      <Atom charge="-0.019279" name="C37" type="cD" />
+      <Atom charge="0.011207" name="H7X" type="hL" />
+      <Atom charge="0.011207" name="H7Y" type="hL" />
+      <Atom charge="-0.020879" name="C38" type="cD" />
+      <Atom charge="0.010385" name="H8X" type="hL" />
+      <Atom charge="0.010385" name="H8Y" type="hL" />
+      <Atom charge="-0.021975" name="C39" type="cD" />
+      <Atom charge="0.005869" name="H9X" type="hL" />
+      <Atom charge="0.005869" name="H9Y" type="hL" />
+      <Atom charge="-0.019575" name="C310" type="cD" />
+      <Atom charge="0.015163" name="H10X" type="hL" />
+      <Atom charge="0.015163" name="H10Y" type="hL" />
+      <Atom charge="0.02332" name="C311" type="cD" />
+      <Atom charge="0.008276" name="H11X" type="hL" />
+      <Atom charge="0.008276" name="H11Y" type="hL" />
+      <Atom charge="-0.118534" name="C312" type="cD" />
+      <Atom charge="0.025809" name="H12X" type="hL" />
+      <Atom charge="0.025809" name="H12Y" type="hL" />
+      <Atom charge="0.025809" name="H12Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="H12T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="H12Z" />
+    </Residue>
+    <Residue name="DLPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.172159" name="C22" type="cD" />
+      <Atom charge="0.054419" name="H2R" type="hL" />
+      <Atom charge="0.054419" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.172159" name="C32" type="cD" />
+      <Atom charge="0.054419" name="H2X" type="hL" />
+      <Atom charge="0.054419" name="H2Y" type="hL" />
+      <Atom charge="0.00151" name="C23" type="cD" />
+      <Atom charge="0.019108" name="H3R" type="hL" />
+      <Atom charge="0.019108" name="H3S" type="hL" />
+      <Atom charge="-0.024078" name="C24" type="cD" />
+      <Atom charge="0.02058" name="H4R" type="hL" />
+      <Atom charge="0.02058" name="H4S" type="hL" />
+      <Atom charge="-0.015735" name="C25" type="cD" />
+      <Atom charge="0.009551" name="H5R" type="hL" />
+      <Atom charge="0.009551" name="H5S" type="hL" />
+      <Atom charge="-0.019631" name="C26" type="cD" />
+      <Atom charge="0.010236" name="H6R" type="hL" />
+      <Atom charge="0.010236" name="H6S" type="hL" />
+      <Atom charge="-0.019279" name="C27" type="cD" />
+      <Atom charge="0.011207" name="H7R" type="hL" />
+      <Atom charge="0.011207" name="H7S" type="hL" />
+      <Atom charge="-0.020879" name="C28" type="cD" />
+      <Atom charge="0.010385" name="H8R" type="hL" />
+      <Atom charge="0.010385" name="H8S" type="hL" />
+      <Atom charge="-0.021975" name="C29" type="cD" />
+      <Atom charge="0.005869" name="H9R" type="hL" />
+      <Atom charge="0.005869" name="H9S" type="hL" />
+      <Atom charge="-0.019575" name="C210" type="cD" />
+      <Atom charge="0.015163" name="H10R" type="hL" />
+      <Atom charge="0.015163" name="H10S" type="hL" />
+      <Atom charge="0.02332" name="C211" type="cD" />
+      <Atom charge="0.008276" name="H11R" type="hL" />
+      <Atom charge="0.008276" name="H11S" type="hL" />
+      <Atom charge="-0.118534" name="C212" type="cD" />
+      <Atom charge="0.025809" name="H12R" type="hL" />
+      <Atom charge="0.025809" name="H12S" type="hL" />
+      <Atom charge="0.025809" name="H12T" type="hL" />
+      <Atom charge="0.00151" name="C33" type="cD" />
+      <Atom charge="0.019108" name="H3X" type="hL" />
+      <Atom charge="0.019108" name="H3Y" type="hL" />
+      <Atom charge="-0.024078" name="C34" type="cD" />
+      <Atom charge="0.02058" name="H4X" type="hL" />
+      <Atom charge="0.02058" name="H4Y" type="hL" />
+      <Atom charge="-0.015735" name="C35" type="cD" />
+      <Atom charge="0.009551" name="H5X" type="hL" />
+      <Atom charge="0.009551" name="H5Y" type="hL" />
+      <Atom charge="-0.019631" name="C36" type="cD" />
+      <Atom charge="0.010236" name="H6X" type="hL" />
+      <Atom charge="0.010236" name="H6Y" type="hL" />
+      <Atom charge="-0.019279" name="C37" type="cD" />
+      <Atom charge="0.011207" name="H7X" type="hL" />
+      <Atom charge="0.011207" name="H7Y" type="hL" />
+      <Atom charge="-0.020879" name="C38" type="cD" />
+      <Atom charge="0.010385" name="H8X" type="hL" />
+      <Atom charge="0.010385" name="H8Y" type="hL" />
+      <Atom charge="-0.021975" name="C39" type="cD" />
+      <Atom charge="0.005869" name="H9X" type="hL" />
+      <Atom charge="0.005869" name="H9Y" type="hL" />
+      <Atom charge="-0.019575" name="C310" type="cD" />
+      <Atom charge="0.015163" name="H10X" type="hL" />
+      <Atom charge="0.015163" name="H10Y" type="hL" />
+      <Atom charge="0.02332" name="C311" type="cD" />
+      <Atom charge="0.008276" name="H11X" type="hL" />
+      <Atom charge="0.008276" name="H11Y" type="hL" />
+      <Atom charge="-0.118534" name="C312" type="cD" />
+      <Atom charge="0.025809" name="H12X" type="hL" />
+      <Atom charge="0.025809" name="H12Y" type="hL" />
+      <Atom charge="0.025809" name="H12Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="H12T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="H12Z" />
+    </Residue>
+    <Residue name="DMPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.1642" name="C22" type="cD" />
+      <Atom charge="0.053944" name="H2R" type="hL" />
+      <Atom charge="0.053944" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.1642" name="C32" type="cD" />
+      <Atom charge="0.053944" name="H2X" type="hL" />
+      <Atom charge="0.053944" name="H2Y" type="hL" />
+      <Atom charge="-0.002435" name="C23" type="cD" />
+      <Atom charge="0.018859" name="H3R" type="hL" />
+      <Atom charge="0.018859" name="H3S" type="hL" />
+      <Atom charge="-0.026954" name="C24" type="cD" />
+      <Atom charge="0.020431" name="H4R" type="hL" />
+      <Atom charge="0.020431" name="H4S" type="hL" />
+      <Atom charge="-0.016521" name="C25" type="cD" />
+      <Atom charge="0.010573" name="H5R" type="hL" />
+      <Atom charge="0.010573" name="H5S" type="hL" />
+      <Atom charge="-0.027812" name="C26" type="cD" />
+      <Atom charge="0.011511" name="H6R" type="hL" />
+      <Atom charge="0.011511" name="H6S" type="hL" />
+      <Atom charge="-0.004386" name="C27" type="cD" />
+      <Atom charge="0.006833" name="H7R" type="hL" />
+      <Atom charge="0.006833" name="H7S" type="hL" />
+      <Atom charge="-0.026451" name="C28" type="cD" />
+      <Atom charge="0.011241" name="H8R" type="hL" />
+      <Atom charge="0.011241" name="H8S" type="hL" />
+      <Atom charge="-0.014653" name="C29" type="cD" />
+      <Atom charge="0.010172" name="H9R" type="hL" />
+      <Atom charge="0.010172" name="H9S" type="hL" />
+      <Atom charge="-0.021025" name="C210" type="cD" />
+      <Atom charge="0.010037" name="H10R" type="hL" />
+      <Atom charge="0.010037" name="H10S" type="hL" />
+      <Atom charge="-0.031787" name="C211" type="cD" />
+      <Atom charge="0.012677" name="H11R" type="hL" />
+      <Atom charge="0.012677" name="H11S" type="hL" />
+      <Atom charge="-0.028094" name="C212" type="cD" />
+      <Atom charge="0.017208" name="H12R" type="hL" />
+      <Atom charge="0.017208" name="H12S" type="hL" />
+      <Atom charge="0.017463" name="C213" type="cD" />
+      <Atom charge="0.007531" name="H13R" type="hL" />
+      <Atom charge="0.007531" name="H13S" type="hL" />
+      <Atom charge="-0.111712" name="C214" type="cD" />
+      <Atom charge="0.025511" name="H14R" type="hL" />
+      <Atom charge="0.025511" name="H14S" type="hL" />
+      <Atom charge="0.025511" name="H14T" type="hL" />
+      <Atom charge="-0.002435" name="C33" type="cD" />
+      <Atom charge="0.018859" name="H3X" type="hL" />
+      <Atom charge="0.018859" name="H3Y" type="hL" />
+      <Atom charge="-0.026954" name="C34" type="cD" />
+      <Atom charge="0.020431" name="H4X" type="hL" />
+      <Atom charge="0.020431" name="H4Y" type="hL" />
+      <Atom charge="-0.016521" name="C35" type="cD" />
+      <Atom charge="0.010573" name="H5X" type="hL" />
+      <Atom charge="0.010573" name="H5Y" type="hL" />
+      <Atom charge="-0.027812" name="C36" type="cD" />
+      <Atom charge="0.011511" name="H6X" type="hL" />
+      <Atom charge="0.011511" name="H6Y" type="hL" />
+      <Atom charge="-0.004386" name="C37" type="cD" />
+      <Atom charge="0.006833" name="H7X" type="hL" />
+      <Atom charge="0.006833" name="H7Y" type="hL" />
+      <Atom charge="-0.026451" name="C38" type="cD" />
+      <Atom charge="0.011241" name="H8X" type="hL" />
+      <Atom charge="0.011241" name="H8Y" type="hL" />
+      <Atom charge="-0.014653" name="C39" type="cD" />
+      <Atom charge="0.010172" name="H9X" type="hL" />
+      <Atom charge="0.010172" name="H9Y" type="hL" />
+      <Atom charge="-0.021025" name="C310" type="cD" />
+      <Atom charge="0.010037" name="H10X" type="hL" />
+      <Atom charge="0.010037" name="H10Y" type="hL" />
+      <Atom charge="-0.031787" name="C311" type="cD" />
+      <Atom charge="0.012677" name="H11X" type="hL" />
+      <Atom charge="0.012677" name="H11Y" type="hL" />
+      <Atom charge="-0.028094" name="C312" type="cD" />
+      <Atom charge="0.017208" name="H12X" type="hL" />
+      <Atom charge="0.017208" name="H12Y" type="hL" />
+      <Atom charge="0.017463" name="C313" type="cD" />
+      <Atom charge="0.007531" name="H13X" type="hL" />
+      <Atom charge="0.007531" name="H13Y" type="hL" />
+      <Atom charge="-0.111712" name="C314" type="cD" />
+      <Atom charge="0.025511" name="H14X" type="hL" />
+      <Atom charge="0.025511" name="H14Y" type="hL" />
+      <Atom charge="0.025511" name="H14Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="H14T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="H14Z" />
+      </Residue>
+    <Residue name="DMPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.1642" name="C22" type="cD" />
+      <Atom charge="0.053944" name="H2R" type="hL" />
+      <Atom charge="0.053944" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.1642" name="C32" type="cD" />
+      <Atom charge="0.053944" name="H2X" type="hL" />
+      <Atom charge="0.053944" name="H2Y" type="hL" />
+      <Atom charge="-0.002435" name="C23" type="cD" />
+      <Atom charge="0.018859" name="H3R" type="hL" />
+      <Atom charge="0.018859" name="H3S" type="hL" />
+      <Atom charge="-0.026954" name="C24" type="cD" />
+      <Atom charge="0.020431" name="H4R" type="hL" />
+      <Atom charge="0.020431" name="H4S" type="hL" />
+      <Atom charge="-0.016521" name="C25" type="cD" />
+      <Atom charge="0.010573" name="H5R" type="hL" />
+      <Atom charge="0.010573" name="H5S" type="hL" />
+      <Atom charge="-0.027812" name="C26" type="cD" />
+      <Atom charge="0.011511" name="H6R" type="hL" />
+      <Atom charge="0.011511" name="H6S" type="hL" />
+      <Atom charge="-0.004386" name="C27" type="cD" />
+      <Atom charge="0.006833" name="H7R" type="hL" />
+      <Atom charge="0.006833" name="H7S" type="hL" />
+      <Atom charge="-0.026451" name="C28" type="cD" />
+      <Atom charge="0.011241" name="H8R" type="hL" />
+      <Atom charge="0.011241" name="H8S" type="hL" />
+      <Atom charge="-0.014653" name="C29" type="cD" />
+      <Atom charge="0.010172" name="H9R" type="hL" />
+      <Atom charge="0.010172" name="H9S" type="hL" />
+      <Atom charge="-0.021025" name="C210" type="cD" />
+      <Atom charge="0.010037" name="H10R" type="hL" />
+      <Atom charge="0.010037" name="H10S" type="hL" />
+      <Atom charge="-0.031787" name="C211" type="cD" />
+      <Atom charge="0.012677" name="H11R" type="hL" />
+      <Atom charge="0.012677" name="H11S" type="hL" />
+      <Atom charge="-0.028094" name="C212" type="cD" />
+      <Atom charge="0.017208" name="H12R" type="hL" />
+      <Atom charge="0.017208" name="H12S" type="hL" />
+      <Atom charge="0.017463" name="C213" type="cD" />
+      <Atom charge="0.007531" name="H13R" type="hL" />
+      <Atom charge="0.007531" name="H13S" type="hL" />
+      <Atom charge="-0.111712" name="C214" type="cD" />
+      <Atom charge="0.025511" name="H14R" type="hL" />
+      <Atom charge="0.025511" name="H14S" type="hL" />
+      <Atom charge="0.025511" name="H14T" type="hL" />
+      <Atom charge="-0.002435" name="C33" type="cD" />
+      <Atom charge="0.018859" name="H3X" type="hL" />
+      <Atom charge="0.018859" name="H3Y" type="hL" />
+      <Atom charge="-0.026954" name="C34" type="cD" />
+      <Atom charge="0.020431" name="H4X" type="hL" />
+      <Atom charge="0.020431" name="H4Y" type="hL" />
+      <Atom charge="-0.016521" name="C35" type="cD" />
+      <Atom charge="0.010573" name="H5X" type="hL" />
+      <Atom charge="0.010573" name="H5Y" type="hL" />
+      <Atom charge="-0.027812" name="C36" type="cD" />
+      <Atom charge="0.011511" name="H6X" type="hL" />
+      <Atom charge="0.011511" name="H6Y" type="hL" />
+      <Atom charge="-0.004386" name="C37" type="cD" />
+      <Atom charge="0.006833" name="H7X" type="hL" />
+      <Atom charge="0.006833" name="H7Y" type="hL" />
+      <Atom charge="-0.026451" name="C38" type="cD" />
+      <Atom charge="0.011241" name="H8X" type="hL" />
+      <Atom charge="0.011241" name="H8Y" type="hL" />
+      <Atom charge="-0.014653" name="C39" type="cD" />
+      <Atom charge="0.010172" name="H9X" type="hL" />
+      <Atom charge="0.010172" name="H9Y" type="hL" />
+      <Atom charge="-0.021025" name="C310" type="cD" />
+      <Atom charge="0.010037" name="H10X" type="hL" />
+      <Atom charge="0.010037" name="H10Y" type="hL" />
+      <Atom charge="-0.031787" name="C311" type="cD" />
+      <Atom charge="0.012677" name="H11X" type="hL" />
+      <Atom charge="0.012677" name="H11Y" type="hL" />
+      <Atom charge="-0.028094" name="C312" type="cD" />
+      <Atom charge="0.017208" name="H12X" type="hL" />
+      <Atom charge="0.017208" name="H12Y" type="hL" />
+      <Atom charge="0.017463" name="C313" type="cD" />
+      <Atom charge="0.007531" name="H13X" type="hL" />
+      <Atom charge="0.007531" name="H13Y" type="hL" />
+      <Atom charge="-0.111712" name="C314" type="cD" />
+      <Atom charge="0.025511" name="H14X" type="hL" />
+      <Atom charge="0.025511" name="H14Y" type="hL" />
+      <Atom charge="0.025511" name="H14Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="H14T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="H14Z" />
+      </Residue>
+    <Residue name="DMPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.1642" name="C22" type="cD" />
+      <Atom charge="0.053944" name="H2R" type="hL" />
+      <Atom charge="0.053944" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.1642" name="C32" type="cD" />
+      <Atom charge="0.053944" name="H2X" type="hL" />
+      <Atom charge="0.053944" name="H2Y" type="hL" />
+      <Atom charge="-0.002435" name="C23" type="cD" />
+      <Atom charge="0.018859" name="H3R" type="hL" />
+      <Atom charge="0.018859" name="H3S" type="hL" />
+      <Atom charge="-0.026954" name="C24" type="cD" />
+      <Atom charge="0.020431" name="H4R" type="hL" />
+      <Atom charge="0.020431" name="H4S" type="hL" />
+      <Atom charge="-0.016521" name="C25" type="cD" />
+      <Atom charge="0.010573" name="H5R" type="hL" />
+      <Atom charge="0.010573" name="H5S" type="hL" />
+      <Atom charge="-0.027812" name="C26" type="cD" />
+      <Atom charge="0.011511" name="H6R" type="hL" />
+      <Atom charge="0.011511" name="H6S" type="hL" />
+      <Atom charge="-0.004386" name="C27" type="cD" />
+      <Atom charge="0.006833" name="H7R" type="hL" />
+      <Atom charge="0.006833" name="H7S" type="hL" />
+      <Atom charge="-0.026451" name="C28" type="cD" />
+      <Atom charge="0.011241" name="H8R" type="hL" />
+      <Atom charge="0.011241" name="H8S" type="hL" />
+      <Atom charge="-0.014653" name="C29" type="cD" />
+      <Atom charge="0.010172" name="H9R" type="hL" />
+      <Atom charge="0.010172" name="H9S" type="hL" />
+      <Atom charge="-0.021025" name="C210" type="cD" />
+      <Atom charge="0.010037" name="H10R" type="hL" />
+      <Atom charge="0.010037" name="H10S" type="hL" />
+      <Atom charge="-0.031787" name="C211" type="cD" />
+      <Atom charge="0.012677" name="H11R" type="hL" />
+      <Atom charge="0.012677" name="H11S" type="hL" />
+      <Atom charge="-0.028094" name="C212" type="cD" />
+      <Atom charge="0.017208" name="H12R" type="hL" />
+      <Atom charge="0.017208" name="H12S" type="hL" />
+      <Atom charge="0.017463" name="C213" type="cD" />
+      <Atom charge="0.007531" name="H13R" type="hL" />
+      <Atom charge="0.007531" name="H13S" type="hL" />
+      <Atom charge="-0.111712" name="C214" type="cD" />
+      <Atom charge="0.025511" name="H14R" type="hL" />
+      <Atom charge="0.025511" name="H14S" type="hL" />
+      <Atom charge="0.025511" name="H14T" type="hL" />
+      <Atom charge="-0.002435" name="C33" type="cD" />
+      <Atom charge="0.018859" name="H3X" type="hL" />
+      <Atom charge="0.018859" name="H3Y" type="hL" />
+      <Atom charge="-0.026954" name="C34" type="cD" />
+      <Atom charge="0.020431" name="H4X" type="hL" />
+      <Atom charge="0.020431" name="H4Y" type="hL" />
+      <Atom charge="-0.016521" name="C35" type="cD" />
+      <Atom charge="0.010573" name="H5X" type="hL" />
+      <Atom charge="0.010573" name="H5Y" type="hL" />
+      <Atom charge="-0.027812" name="C36" type="cD" />
+      <Atom charge="0.011511" name="H6X" type="hL" />
+      <Atom charge="0.011511" name="H6Y" type="hL" />
+      <Atom charge="-0.004386" name="C37" type="cD" />
+      <Atom charge="0.006833" name="H7X" type="hL" />
+      <Atom charge="0.006833" name="H7Y" type="hL" />
+      <Atom charge="-0.026451" name="C38" type="cD" />
+      <Atom charge="0.011241" name="H8X" type="hL" />
+      <Atom charge="0.011241" name="H8Y" type="hL" />
+      <Atom charge="-0.014653" name="C39" type="cD" />
+      <Atom charge="0.010172" name="H9X" type="hL" />
+      <Atom charge="0.010172" name="H9Y" type="hL" />
+      <Atom charge="-0.021025" name="C310" type="cD" />
+      <Atom charge="0.010037" name="H10X" type="hL" />
+      <Atom charge="0.010037" name="H10Y" type="hL" />
+      <Atom charge="-0.031787" name="C311" type="cD" />
+      <Atom charge="0.012677" name="H11X" type="hL" />
+      <Atom charge="0.012677" name="H11Y" type="hL" />
+      <Atom charge="-0.028094" name="C312" type="cD" />
+      <Atom charge="0.017208" name="H12X" type="hL" />
+      <Atom charge="0.017208" name="H12Y" type="hL" />
+      <Atom charge="0.017463" name="C313" type="cD" />
+      <Atom charge="0.007531" name="H13X" type="hL" />
+      <Atom charge="0.007531" name="H13Y" type="hL" />
+      <Atom charge="-0.111712" name="C314" type="cD" />
+      <Atom charge="0.025511" name="H14X" type="hL" />
+      <Atom charge="0.025511" name="H14Y" type="hL" />
+      <Atom charge="0.025511" name="H14Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="H14T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="H14Z" />
+      </Residue>
+    <Residue name="DMPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.1642" name="C22" type="cD" />
+      <Atom charge="0.053944" name="H2R" type="hL" />
+      <Atom charge="0.053944" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.1642" name="C32" type="cD" />
+      <Atom charge="0.053944" name="H2X" type="hL" />
+      <Atom charge="0.053944" name="H2Y" type="hL" />
+      <Atom charge="-0.002435" name="C23" type="cD" />
+      <Atom charge="0.018859" name="H3R" type="hL" />
+      <Atom charge="0.018859" name="H3S" type="hL" />
+      <Atom charge="-0.026954" name="C24" type="cD" />
+      <Atom charge="0.020431" name="H4R" type="hL" />
+      <Atom charge="0.020431" name="H4S" type="hL" />
+      <Atom charge="-0.016521" name="C25" type="cD" />
+      <Atom charge="0.010573" name="H5R" type="hL" />
+      <Atom charge="0.010573" name="H5S" type="hL" />
+      <Atom charge="-0.027812" name="C26" type="cD" />
+      <Atom charge="0.011511" name="H6R" type="hL" />
+      <Atom charge="0.011511" name="H6S" type="hL" />
+      <Atom charge="-0.004386" name="C27" type="cD" />
+      <Atom charge="0.006833" name="H7R" type="hL" />
+      <Atom charge="0.006833" name="H7S" type="hL" />
+      <Atom charge="-0.026451" name="C28" type="cD" />
+      <Atom charge="0.011241" name="H8R" type="hL" />
+      <Atom charge="0.011241" name="H8S" type="hL" />
+      <Atom charge="-0.014653" name="C29" type="cD" />
+      <Atom charge="0.010172" name="H9R" type="hL" />
+      <Atom charge="0.010172" name="H9S" type="hL" />
+      <Atom charge="-0.021025" name="C210" type="cD" />
+      <Atom charge="0.010037" name="H10R" type="hL" />
+      <Atom charge="0.010037" name="H10S" type="hL" />
+      <Atom charge="-0.031787" name="C211" type="cD" />
+      <Atom charge="0.012677" name="H11R" type="hL" />
+      <Atom charge="0.012677" name="H11S" type="hL" />
+      <Atom charge="-0.028094" name="C212" type="cD" />
+      <Atom charge="0.017208" name="H12R" type="hL" />
+      <Atom charge="0.017208" name="H12S" type="hL" />
+      <Atom charge="0.017463" name="C213" type="cD" />
+      <Atom charge="0.007531" name="H13R" type="hL" />
+      <Atom charge="0.007531" name="H13S" type="hL" />
+      <Atom charge="-0.111712" name="C214" type="cD" />
+      <Atom charge="0.025511" name="H14R" type="hL" />
+      <Atom charge="0.025511" name="H14S" type="hL" />
+      <Atom charge="0.025511" name="H14T" type="hL" />
+      <Atom charge="-0.002435" name="C33" type="cD" />
+      <Atom charge="0.018859" name="H3X" type="hL" />
+      <Atom charge="0.018859" name="H3Y" type="hL" />
+      <Atom charge="-0.026954" name="C34" type="cD" />
+      <Atom charge="0.020431" name="H4X" type="hL" />
+      <Atom charge="0.020431" name="H4Y" type="hL" />
+      <Atom charge="-0.016521" name="C35" type="cD" />
+      <Atom charge="0.010573" name="H5X" type="hL" />
+      <Atom charge="0.010573" name="H5Y" type="hL" />
+      <Atom charge="-0.027812" name="C36" type="cD" />
+      <Atom charge="0.011511" name="H6X" type="hL" />
+      <Atom charge="0.011511" name="H6Y" type="hL" />
+      <Atom charge="-0.004386" name="C37" type="cD" />
+      <Atom charge="0.006833" name="H7X" type="hL" />
+      <Atom charge="0.006833" name="H7Y" type="hL" />
+      <Atom charge="-0.026451" name="C38" type="cD" />
+      <Atom charge="0.011241" name="H8X" type="hL" />
+      <Atom charge="0.011241" name="H8Y" type="hL" />
+      <Atom charge="-0.014653" name="C39" type="cD" />
+      <Atom charge="0.010172" name="H9X" type="hL" />
+      <Atom charge="0.010172" name="H9Y" type="hL" />
+      <Atom charge="-0.021025" name="C310" type="cD" />
+      <Atom charge="0.010037" name="H10X" type="hL" />
+      <Atom charge="0.010037" name="H10Y" type="hL" />
+      <Atom charge="-0.031787" name="C311" type="cD" />
+      <Atom charge="0.012677" name="H11X" type="hL" />
+      <Atom charge="0.012677" name="H11Y" type="hL" />
+      <Atom charge="-0.028094" name="C312" type="cD" />
+      <Atom charge="0.017208" name="H12X" type="hL" />
+      <Atom charge="0.017208" name="H12Y" type="hL" />
+      <Atom charge="0.017463" name="C313" type="cD" />
+      <Atom charge="0.007531" name="H13X" type="hL" />
+      <Atom charge="0.007531" name="H13Y" type="hL" />
+      <Atom charge="-0.111712" name="C314" type="cD" />
+      <Atom charge="0.025511" name="H14X" type="hL" />
+      <Atom charge="0.025511" name="H14Y" type="hL" />
+      <Atom charge="0.025511" name="H14Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="H14T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="H14Z" />
+    </Residue>
+    <Residue name="DMPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.1642" name="C22" type="cD" />
+      <Atom charge="0.053944" name="H2R" type="hL" />
+      <Atom charge="0.053944" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.1642" name="C32" type="cD" />
+      <Atom charge="0.053944" name="H2X" type="hL" />
+      <Atom charge="0.053944" name="H2Y" type="hL" />
+      <Atom charge="-0.002435" name="C23" type="cD" />
+      <Atom charge="0.018859" name="H3R" type="hL" />
+      <Atom charge="0.018859" name="H3S" type="hL" />
+      <Atom charge="-0.026954" name="C24" type="cD" />
+      <Atom charge="0.020431" name="H4R" type="hL" />
+      <Atom charge="0.020431" name="H4S" type="hL" />
+      <Atom charge="-0.016521" name="C25" type="cD" />
+      <Atom charge="0.010573" name="H5R" type="hL" />
+      <Atom charge="0.010573" name="H5S" type="hL" />
+      <Atom charge="-0.027812" name="C26" type="cD" />
+      <Atom charge="0.011511" name="H6R" type="hL" />
+      <Atom charge="0.011511" name="H6S" type="hL" />
+      <Atom charge="-0.004386" name="C27" type="cD" />
+      <Atom charge="0.006833" name="H7R" type="hL" />
+      <Atom charge="0.006833" name="H7S" type="hL" />
+      <Atom charge="-0.026451" name="C28" type="cD" />
+      <Atom charge="0.011241" name="H8R" type="hL" />
+      <Atom charge="0.011241" name="H8S" type="hL" />
+      <Atom charge="-0.014653" name="C29" type="cD" />
+      <Atom charge="0.010172" name="H9R" type="hL" />
+      <Atom charge="0.010172" name="H9S" type="hL" />
+      <Atom charge="-0.021025" name="C210" type="cD" />
+      <Atom charge="0.010037" name="H10R" type="hL" />
+      <Atom charge="0.010037" name="H10S" type="hL" />
+      <Atom charge="-0.031787" name="C211" type="cD" />
+      <Atom charge="0.012677" name="H11R" type="hL" />
+      <Atom charge="0.012677" name="H11S" type="hL" />
+      <Atom charge="-0.028094" name="C212" type="cD" />
+      <Atom charge="0.017208" name="H12R" type="hL" />
+      <Atom charge="0.017208" name="H12S" type="hL" />
+      <Atom charge="0.017463" name="C213" type="cD" />
+      <Atom charge="0.007531" name="H13R" type="hL" />
+      <Atom charge="0.007531" name="H13S" type="hL" />
+      <Atom charge="-0.111712" name="C214" type="cD" />
+      <Atom charge="0.025511" name="H14R" type="hL" />
+      <Atom charge="0.025511" name="H14S" type="hL" />
+      <Atom charge="0.025511" name="H14T" type="hL" />
+      <Atom charge="-0.002435" name="C33" type="cD" />
+      <Atom charge="0.018859" name="H3X" type="hL" />
+      <Atom charge="0.018859" name="H3Y" type="hL" />
+      <Atom charge="-0.026954" name="C34" type="cD" />
+      <Atom charge="0.020431" name="H4X" type="hL" />
+      <Atom charge="0.020431" name="H4Y" type="hL" />
+      <Atom charge="-0.016521" name="C35" type="cD" />
+      <Atom charge="0.010573" name="H5X" type="hL" />
+      <Atom charge="0.010573" name="H5Y" type="hL" />
+      <Atom charge="-0.027812" name="C36" type="cD" />
+      <Atom charge="0.011511" name="H6X" type="hL" />
+      <Atom charge="0.011511" name="H6Y" type="hL" />
+      <Atom charge="-0.004386" name="C37" type="cD" />
+      <Atom charge="0.006833" name="H7X" type="hL" />
+      <Atom charge="0.006833" name="H7Y" type="hL" />
+      <Atom charge="-0.026451" name="C38" type="cD" />
+      <Atom charge="0.011241" name="H8X" type="hL" />
+      <Atom charge="0.011241" name="H8Y" type="hL" />
+      <Atom charge="-0.014653" name="C39" type="cD" />
+      <Atom charge="0.010172" name="H9X" type="hL" />
+      <Atom charge="0.010172" name="H9Y" type="hL" />
+      <Atom charge="-0.021025" name="C310" type="cD" />
+      <Atom charge="0.010037" name="H10X" type="hL" />
+      <Atom charge="0.010037" name="H10Y" type="hL" />
+      <Atom charge="-0.031787" name="C311" type="cD" />
+      <Atom charge="0.012677" name="H11X" type="hL" />
+      <Atom charge="0.012677" name="H11Y" type="hL" />
+      <Atom charge="-0.028094" name="C312" type="cD" />
+      <Atom charge="0.017208" name="H12X" type="hL" />
+      <Atom charge="0.017208" name="H12Y" type="hL" />
+      <Atom charge="0.017463" name="C313" type="cD" />
+      <Atom charge="0.007531" name="H13X" type="hL" />
+      <Atom charge="0.007531" name="H13Y" type="hL" />
+      <Atom charge="-0.111712" name="C314" type="cD" />
+      <Atom charge="0.025511" name="H14X" type="hL" />
+      <Atom charge="0.025511" name="H14Y" type="hL" />
+      <Atom charge="0.025511" name="H14Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="H14T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="H14Z" />
+    </Residue>
+    <Residue name="DPPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.149259" name="C22" type="cD" />
+      <Atom charge="0.047345" name="H2R" type="hL" />
+      <Atom charge="0.047345" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="-0.004882" name="C23" type="cD" />
+      <Atom charge="0.019007" name="H3R" type="hL" />
+      <Atom charge="0.019007" name="H3S" type="hL" />
+      <Atom charge="-0.030099" name="C24" type="cD" />
+      <Atom charge="0.020877" name="H4R" type="hL" />
+      <Atom charge="0.020877" name="H4S" type="hL" />
+      <Atom charge="-0.029387" name="C25" type="cD" />
+      <Atom charge="0.016763" name="H5R" type="hL" />
+      <Atom charge="0.016763" name="H5S" type="hL" />
+      <Atom charge="-0.024427" name="C26" type="cD" />
+      <Atom charge="0.013334" name="H6R" type="hL" />
+      <Atom charge="0.013334" name="H6S" type="hL" />
+      <Atom charge="-0.01963" name="C27" type="cD" />
+      <Atom charge="0.011041" name="H7R" type="hL" />
+      <Atom charge="0.011041" name="H7S" type="hL" />
+      <Atom charge="-0.015793" name="C28" type="cD" />
+      <Atom charge="0.009067" name="H8R" type="hL" />
+      <Atom charge="0.009067" name="H8S" type="hL" />
+      <Atom charge="-0.030472" name="C29" type="cD" />
+      <Atom charge="0.013897" name="H9R" type="hL" />
+      <Atom charge="0.013897" name="H9S" type="hL" />
+      <Atom charge="-0.028831" name="C210" type="cD" />
+      <Atom charge="0.014691" name="H10R" type="hL" />
+      <Atom charge="0.014691" name="H10S" type="hL" />
+      <Atom charge="-0.025206" name="C211" type="cD" />
+      <Atom charge="0.014334" name="H11R" type="hL" />
+      <Atom charge="0.014334" name="H11S" type="hL" />
+      <Atom charge="-0.027633" name="C212" type="cD" />
+      <Atom charge="0.011368" name="H12R" type="hL" />
+      <Atom charge="0.011368" name="H12S" type="hL" />
+      <Atom charge="-0.033096" name="C213" type="cD" />
+      <Atom charge="0.014621" name="H13R" type="hL" />
+      <Atom charge="0.014621" name="H13S" type="hL" />
+      <Atom charge="-0.020086" name="C214" type="cD" />
+      <Atom charge="0.015929" name="H14R" type="hL" />
+      <Atom charge="0.015929" name="H14S" type="hL" />
+      <Atom charge="0.013975" name="C215" type="cD" />
+      <Atom charge="0.009292" name="H15R" type="hL" />
+      <Atom charge="0.009292" name="H15S" type="hL" />
+      <Atom charge="-0.125447" name="C216" type="cD" />
+      <Atom charge="0.029047" name="H16R" type="hL" />
+      <Atom charge="0.029047" name="H16S" type="hL" />
+      <Atom charge="0.029047" name="H16T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="H16T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+      </Residue>
+    <Residue name="DPPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.149259" name="C22" type="cD" />
+      <Atom charge="0.047345" name="H2R" type="hL" />
+      <Atom charge="0.047345" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="-0.004882" name="C23" type="cD" />
+      <Atom charge="0.019007" name="H3R" type="hL" />
+      <Atom charge="0.019007" name="H3S" type="hL" />
+      <Atom charge="-0.030099" name="C24" type="cD" />
+      <Atom charge="0.020877" name="H4R" type="hL" />
+      <Atom charge="0.020877" name="H4S" type="hL" />
+      <Atom charge="-0.029387" name="C25" type="cD" />
+      <Atom charge="0.016763" name="H5R" type="hL" />
+      <Atom charge="0.016763" name="H5S" type="hL" />
+      <Atom charge="-0.024427" name="C26" type="cD" />
+      <Atom charge="0.013334" name="H6R" type="hL" />
+      <Atom charge="0.013334" name="H6S" type="hL" />
+      <Atom charge="-0.01963" name="C27" type="cD" />
+      <Atom charge="0.011041" name="H7R" type="hL" />
+      <Atom charge="0.011041" name="H7S" type="hL" />
+      <Atom charge="-0.015793" name="C28" type="cD" />
+      <Atom charge="0.009067" name="H8R" type="hL" />
+      <Atom charge="0.009067" name="H8S" type="hL" />
+      <Atom charge="-0.030472" name="C29" type="cD" />
+      <Atom charge="0.013897" name="H9R" type="hL" />
+      <Atom charge="0.013897" name="H9S" type="hL" />
+      <Atom charge="-0.028831" name="C210" type="cD" />
+      <Atom charge="0.014691" name="H10R" type="hL" />
+      <Atom charge="0.014691" name="H10S" type="hL" />
+      <Atom charge="-0.025206" name="C211" type="cD" />
+      <Atom charge="0.014334" name="H11R" type="hL" />
+      <Atom charge="0.014334" name="H11S" type="hL" />
+      <Atom charge="-0.027633" name="C212" type="cD" />
+      <Atom charge="0.011368" name="H12R" type="hL" />
+      <Atom charge="0.011368" name="H12S" type="hL" />
+      <Atom charge="-0.033096" name="C213" type="cD" />
+      <Atom charge="0.014621" name="H13R" type="hL" />
+      <Atom charge="0.014621" name="H13S" type="hL" />
+      <Atom charge="-0.020086" name="C214" type="cD" />
+      <Atom charge="0.015929" name="H14R" type="hL" />
+      <Atom charge="0.015929" name="H14S" type="hL" />
+      <Atom charge="0.013975" name="C215" type="cD" />
+      <Atom charge="0.009292" name="H15R" type="hL" />
+      <Atom charge="0.009292" name="H15S" type="hL" />
+      <Atom charge="-0.125447" name="C216" type="cD" />
+      <Atom charge="0.029047" name="H16R" type="hL" />
+      <Atom charge="0.029047" name="H16S" type="hL" />
+      <Atom charge="0.029047" name="H16T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="H16T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+      </Residue>
+    <Residue name="DPPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.149259" name="C22" type="cD" />
+      <Atom charge="0.047345" name="H2R" type="hL" />
+      <Atom charge="0.047345" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="-0.004882" name="C23" type="cD" />
+      <Atom charge="0.019007" name="H3R" type="hL" />
+      <Atom charge="0.019007" name="H3S" type="hL" />
+      <Atom charge="-0.030099" name="C24" type="cD" />
+      <Atom charge="0.020877" name="H4R" type="hL" />
+      <Atom charge="0.020877" name="H4S" type="hL" />
+      <Atom charge="-0.029387" name="C25" type="cD" />
+      <Atom charge="0.016763" name="H5R" type="hL" />
+      <Atom charge="0.016763" name="H5S" type="hL" />
+      <Atom charge="-0.024427" name="C26" type="cD" />
+      <Atom charge="0.013334" name="H6R" type="hL" />
+      <Atom charge="0.013334" name="H6S" type="hL" />
+      <Atom charge="-0.01963" name="C27" type="cD" />
+      <Atom charge="0.011041" name="H7R" type="hL" />
+      <Atom charge="0.011041" name="H7S" type="hL" />
+      <Atom charge="-0.015793" name="C28" type="cD" />
+      <Atom charge="0.009067" name="H8R" type="hL" />
+      <Atom charge="0.009067" name="H8S" type="hL" />
+      <Atom charge="-0.030472" name="C29" type="cD" />
+      <Atom charge="0.013897" name="H9R" type="hL" />
+      <Atom charge="0.013897" name="H9S" type="hL" />
+      <Atom charge="-0.028831" name="C210" type="cD" />
+      <Atom charge="0.014691" name="H10R" type="hL" />
+      <Atom charge="0.014691" name="H10S" type="hL" />
+      <Atom charge="-0.025206" name="C211" type="cD" />
+      <Atom charge="0.014334" name="H11R" type="hL" />
+      <Atom charge="0.014334" name="H11S" type="hL" />
+      <Atom charge="-0.027633" name="C212" type="cD" />
+      <Atom charge="0.011368" name="H12R" type="hL" />
+      <Atom charge="0.011368" name="H12S" type="hL" />
+      <Atom charge="-0.033096" name="C213" type="cD" />
+      <Atom charge="0.014621" name="H13R" type="hL" />
+      <Atom charge="0.014621" name="H13S" type="hL" />
+      <Atom charge="-0.020086" name="C214" type="cD" />
+      <Atom charge="0.015929" name="H14R" type="hL" />
+      <Atom charge="0.015929" name="H14S" type="hL" />
+      <Atom charge="0.013975" name="C215" type="cD" />
+      <Atom charge="0.009292" name="H15R" type="hL" />
+      <Atom charge="0.009292" name="H15S" type="hL" />
+      <Atom charge="-0.125447" name="C216" type="cD" />
+      <Atom charge="0.029047" name="H16R" type="hL" />
+      <Atom charge="0.029047" name="H16S" type="hL" />
+      <Atom charge="0.029047" name="H16T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="H16T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+      </Residue>
+    <Residue name="DPPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.149259" name="C22" type="cD" />
+      <Atom charge="0.047345" name="H2R" type="hL" />
+      <Atom charge="0.047345" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="-0.004882" name="C23" type="cD" />
+      <Atom charge="0.019007" name="H3R" type="hL" />
+      <Atom charge="0.019007" name="H3S" type="hL" />
+      <Atom charge="-0.030099" name="C24" type="cD" />
+      <Atom charge="0.020877" name="H4R" type="hL" />
+      <Atom charge="0.020877" name="H4S" type="hL" />
+      <Atom charge="-0.029387" name="C25" type="cD" />
+      <Atom charge="0.016763" name="H5R" type="hL" />
+      <Atom charge="0.016763" name="H5S" type="hL" />
+      <Atom charge="-0.024427" name="C26" type="cD" />
+      <Atom charge="0.013334" name="H6R" type="hL" />
+      <Atom charge="0.013334" name="H6S" type="hL" />
+      <Atom charge="-0.01963" name="C27" type="cD" />
+      <Atom charge="0.011041" name="H7R" type="hL" />
+      <Atom charge="0.011041" name="H7S" type="hL" />
+      <Atom charge="-0.015793" name="C28" type="cD" />
+      <Atom charge="0.009067" name="H8R" type="hL" />
+      <Atom charge="0.009067" name="H8S" type="hL" />
+      <Atom charge="-0.030472" name="C29" type="cD" />
+      <Atom charge="0.013897" name="H9R" type="hL" />
+      <Atom charge="0.013897" name="H9S" type="hL" />
+      <Atom charge="-0.028831" name="C210" type="cD" />
+      <Atom charge="0.014691" name="H10R" type="hL" />
+      <Atom charge="0.014691" name="H10S" type="hL" />
+      <Atom charge="-0.025206" name="C211" type="cD" />
+      <Atom charge="0.014334" name="H11R" type="hL" />
+      <Atom charge="0.014334" name="H11S" type="hL" />
+      <Atom charge="-0.027633" name="C212" type="cD" />
+      <Atom charge="0.011368" name="H12R" type="hL" />
+      <Atom charge="0.011368" name="H12S" type="hL" />
+      <Atom charge="-0.033096" name="C213" type="cD" />
+      <Atom charge="0.014621" name="H13R" type="hL" />
+      <Atom charge="0.014621" name="H13S" type="hL" />
+      <Atom charge="-0.020086" name="C214" type="cD" />
+      <Atom charge="0.015929" name="H14R" type="hL" />
+      <Atom charge="0.015929" name="H14S" type="hL" />
+      <Atom charge="0.013975" name="C215" type="cD" />
+      <Atom charge="0.009292" name="H15R" type="hL" />
+      <Atom charge="0.009292" name="H15S" type="hL" />
+      <Atom charge="-0.125447" name="C216" type="cD" />
+      <Atom charge="0.029047" name="H16R" type="hL" />
+      <Atom charge="0.029047" name="H16S" type="hL" />
+      <Atom charge="0.029047" name="H16T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="H16T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+    </Residue>
+    <Residue name="DPPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.149259" name="C22" type="cD" />
+      <Atom charge="0.047345" name="H2R" type="hL" />
+      <Atom charge="0.047345" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="-0.004882" name="C23" type="cD" />
+      <Atom charge="0.019007" name="H3R" type="hL" />
+      <Atom charge="0.019007" name="H3S" type="hL" />
+      <Atom charge="-0.030099" name="C24" type="cD" />
+      <Atom charge="0.020877" name="H4R" type="hL" />
+      <Atom charge="0.020877" name="H4S" type="hL" />
+      <Atom charge="-0.029387" name="C25" type="cD" />
+      <Atom charge="0.016763" name="H5R" type="hL" />
+      <Atom charge="0.016763" name="H5S" type="hL" />
+      <Atom charge="-0.024427" name="C26" type="cD" />
+      <Atom charge="0.013334" name="H6R" type="hL" />
+      <Atom charge="0.013334" name="H6S" type="hL" />
+      <Atom charge="-0.01963" name="C27" type="cD" />
+      <Atom charge="0.011041" name="H7R" type="hL" />
+      <Atom charge="0.011041" name="H7S" type="hL" />
+      <Atom charge="-0.015793" name="C28" type="cD" />
+      <Atom charge="0.009067" name="H8R" type="hL" />
+      <Atom charge="0.009067" name="H8S" type="hL" />
+      <Atom charge="-0.030472" name="C29" type="cD" />
+      <Atom charge="0.013897" name="H9R" type="hL" />
+      <Atom charge="0.013897" name="H9S" type="hL" />
+      <Atom charge="-0.028831" name="C210" type="cD" />
+      <Atom charge="0.014691" name="H10R" type="hL" />
+      <Atom charge="0.014691" name="H10S" type="hL" />
+      <Atom charge="-0.025206" name="C211" type="cD" />
+      <Atom charge="0.014334" name="H11R" type="hL" />
+      <Atom charge="0.014334" name="H11S" type="hL" />
+      <Atom charge="-0.027633" name="C212" type="cD" />
+      <Atom charge="0.011368" name="H12R" type="hL" />
+      <Atom charge="0.011368" name="H12S" type="hL" />
+      <Atom charge="-0.033096" name="C213" type="cD" />
+      <Atom charge="0.014621" name="H13R" type="hL" />
+      <Atom charge="0.014621" name="H13S" type="hL" />
+      <Atom charge="-0.020086" name="C214" type="cD" />
+      <Atom charge="0.015929" name="H14R" type="hL" />
+      <Atom charge="0.015929" name="H14S" type="hL" />
+      <Atom charge="0.013975" name="C215" type="cD" />
+      <Atom charge="0.009292" name="H15R" type="hL" />
+      <Atom charge="0.009292" name="H15S" type="hL" />
+      <Atom charge="-0.125447" name="C216" type="cD" />
+      <Atom charge="0.029047" name="H16R" type="hL" />
+      <Atom charge="0.029047" name="H16S" type="hL" />
+      <Atom charge="0.029047" name="H16T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="H16T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+    </Residue>
+    <Residue name="DSPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.11702" name="C22" type="cD" />
+      <Atom charge="0.051807" name="H2R" type="hL" />
+      <Atom charge="0.051807" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="-0.000128" name="C23" type="cD" />
+      <Atom charge="0.013886" name="H3R" type="hL" />
+      <Atom charge="0.013886" name="H3S" type="hL" />
+      <Atom charge="-0.059792" name="C24" type="cD" />
+      <Atom charge="0.024241" name="H4R" type="hL" />
+      <Atom charge="0.024241" name="H4S" type="hL" />
+      <Atom charge="-0.013443" name="C25" type="cD" />
+      <Atom charge="0.008191" name="H5R" type="hL" />
+      <Atom charge="0.008191" name="H5S" type="hL" />
+      <Atom charge="-0.037627" name="C26" type="cD" />
+      <Atom charge="0.01774" name="H6R" type="hL" />
+      <Atom charge="0.01774" name="H6S" type="hL" />
+      <Atom charge="-0.019469" name="C27" type="cD" />
+      <Atom charge="0.009292" name="H7R" type="hL" />
+      <Atom charge="0.009292" name="H7S" type="hL" />
+      <Atom charge="-0.014623" name="C28" type="cD" />
+      <Atom charge="0.007326" name="H8R" type="hL" />
+      <Atom charge="0.007326" name="H8S" type="hL" />
+      <Atom charge="-0.017997" name="C29" type="cD" />
+      <Atom charge="0.009595" name="H9R" type="hL" />
+      <Atom charge="0.009595" name="H9S" type="hL" />
+      <Atom charge="-0.026418" name="C210" type="cD" />
+      <Atom charge="0.010825" name="H10R" type="hL" />
+      <Atom charge="0.010825" name="H10S" type="hL" />
+      <Atom charge="-0.017093" name="C211" type="cD" />
+      <Atom charge="0.010206" name="H11R" type="hL" />
+      <Atom charge="0.010206" name="H11S" type="hL" />
+      <Atom charge="-0.019153" name="C212" type="cD" />
+      <Atom charge="0.008198" name="H12R" type="hL" />
+      <Atom charge="0.008198" name="H12S" type="hL" />
+      <Atom charge="-0.01159" name="C213" type="cD" />
+      <Atom charge="0.006022" name="H13R" type="hL" />
+      <Atom charge="0.006022" name="H13S" type="hL" />
+      <Atom charge="-0.013489" name="C214" type="cD" />
+      <Atom charge="0.010073" name="H14R" type="hL" />
+      <Atom charge="0.010073" name="H14S" type="hL" />
+      <Atom charge="-0.032444" name="C215" type="cD" />
+      <Atom charge="0.010253" name="H15R" type="hL" />
+      <Atom charge="0.010253" name="H15S" type="hL" />
+      <Atom charge="-0.027654" name="C216" type="cD" />
+      <Atom charge="0.015627" name="H16R" type="hL" />
+      <Atom charge="0.015627" name="H16S" type="hL" />
+      <Atom charge="0.020665" name="C217" type="cD" />
+      <Atom charge="0.008483" name="H17R" type="hL" />
+      <Atom charge="0.008483" name="H17S" type="hL" />
+      <Atom charge="-0.120069" name="C218" type="cD" />
+      <Atom charge="0.027938" name="H18R" type="hL" />
+      <Atom charge="0.027938" name="H18S" type="hL" />
+      <Atom charge="0.027938" name="H18T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DSPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.11702" name="C22" type="cD" />
+      <Atom charge="0.051807" name="H2R" type="hL" />
+      <Atom charge="0.051807" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="-0.000128" name="C23" type="cD" />
+      <Atom charge="0.013886" name="H3R" type="hL" />
+      <Atom charge="0.013886" name="H3S" type="hL" />
+      <Atom charge="-0.059792" name="C24" type="cD" />
+      <Atom charge="0.024241" name="H4R" type="hL" />
+      <Atom charge="0.024241" name="H4S" type="hL" />
+      <Atom charge="-0.013443" name="C25" type="cD" />
+      <Atom charge="0.008191" name="H5R" type="hL" />
+      <Atom charge="0.008191" name="H5S" type="hL" />
+      <Atom charge="-0.037627" name="C26" type="cD" />
+      <Atom charge="0.01774" name="H6R" type="hL" />
+      <Atom charge="0.01774" name="H6S" type="hL" />
+      <Atom charge="-0.019469" name="C27" type="cD" />
+      <Atom charge="0.009292" name="H7R" type="hL" />
+      <Atom charge="0.009292" name="H7S" type="hL" />
+      <Atom charge="-0.014623" name="C28" type="cD" />
+      <Atom charge="0.007326" name="H8R" type="hL" />
+      <Atom charge="0.007326" name="H8S" type="hL" />
+      <Atom charge="-0.017997" name="C29" type="cD" />
+      <Atom charge="0.009595" name="H9R" type="hL" />
+      <Atom charge="0.009595" name="H9S" type="hL" />
+      <Atom charge="-0.026418" name="C210" type="cD" />
+      <Atom charge="0.010825" name="H10R" type="hL" />
+      <Atom charge="0.010825" name="H10S" type="hL" />
+      <Atom charge="-0.017093" name="C211" type="cD" />
+      <Atom charge="0.010206" name="H11R" type="hL" />
+      <Atom charge="0.010206" name="H11S" type="hL" />
+      <Atom charge="-0.019153" name="C212" type="cD" />
+      <Atom charge="0.008198" name="H12R" type="hL" />
+      <Atom charge="0.008198" name="H12S" type="hL" />
+      <Atom charge="-0.01159" name="C213" type="cD" />
+      <Atom charge="0.006022" name="H13R" type="hL" />
+      <Atom charge="0.006022" name="H13S" type="hL" />
+      <Atom charge="-0.013489" name="C214" type="cD" />
+      <Atom charge="0.010073" name="H14R" type="hL" />
+      <Atom charge="0.010073" name="H14S" type="hL" />
+      <Atom charge="-0.032444" name="C215" type="cD" />
+      <Atom charge="0.010253" name="H15R" type="hL" />
+      <Atom charge="0.010253" name="H15S" type="hL" />
+      <Atom charge="-0.027654" name="C216" type="cD" />
+      <Atom charge="0.015627" name="H16R" type="hL" />
+      <Atom charge="0.015627" name="H16S" type="hL" />
+      <Atom charge="0.020665" name="C217" type="cD" />
+      <Atom charge="0.008483" name="H17R" type="hL" />
+      <Atom charge="0.008483" name="H17S" type="hL" />
+      <Atom charge="-0.120069" name="C218" type="cD" />
+      <Atom charge="0.027938" name="H18R" type="hL" />
+      <Atom charge="0.027938" name="H18S" type="hL" />
+      <Atom charge="0.027938" name="H18T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DSPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.11702" name="C22" type="cD" />
+      <Atom charge="0.051807" name="H2R" type="hL" />
+      <Atom charge="0.051807" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="-0.000128" name="C23" type="cD" />
+      <Atom charge="0.013886" name="H3R" type="hL" />
+      <Atom charge="0.013886" name="H3S" type="hL" />
+      <Atom charge="-0.059792" name="C24" type="cD" />
+      <Atom charge="0.024241" name="H4R" type="hL" />
+      <Atom charge="0.024241" name="H4S" type="hL" />
+      <Atom charge="-0.013443" name="C25" type="cD" />
+      <Atom charge="0.008191" name="H5R" type="hL" />
+      <Atom charge="0.008191" name="H5S" type="hL" />
+      <Atom charge="-0.037627" name="C26" type="cD" />
+      <Atom charge="0.01774" name="H6R" type="hL" />
+      <Atom charge="0.01774" name="H6S" type="hL" />
+      <Atom charge="-0.019469" name="C27" type="cD" />
+      <Atom charge="0.009292" name="H7R" type="hL" />
+      <Atom charge="0.009292" name="H7S" type="hL" />
+      <Atom charge="-0.014623" name="C28" type="cD" />
+      <Atom charge="0.007326" name="H8R" type="hL" />
+      <Atom charge="0.007326" name="H8S" type="hL" />
+      <Atom charge="-0.017997" name="C29" type="cD" />
+      <Atom charge="0.009595" name="H9R" type="hL" />
+      <Atom charge="0.009595" name="H9S" type="hL" />
+      <Atom charge="-0.026418" name="C210" type="cD" />
+      <Atom charge="0.010825" name="H10R" type="hL" />
+      <Atom charge="0.010825" name="H10S" type="hL" />
+      <Atom charge="-0.017093" name="C211" type="cD" />
+      <Atom charge="0.010206" name="H11R" type="hL" />
+      <Atom charge="0.010206" name="H11S" type="hL" />
+      <Atom charge="-0.019153" name="C212" type="cD" />
+      <Atom charge="0.008198" name="H12R" type="hL" />
+      <Atom charge="0.008198" name="H12S" type="hL" />
+      <Atom charge="-0.01159" name="C213" type="cD" />
+      <Atom charge="0.006022" name="H13R" type="hL" />
+      <Atom charge="0.006022" name="H13S" type="hL" />
+      <Atom charge="-0.013489" name="C214" type="cD" />
+      <Atom charge="0.010073" name="H14R" type="hL" />
+      <Atom charge="0.010073" name="H14S" type="hL" />
+      <Atom charge="-0.032444" name="C215" type="cD" />
+      <Atom charge="0.010253" name="H15R" type="hL" />
+      <Atom charge="0.010253" name="H15S" type="hL" />
+      <Atom charge="-0.027654" name="C216" type="cD" />
+      <Atom charge="0.015627" name="H16R" type="hL" />
+      <Atom charge="0.015627" name="H16S" type="hL" />
+      <Atom charge="0.020665" name="C217" type="cD" />
+      <Atom charge="0.008483" name="H17R" type="hL" />
+      <Atom charge="0.008483" name="H17S" type="hL" />
+      <Atom charge="-0.120069" name="C218" type="cD" />
+      <Atom charge="0.027938" name="H18R" type="hL" />
+      <Atom charge="0.027938" name="H18S" type="hL" />
+      <Atom charge="0.027938" name="H18T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DSPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.11702" name="C22" type="cD" />
+      <Atom charge="0.051807" name="H2R" type="hL" />
+      <Atom charge="0.051807" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="-0.000128" name="C23" type="cD" />
+      <Atom charge="0.013886" name="H3R" type="hL" />
+      <Atom charge="0.013886" name="H3S" type="hL" />
+      <Atom charge="-0.059792" name="C24" type="cD" />
+      <Atom charge="0.024241" name="H4R" type="hL" />
+      <Atom charge="0.024241" name="H4S" type="hL" />
+      <Atom charge="-0.013443" name="C25" type="cD" />
+      <Atom charge="0.008191" name="H5R" type="hL" />
+      <Atom charge="0.008191" name="H5S" type="hL" />
+      <Atom charge="-0.037627" name="C26" type="cD" />
+      <Atom charge="0.01774" name="H6R" type="hL" />
+      <Atom charge="0.01774" name="H6S" type="hL" />
+      <Atom charge="-0.019469" name="C27" type="cD" />
+      <Atom charge="0.009292" name="H7R" type="hL" />
+      <Atom charge="0.009292" name="H7S" type="hL" />
+      <Atom charge="-0.014623" name="C28" type="cD" />
+      <Atom charge="0.007326" name="H8R" type="hL" />
+      <Atom charge="0.007326" name="H8S" type="hL" />
+      <Atom charge="-0.017997" name="C29" type="cD" />
+      <Atom charge="0.009595" name="H9R" type="hL" />
+      <Atom charge="0.009595" name="H9S" type="hL" />
+      <Atom charge="-0.026418" name="C210" type="cD" />
+      <Atom charge="0.010825" name="H10R" type="hL" />
+      <Atom charge="0.010825" name="H10S" type="hL" />
+      <Atom charge="-0.017093" name="C211" type="cD" />
+      <Atom charge="0.010206" name="H11R" type="hL" />
+      <Atom charge="0.010206" name="H11S" type="hL" />
+      <Atom charge="-0.019153" name="C212" type="cD" />
+      <Atom charge="0.008198" name="H12R" type="hL" />
+      <Atom charge="0.008198" name="H12S" type="hL" />
+      <Atom charge="-0.01159" name="C213" type="cD" />
+      <Atom charge="0.006022" name="H13R" type="hL" />
+      <Atom charge="0.006022" name="H13S" type="hL" />
+      <Atom charge="-0.013489" name="C214" type="cD" />
+      <Atom charge="0.010073" name="H14R" type="hL" />
+      <Atom charge="0.010073" name="H14S" type="hL" />
+      <Atom charge="-0.032444" name="C215" type="cD" />
+      <Atom charge="0.010253" name="H15R" type="hL" />
+      <Atom charge="0.010253" name="H15S" type="hL" />
+      <Atom charge="-0.027654" name="C216" type="cD" />
+      <Atom charge="0.015627" name="H16R" type="hL" />
+      <Atom charge="0.015627" name="H16S" type="hL" />
+      <Atom charge="0.020665" name="C217" type="cD" />
+      <Atom charge="0.008483" name="H17R" type="hL" />
+      <Atom charge="0.008483" name="H17S" type="hL" />
+      <Atom charge="-0.120069" name="C218" type="cD" />
+      <Atom charge="0.027938" name="H18R" type="hL" />
+      <Atom charge="0.027938" name="H18S" type="hL" />
+      <Atom charge="0.027938" name="H18T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+    </Residue>
+    <Residue name="DSPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.11702" name="C22" type="cD" />
+      <Atom charge="0.051807" name="H2R" type="hL" />
+      <Atom charge="0.051807" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="-0.000128" name="C23" type="cD" />
+      <Atom charge="0.013886" name="H3R" type="hL" />
+      <Atom charge="0.013886" name="H3S" type="hL" />
+      <Atom charge="-0.059792" name="C24" type="cD" />
+      <Atom charge="0.024241" name="H4R" type="hL" />
+      <Atom charge="0.024241" name="H4S" type="hL" />
+      <Atom charge="-0.013443" name="C25" type="cD" />
+      <Atom charge="0.008191" name="H5R" type="hL" />
+      <Atom charge="0.008191" name="H5S" type="hL" />
+      <Atom charge="-0.037627" name="C26" type="cD" />
+      <Atom charge="0.01774" name="H6R" type="hL" />
+      <Atom charge="0.01774" name="H6S" type="hL" />
+      <Atom charge="-0.019469" name="C27" type="cD" />
+      <Atom charge="0.009292" name="H7R" type="hL" />
+      <Atom charge="0.009292" name="H7S" type="hL" />
+      <Atom charge="-0.014623" name="C28" type="cD" />
+      <Atom charge="0.007326" name="H8R" type="hL" />
+      <Atom charge="0.007326" name="H8S" type="hL" />
+      <Atom charge="-0.017997" name="C29" type="cD" />
+      <Atom charge="0.009595" name="H9R" type="hL" />
+      <Atom charge="0.009595" name="H9S" type="hL" />
+      <Atom charge="-0.026418" name="C210" type="cD" />
+      <Atom charge="0.010825" name="H10R" type="hL" />
+      <Atom charge="0.010825" name="H10S" type="hL" />
+      <Atom charge="-0.017093" name="C211" type="cD" />
+      <Atom charge="0.010206" name="H11R" type="hL" />
+      <Atom charge="0.010206" name="H11S" type="hL" />
+      <Atom charge="-0.019153" name="C212" type="cD" />
+      <Atom charge="0.008198" name="H12R" type="hL" />
+      <Atom charge="0.008198" name="H12S" type="hL" />
+      <Atom charge="-0.01159" name="C213" type="cD" />
+      <Atom charge="0.006022" name="H13R" type="hL" />
+      <Atom charge="0.006022" name="H13S" type="hL" />
+      <Atom charge="-0.013489" name="C214" type="cD" />
+      <Atom charge="0.010073" name="H14R" type="hL" />
+      <Atom charge="0.010073" name="H14S" type="hL" />
+      <Atom charge="-0.032444" name="C215" type="cD" />
+      <Atom charge="0.010253" name="H15R" type="hL" />
+      <Atom charge="0.010253" name="H15S" type="hL" />
+      <Atom charge="-0.027654" name="C216" type="cD" />
+      <Atom charge="0.015627" name="H16R" type="hL" />
+      <Atom charge="0.015627" name="H16S" type="hL" />
+      <Atom charge="0.020665" name="C217" type="cD" />
+      <Atom charge="0.008483" name="H17R" type="hL" />
+      <Atom charge="0.008483" name="H17S" type="hL" />
+      <Atom charge="-0.120069" name="C218" type="cD" />
+      <Atom charge="0.027938" name="H18R" type="hL" />
+      <Atom charge="0.027938" name="H18S" type="hL" />
+      <Atom charge="0.027938" name="H18T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+    </Residue>
+    <Residue name="DOPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.143418" name="C32" type="cD" />
+      <Atom charge="0.042861" name="H2X" type="hL" />
+      <Atom charge="0.042861" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H9R" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H10R" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="0.001619" name="C33" type="cD" />
+      <Atom charge="0.019529" name="H3X" type="hL" />
+      <Atom charge="0.019529" name="H3Y" type="hL" />
+      <Atom charge="-0.02296" name="C34" type="cD" />
+      <Atom charge="0.018134" name="H4X" type="hL" />
+      <Atom charge="0.018134" name="H4Y" type="hL" />
+      <Atom charge="-0.016692" name="C35" type="cD" />
+      <Atom charge="0.00869" name="H5X" type="hL" />
+      <Atom charge="0.00869" name="H5Y" type="hL" />
+      <Atom charge="-0.023789" name="C36" type="cD" />
+      <Atom charge="0.009266" name="H6X" type="hL" />
+      <Atom charge="0.009266" name="H6Y" type="hL" />
+      <Atom charge="-0.017495" name="C37" type="cD" />
+      <Atom charge="0.019598" name="H7X" type="hL" />
+      <Atom charge="0.019598" name="H7Y" type="hL" />
+      <Atom charge="0.031775" name="C38" type="cD" />
+      <Atom charge="0.032685" name="H8X" type="hL" />
+      <Atom charge="0.032685" name="H8Y" type="hL" />
+      <Atom charge="-0.244228" name="C39" type="cB" />
+      <Atom charge="0.131512" name="H9X" type="hB" />
+      <Atom charge="-0.239284" name="C310" type="cB" />
+      <Atom charge="0.126878" name="H10X" type="hB" />
+      <Atom charge="0.029059" name="C311" type="cD" />
+      <Atom charge="0.033531" name="H11X" type="hL" />
+      <Atom charge="0.033531" name="H11Y" type="hL" />
+      <Atom charge="-0.026353" name="C312" type="cD" />
+      <Atom charge="0.019717" name="H12X" type="hL" />
+      <Atom charge="0.019717" name="H12Y" type="hL" />
+      <Atom charge="-0.018257" name="C313" type="cD" />
+      <Atom charge="0.0138" name="H13X" type="hL" />
+      <Atom charge="0.0138" name="H13Y" type="hL" />
+      <Atom charge="-0.024849" name="C314" type="cD" />
+      <Atom charge="0.008572" name="H14X" type="hL" />
+      <Atom charge="0.008572" name="H14Y" type="hL" />
+      <Atom charge="-0.023247" name="C315" type="cD" />
+      <Atom charge="0.010403" name="H15X" type="hL" />
+      <Atom charge="0.010403" name="H15Y" type="hL" />
+      <Atom charge="-0.012488" name="C316" type="cD" />
+      <Atom charge="0.013659" name="H16X" type="hL" />
+      <Atom charge="0.013659" name="H16Y" type="hL" />
+      <Atom charge="0.008684" name="C317" type="cD" />
+      <Atom charge="0.010026" name="H17X" type="hL" />
+      <Atom charge="0.010026" name="H17Y" type="hL" />
+      <Atom charge="-0.11729" name="C318" type="cD" />
+      <Atom charge="0.026627" name="H18X" type="hL" />
+      <Atom charge="0.026627" name="H18Y" type="hL" />
+      <Atom charge="0.026627" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DOPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.143418" name="C32" type="cD" />
+      <Atom charge="0.042861" name="H2X" type="hL" />
+      <Atom charge="0.042861" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H9R" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H10R" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="0.001619" name="C33" type="cD" />
+      <Atom charge="0.019529" name="H3X" type="hL" />
+      <Atom charge="0.019529" name="H3Y" type="hL" />
+      <Atom charge="-0.02296" name="C34" type="cD" />
+      <Atom charge="0.018134" name="H4X" type="hL" />
+      <Atom charge="0.018134" name="H4Y" type="hL" />
+      <Atom charge="-0.016692" name="C35" type="cD" />
+      <Atom charge="0.00869" name="H5X" type="hL" />
+      <Atom charge="0.00869" name="H5Y" type="hL" />
+      <Atom charge="-0.023789" name="C36" type="cD" />
+      <Atom charge="0.009266" name="H6X" type="hL" />
+      <Atom charge="0.009266" name="H6Y" type="hL" />
+      <Atom charge="-0.017495" name="C37" type="cD" />
+      <Atom charge="0.019598" name="H7X" type="hL" />
+      <Atom charge="0.019598" name="H7Y" type="hL" />
+      <Atom charge="0.031775" name="C38" type="cD" />
+      <Atom charge="0.032685" name="H8X" type="hL" />
+      <Atom charge="0.032685" name="H8Y" type="hL" />
+      <Atom charge="-0.244228" name="C39" type="cB" />
+      <Atom charge="0.131512" name="H9X" type="hB" />
+      <Atom charge="-0.239284" name="C310" type="cB" />
+      <Atom charge="0.126878" name="H10X" type="hB" />
+      <Atom charge="0.029059" name="C311" type="cD" />
+      <Atom charge="0.033531" name="H11X" type="hL" />
+      <Atom charge="0.033531" name="H11Y" type="hL" />
+      <Atom charge="-0.026353" name="C312" type="cD" />
+      <Atom charge="0.019717" name="H12X" type="hL" />
+      <Atom charge="0.019717" name="H12Y" type="hL" />
+      <Atom charge="-0.018257" name="C313" type="cD" />
+      <Atom charge="0.0138" name="H13X" type="hL" />
+      <Atom charge="0.0138" name="H13Y" type="hL" />
+      <Atom charge="-0.024849" name="C314" type="cD" />
+      <Atom charge="0.008572" name="H14X" type="hL" />
+      <Atom charge="0.008572" name="H14Y" type="hL" />
+      <Atom charge="-0.023247" name="C315" type="cD" />
+      <Atom charge="0.010403" name="H15X" type="hL" />
+      <Atom charge="0.010403" name="H15Y" type="hL" />
+      <Atom charge="-0.012488" name="C316" type="cD" />
+      <Atom charge="0.013659" name="H16X" type="hL" />
+      <Atom charge="0.013659" name="H16Y" type="hL" />
+      <Atom charge="0.008684" name="C317" type="cD" />
+      <Atom charge="0.010026" name="H17X" type="hL" />
+      <Atom charge="0.010026" name="H17Y" type="hL" />
+      <Atom charge="-0.11729" name="C318" type="cD" />
+      <Atom charge="0.026627" name="H18X" type="hL" />
+      <Atom charge="0.026627" name="H18Y" type="hL" />
+      <Atom charge="0.026627" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DOPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.143418" name="C32" type="cD" />
+      <Atom charge="0.042861" name="H2X" type="hL" />
+      <Atom charge="0.042861" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H9R" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H10R" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="0.001619" name="C33" type="cD" />
+      <Atom charge="0.019529" name="H3X" type="hL" />
+      <Atom charge="0.019529" name="H3Y" type="hL" />
+      <Atom charge="-0.02296" name="C34" type="cD" />
+      <Atom charge="0.018134" name="H4X" type="hL" />
+      <Atom charge="0.018134" name="H4Y" type="hL" />
+      <Atom charge="-0.016692" name="C35" type="cD" />
+      <Atom charge="0.00869" name="H5X" type="hL" />
+      <Atom charge="0.00869" name="H5Y" type="hL" />
+      <Atom charge="-0.023789" name="C36" type="cD" />
+      <Atom charge="0.009266" name="H6X" type="hL" />
+      <Atom charge="0.009266" name="H6Y" type="hL" />
+      <Atom charge="-0.017495" name="C37" type="cD" />
+      <Atom charge="0.019598" name="H7X" type="hL" />
+      <Atom charge="0.019598" name="H7Y" type="hL" />
+      <Atom charge="0.031775" name="C38" type="cD" />
+      <Atom charge="0.032685" name="H8X" type="hL" />
+      <Atom charge="0.032685" name="H8Y" type="hL" />
+      <Atom charge="-0.244228" name="C39" type="cB" />
+      <Atom charge="0.131512" name="H9X" type="hB" />
+      <Atom charge="-0.239284" name="C310" type="cB" />
+      <Atom charge="0.126878" name="H10X" type="hB" />
+      <Atom charge="0.029059" name="C311" type="cD" />
+      <Atom charge="0.033531" name="H11X" type="hL" />
+      <Atom charge="0.033531" name="H11Y" type="hL" />
+      <Atom charge="-0.026353" name="C312" type="cD" />
+      <Atom charge="0.019717" name="H12X" type="hL" />
+      <Atom charge="0.019717" name="H12Y" type="hL" />
+      <Atom charge="-0.018257" name="C313" type="cD" />
+      <Atom charge="0.0138" name="H13X" type="hL" />
+      <Atom charge="0.0138" name="H13Y" type="hL" />
+      <Atom charge="-0.024849" name="C314" type="cD" />
+      <Atom charge="0.008572" name="H14X" type="hL" />
+      <Atom charge="0.008572" name="H14Y" type="hL" />
+      <Atom charge="-0.023247" name="C315" type="cD" />
+      <Atom charge="0.010403" name="H15X" type="hL" />
+      <Atom charge="0.010403" name="H15Y" type="hL" />
+      <Atom charge="-0.012488" name="C316" type="cD" />
+      <Atom charge="0.013659" name="H16X" type="hL" />
+      <Atom charge="0.013659" name="H16Y" type="hL" />
+      <Atom charge="0.008684" name="C317" type="cD" />
+      <Atom charge="0.010026" name="H17X" type="hL" />
+      <Atom charge="0.010026" name="H17Y" type="hL" />
+      <Atom charge="-0.11729" name="C318" type="cD" />
+      <Atom charge="0.026627" name="H18X" type="hL" />
+      <Atom charge="0.026627" name="H18Y" type="hL" />
+      <Atom charge="0.026627" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DOPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.143418" name="C32" type="cD" />
+      <Atom charge="0.042861" name="H2X" type="hL" />
+      <Atom charge="0.042861" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H9R" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H10R" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="0.001619" name="C33" type="cD" />
+      <Atom charge="0.019529" name="H3X" type="hL" />
+      <Atom charge="0.019529" name="H3Y" type="hL" />
+      <Atom charge="-0.02296" name="C34" type="cD" />
+      <Atom charge="0.018134" name="H4X" type="hL" />
+      <Atom charge="0.018134" name="H4Y" type="hL" />
+      <Atom charge="-0.016692" name="C35" type="cD" />
+      <Atom charge="0.00869" name="H5X" type="hL" />
+      <Atom charge="0.00869" name="H5Y" type="hL" />
+      <Atom charge="-0.023789" name="C36" type="cD" />
+      <Atom charge="0.009266" name="H6X" type="hL" />
+      <Atom charge="0.009266" name="H6Y" type="hL" />
+      <Atom charge="-0.017495" name="C37" type="cD" />
+      <Atom charge="0.019598" name="H7X" type="hL" />
+      <Atom charge="0.019598" name="H7Y" type="hL" />
+      <Atom charge="0.031775" name="C38" type="cD" />
+      <Atom charge="0.032685" name="H8X" type="hL" />
+      <Atom charge="0.032685" name="H8Y" type="hL" />
+      <Atom charge="-0.244228" name="C39" type="cB" />
+      <Atom charge="0.131512" name="H9X" type="hB" />
+      <Atom charge="-0.239284" name="C310" type="cB" />
+      <Atom charge="0.126878" name="H10X" type="hB" />
+      <Atom charge="0.029059" name="C311" type="cD" />
+      <Atom charge="0.033531" name="H11X" type="hL" />
+      <Atom charge="0.033531" name="H11Y" type="hL" />
+      <Atom charge="-0.026353" name="C312" type="cD" />
+      <Atom charge="0.019717" name="H12X" type="hL" />
+      <Atom charge="0.019717" name="H12Y" type="hL" />
+      <Atom charge="-0.018257" name="C313" type="cD" />
+      <Atom charge="0.0138" name="H13X" type="hL" />
+      <Atom charge="0.0138" name="H13Y" type="hL" />
+      <Atom charge="-0.024849" name="C314" type="cD" />
+      <Atom charge="0.008572" name="H14X" type="hL" />
+      <Atom charge="0.008572" name="H14Y" type="hL" />
+      <Atom charge="-0.023247" name="C315" type="cD" />
+      <Atom charge="0.010403" name="H15X" type="hL" />
+      <Atom charge="0.010403" name="H15Y" type="hL" />
+      <Atom charge="-0.012488" name="C316" type="cD" />
+      <Atom charge="0.013659" name="H16X" type="hL" />
+      <Atom charge="0.013659" name="H16Y" type="hL" />
+      <Atom charge="0.008684" name="C317" type="cD" />
+      <Atom charge="0.010026" name="H17X" type="hL" />
+      <Atom charge="0.010026" name="H17Y" type="hL" />
+      <Atom charge="-0.11729" name="C318" type="cD" />
+      <Atom charge="0.026627" name="H18X" type="hL" />
+      <Atom charge="0.026627" name="H18Y" type="hL" />
+      <Atom charge="0.026627" name="H18Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+    </Residue>
+    <Residue name="DOPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.143418" name="C32" type="cD" />
+      <Atom charge="0.042861" name="H2X" type="hL" />
+      <Atom charge="0.042861" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H9R" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H10R" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="0.001619" name="C33" type="cD" />
+      <Atom charge="0.019529" name="H3X" type="hL" />
+      <Atom charge="0.019529" name="H3Y" type="hL" />
+      <Atom charge="-0.02296" name="C34" type="cD" />
+      <Atom charge="0.018134" name="H4X" type="hL" />
+      <Atom charge="0.018134" name="H4Y" type="hL" />
+      <Atom charge="-0.016692" name="C35" type="cD" />
+      <Atom charge="0.00869" name="H5X" type="hL" />
+      <Atom charge="0.00869" name="H5Y" type="hL" />
+      <Atom charge="-0.023789" name="C36" type="cD" />
+      <Atom charge="0.009266" name="H6X" type="hL" />
+      <Atom charge="0.009266" name="H6Y" type="hL" />
+      <Atom charge="-0.017495" name="C37" type="cD" />
+      <Atom charge="0.019598" name="H7X" type="hL" />
+      <Atom charge="0.019598" name="H7Y" type="hL" />
+      <Atom charge="0.031775" name="C38" type="cD" />
+      <Atom charge="0.032685" name="H8X" type="hL" />
+      <Atom charge="0.032685" name="H8Y" type="hL" />
+      <Atom charge="-0.244228" name="C39" type="cB" />
+      <Atom charge="0.131512" name="H9X" type="hB" />
+      <Atom charge="-0.239284" name="C310" type="cB" />
+      <Atom charge="0.126878" name="H10X" type="hB" />
+      <Atom charge="0.029059" name="C311" type="cD" />
+      <Atom charge="0.033531" name="H11X" type="hL" />
+      <Atom charge="0.033531" name="H11Y" type="hL" />
+      <Atom charge="-0.026353" name="C312" type="cD" />
+      <Atom charge="0.019717" name="H12X" type="hL" />
+      <Atom charge="0.019717" name="H12Y" type="hL" />
+      <Atom charge="-0.018257" name="C313" type="cD" />
+      <Atom charge="0.0138" name="H13X" type="hL" />
+      <Atom charge="0.0138" name="H13Y" type="hL" />
+      <Atom charge="-0.024849" name="C314" type="cD" />
+      <Atom charge="0.008572" name="H14X" type="hL" />
+      <Atom charge="0.008572" name="H14Y" type="hL" />
+      <Atom charge="-0.023247" name="C315" type="cD" />
+      <Atom charge="0.010403" name="H15X" type="hL" />
+      <Atom charge="0.010403" name="H15Y" type="hL" />
+      <Atom charge="-0.012488" name="C316" type="cD" />
+      <Atom charge="0.013659" name="H16X" type="hL" />
+      <Atom charge="0.013659" name="H16Y" type="hL" />
+      <Atom charge="0.008684" name="C317" type="cD" />
+      <Atom charge="0.010026" name="H17X" type="hL" />
+      <Atom charge="0.010026" name="H17Y" type="hL" />
+      <Atom charge="-0.11729" name="C318" type="cD" />
+      <Atom charge="0.026627" name="H18X" type="hL" />
+      <Atom charge="0.026627" name="H18Y" type="hL" />
+      <Atom charge="0.026627" name="H18Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+    </Residue>
+    <Residue name="POPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H91" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H101" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H91" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H101" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+      </Residue>
+    <Residue name="POPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H91" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H101" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H91" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H101" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+      </Residue>
+    <Residue name="POPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H91" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H101" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H91" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H101" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+      </Residue>
+    <Residue name="POPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H91" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H101" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H91" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H101" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+    </Residue>
+    <Residue name="POPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.143418" name="C22" type="cD" />
+      <Atom charge="0.042861" name="H2R" type="hL" />
+      <Atom charge="0.042861" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.149259" name="C32" type="cD" />
+      <Atom charge="0.047345" name="H2X" type="hL" />
+      <Atom charge="0.047345" name="H2Y" type="hL" />
+      <Atom charge="0.001619" name="C23" type="cD" />
+      <Atom charge="0.019529" name="H3R" type="hL" />
+      <Atom charge="0.019529" name="H3S" type="hL" />
+      <Atom charge="-0.02296" name="C24" type="cD" />
+      <Atom charge="0.018134" name="H4R" type="hL" />
+      <Atom charge="0.018134" name="H4S" type="hL" />
+      <Atom charge="-0.016692" name="C25" type="cD" />
+      <Atom charge="0.00869" name="H5R" type="hL" />
+      <Atom charge="0.00869" name="H5S" type="hL" />
+      <Atom charge="-0.023789" name="C26" type="cD" />
+      <Atom charge="0.009266" name="H6R" type="hL" />
+      <Atom charge="0.009266" name="H6S" type="hL" />
+      <Atom charge="-0.017495" name="C27" type="cD" />
+      <Atom charge="0.019598" name="H7R" type="hL" />
+      <Atom charge="0.019598" name="H7S" type="hL" />
+      <Atom charge="0.031775" name="C28" type="cD" />
+      <Atom charge="0.032685" name="H8R" type="hL" />
+      <Atom charge="0.032685" name="H8S" type="hL" />
+      <Atom charge="-0.244228" name="C29" type="cB" />
+      <Atom charge="0.131512" name="H91" type="hB" />
+      <Atom charge="-0.239284" name="C210" type="cB" />
+      <Atom charge="0.126878" name="H101" type="hB" />
+      <Atom charge="0.029059" name="C211" type="cD" />
+      <Atom charge="0.033531" name="H11R" type="hL" />
+      <Atom charge="0.033531" name="H11S" type="hL" />
+      <Atom charge="-0.026353" name="C212" type="cD" />
+      <Atom charge="0.019717" name="H12R" type="hL" />
+      <Atom charge="0.019717" name="H12S" type="hL" />
+      <Atom charge="-0.018257" name="C213" type="cD" />
+      <Atom charge="0.0138" name="H13R" type="hL" />
+      <Atom charge="0.0138" name="H13S" type="hL" />
+      <Atom charge="-0.024849" name="C214" type="cD" />
+      <Atom charge="0.008572" name="H14R" type="hL" />
+      <Atom charge="0.008572" name="H14S" type="hL" />
+      <Atom charge="-0.023247" name="C215" type="cD" />
+      <Atom charge="0.010403" name="H15R" type="hL" />
+      <Atom charge="0.010403" name="H15S" type="hL" />
+      <Atom charge="-0.012488" name="C216" type="cD" />
+      <Atom charge="0.013659" name="H16R" type="hL" />
+      <Atom charge="0.013659" name="H16S" type="hL" />
+      <Atom charge="0.008684" name="C217" type="cD" />
+      <Atom charge="0.010026" name="H17R" type="hL" />
+      <Atom charge="0.010026" name="H17S" type="hL" />
+      <Atom charge="-0.11729" name="C218" type="cD" />
+      <Atom charge="0.026627" name="H18R" type="hL" />
+      <Atom charge="0.026627" name="H18S" type="hL" />
+      <Atom charge="0.026627" name="H18T" type="hL" />
+      <Atom charge="-0.004882" name="C33" type="cD" />
+      <Atom charge="0.019007" name="H3X" type="hL" />
+      <Atom charge="0.019007" name="H3Y" type="hL" />
+      <Atom charge="-0.030099" name="C34" type="cD" />
+      <Atom charge="0.020877" name="H4X" type="hL" />
+      <Atom charge="0.020877" name="H4Y" type="hL" />
+      <Atom charge="-0.029387" name="C35" type="cD" />
+      <Atom charge="0.016763" name="H5X" type="hL" />
+      <Atom charge="0.016763" name="H5Y" type="hL" />
+      <Atom charge="-0.024427" name="C36" type="cD" />
+      <Atom charge="0.013334" name="H6X" type="hL" />
+      <Atom charge="0.013334" name="H6Y" type="hL" />
+      <Atom charge="-0.01963" name="C37" type="cD" />
+      <Atom charge="0.011041" name="H7X" type="hL" />
+      <Atom charge="0.011041" name="H7Y" type="hL" />
+      <Atom charge="-0.015793" name="C38" type="cD" />
+      <Atom charge="0.009067" name="H8X" type="hL" />
+      <Atom charge="0.009067" name="H8Y" type="hL" />
+      <Atom charge="-0.030472" name="C39" type="cD" />
+      <Atom charge="0.013897" name="H9X" type="hL" />
+      <Atom charge="0.013897" name="H9Y" type="hL" />
+      <Atom charge="-0.028831" name="C310" type="cD" />
+      <Atom charge="0.014691" name="H10X" type="hL" />
+      <Atom charge="0.014691" name="H10Y" type="hL" />
+      <Atom charge="-0.025206" name="C311" type="cD" />
+      <Atom charge="0.014334" name="H11X" type="hL" />
+      <Atom charge="0.014334" name="H11Y" type="hL" />
+      <Atom charge="-0.027633" name="C312" type="cD" />
+      <Atom charge="0.011368" name="H12X" type="hL" />
+      <Atom charge="0.011368" name="H12Y" type="hL" />
+      <Atom charge="-0.033096" name="C313" type="cD" />
+      <Atom charge="0.014621" name="H13X" type="hL" />
+      <Atom charge="0.014621" name="H13Y" type="hL" />
+      <Atom charge="-0.020086" name="C314" type="cD" />
+      <Atom charge="0.015929" name="H14X" type="hL" />
+      <Atom charge="0.015929" name="H14Y" type="hL" />
+      <Atom charge="0.013975" name="C315" type="cD" />
+      <Atom charge="0.009292" name="H15X" type="hL" />
+      <Atom charge="0.009292" name="H15Y" type="hL" />
+      <Atom charge="-0.125447" name="C316" type="cD" />
+      <Atom charge="0.029047" name="H16X" type="hL" />
+      <Atom charge="0.029047" name="H16Y" type="hL" />
+      <Atom charge="0.029047" name="H16Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="H5S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="H8S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H91" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H101" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="H11S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="H14S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="H18T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="H16Z" />
+    </Residue>
+    <Residue name="SDPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.142937" name="C22" type="cD" />
+      <Atom charge="0.037544" name="H2R" type="hL" />
+      <Atom charge="0.037544" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="0.120999" name="C23" type="cD" />
+      <Atom charge="0.026097" name="H3R" type="hL" />
+      <Atom charge="0.026097" name="H3S" type="hL" />
+      <Atom charge="-0.287059" name="C24" type="cB" />
+      <Atom charge="0.154038" name="H4R" type="hB" />
+      <Atom charge="-0.214845" name="C25" type="cB" />
+      <Atom charge="0.132504" name="H5R" type="hB" />
+      <Atom charge="0.060337" name="C26" type="cD" />
+      <Atom charge="0.063515" name="H6R" type="hL" />
+      <Atom charge="0.063515" name="H6S" type="hL" />
+      <Atom charge="-0.220895" name="C27" type="cB" />
+      <Atom charge="0.139863" name="H7R" type="hB" />
+      <Atom charge="-0.226254" name="C28" type="cB" />
+      <Atom charge="0.128147" name="H8R" type="hB" />
+      <Atom charge="0.089043" name="C29" type="cD" />
+      <Atom charge="0.054255" name="H9R" type="hL" />
+      <Atom charge="0.054255" name="H9S" type="hL" />
+      <Atom charge="-0.221433" name="C210" type="cB" />
+      <Atom charge="0.133628" name="H10R" type="hB" />
+      <Atom charge="-0.241205" name="C211" type="cB" />
+      <Atom charge="0.136308" name="H11R" type="hB" />
+      <Atom charge="0.085245" name="C212" type="cD" />
+      <Atom charge="0.053422" name="H12R" type="hL" />
+      <Atom charge="0.053422" name="H12S" type="hL" />
+      <Atom charge="-0.218668" name="C213" type="cB" />
+      <Atom charge="0.131575" name="H13R" type="hB" />
+      <Atom charge="-0.240419" name="C214" type="cB" />
+      <Atom charge="0.138337" name="H14R" type="hB" />
+      <Atom charge="0.069215" name="C215" type="cD" />
+      <Atom charge="0.058341" name="H15R" type="hL" />
+      <Atom charge="0.058341" name="H15S" type="hL" />
+      <Atom charge="-0.233897" name="C216" type="cB" />
+      <Atom charge="0.133812" name="H16R" type="hB" />
+      <Atom charge="-0.216499" name="C217" type="cB" />
+      <Atom charge="0.132121" name="H17R" type="hB" />
+      <Atom charge="0.092718" name="C218" type="cD" />
+      <Atom charge="0.053227" name="H18R" type="hL" />
+      <Atom charge="0.053227" name="H18S" type="hL" />
+      <Atom charge="-0.246833" name="C219" type="cB" />
+      <Atom charge="0.136323" name="H19R" type="hB" />
+      <Atom charge="-0.240216" name="C220" type="cB" />
+      <Atom charge="0.133048" name="H20R" type="hB" />
+      <Atom charge="0.122022" name="C221" type="cD" />
+      <Atom charge="0.010042" name="H21R" type="hL" />
+      <Atom charge="0.010042" name="H21S" type="hL" />
+      <Atom charge="-0.108913" name="C222" type="cD" />
+      <Atom charge="0.025968" name="H22R" type="hL" />
+      <Atom charge="0.025968" name="H22S" type="hL" />
+      <Atom charge="0.025968" name="H22T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="C221" />
+      <Bond atomName1="C221" atomName2="H21R" />
+      <Bond atomName1="C221" atomName2="H21S" />
+      <Bond atomName1="C221" atomName2="C222" />
+      <Bond atomName1="C222" atomName2="H22R" />
+      <Bond atomName1="C222" atomName2="H22S" />
+      <Bond atomName1="C222" atomName2="H22T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DAPC">
+      <Atom charge="0.245262" name="N" type="nA" />
+      <Atom charge="-0.170824" name="C12" type="cA" />
+      <Atom charge="0.136415" name="H12A" type="hX" />
+      <Atom charge="0.136415" name="H12B" type="hX" />
+      <Atom charge="-0.338973" name="C13" type="cA" />
+      <Atom charge="0.17223" name="H13A" type="hX" />
+      <Atom charge="0.17223" name="H13B" type="hX" />
+      <Atom charge="0.17223" name="H13C" type="hX" />
+      <Atom charge="-0.338973" name="C14" type="cA" />
+      <Atom charge="0.17223" name="H14A" type="hX" />
+      <Atom charge="0.17223" name="H14B" type="hX" />
+      <Atom charge="0.17223" name="H14C" type="hX" />
+      <Atom charge="-0.338973" name="C15" type="cA" />
+      <Atom charge="0.17223" name="H15A" type="hX" />
+      <Atom charge="0.17223" name="H15B" type="hX" />
+      <Atom charge="0.17223" name="H15C" type="hX" />
+      <Atom charge="0.166801" name="C11" type="cA" />
+      <Atom charge="0.078534" name="H11A" type="hE" />
+      <Atom charge="0.078534" name="H11B" type="hE" />
+      <Atom charge="1.339721" name="P" type="pA" />
+      <Atom charge="-0.875812" name="O13" type="oP" />
+      <Atom charge="-0.875812" name="O14" type="oP" />
+      <Atom charge="-0.508176" name="O12" type="oT" />
+      <Atom charge="-0.50948" name="O11" type="oT" />
+      <Atom charge="0.017459" name="C1" type="cA" />
+      <Atom charge="0.095591" name="HA" type="hE" />
+      <Atom charge="0.095591" name="HB" type="hE" />
+      <Atom charge="0.281242" name="C2" type="cA" />
+      <Atom charge="0.063253" name="HS" type="hE" />
+      <Atom charge="-0.552948" name="O21" type="oS" />
+      <Atom charge="0.897613" name="C21" type="cC" />
+      <Atom charge="-0.673755" name="O22" type="oC" />
+      <Atom charge="-0.123935" name="C22" type="cD" />
+      <Atom charge="0.024535" name="H2R" type="hL" />
+      <Atom charge="0.024535" name="H2S" type="hL" />
+      <Atom charge="0.196939" name="C3" type="cA" />
+      <Atom charge="0.070469" name="HX" type="hE" />
+      <Atom charge="0.070469" name="HY" type="hE" />
+      <Atom charge="-0.575489" name="O31" type="oS" />
+      <Atom charge="0.910403" name="C31" type="cC" />
+      <Atom charge="-0.671566" name="O32" type="oC" />
+      <Atom charge="-0.123935" name="C32" type="cD" />
+      <Atom charge="0.024535" name="H2X" type="hL" />
+      <Atom charge="0.024535" name="H2Y" type="hL" />
+      <Atom charge="0.025626" name="C23" type="cD" />
+      <Atom charge="0.025117" name="H3R" type="hL" />
+      <Atom charge="0.025117" name="H3S" type="hL" />
+      <Atom charge="0.031382" name="C24" type="cD" />
+      <Atom charge="0.038708" name="H4R" type="hL" />
+      <Atom charge="0.038708" name="H4S" type="hL" />
+      <Atom charge="-0.26789" name="C25" type="cB" />
+      <Atom charge="0.143577" name="H5R" type="hB" />
+      <Atom charge="-0.206786" name="C26" type="cB" />
+      <Atom charge="0.129858" name="H6R" type="hB" />
+      <Atom charge="0.055784" name="C27" type="cD" />
+      <Atom charge="0.062775" name="H7R" type="hL" />
+      <Atom charge="0.062775" name="H7S" type="hL" />
+      <Atom charge="-0.228527" name="C28" type="cB" />
+      <Atom charge="0.134735" name="H8R" type="hB" />
+      <Atom charge="-0.228694" name="C29" type="cB" />
+      <Atom charge="0.132167" name="H9R" type="hB" />
+      <Atom charge="0.095406" name="C210" type="cD" />
+      <Atom charge="0.05114" name="H10R" type="hL" />
+      <Atom charge="0.05114" name="H10S" type="hL" />
+      <Atom charge="-0.228704" name="C211" type="cB" />
+      <Atom charge="0.131341" name="H11R" type="hB" />
+      <Atom charge="-0.220164" name="C212" type="cB" />
+      <Atom charge="0.131986" name="H12R" type="hB" />
+      <Atom charge="0.058197" name="C213" type="cD" />
+      <Atom charge="0.06135" name="H13R" type="hL" />
+      <Atom charge="0.06135" name="H13S" type="hL" />
+      <Atom charge="-0.224769" name="C214" type="cB" />
+      <Atom charge="0.129616" name="H14R" type="hB" />
+      <Atom charge="-0.244149" name="C215" type="cB" />
+      <Atom charge="0.132793" name="H15R" type="hB" />
+      <Atom charge="0.0391" name="C216" type="cD" />
+      <Atom charge="0.028848" name="H16R" type="hL" />
+      <Atom charge="0.028848" name="H16S" type="hL" />
+      <Atom charge="-0.028398" name="C217" type="cD" />
+      <Atom charge="0.019581" name="H17R" type="hL" />
+      <Atom charge="0.019581" name="H17S" type="hL" />
+      <Atom charge="-0.019772" name="C218" type="cD" />
+      <Atom charge="0.014218" name="H18R" type="hL" />
+      <Atom charge="0.014218" name="H18S" type="hL" />
+      <Atom charge="0.024957" name="C219" type="cD" />
+      <Atom charge="0.005426" name="H19R" type="hL" />
+      <Atom charge="0.005426" name="H19S" type="hL" />
+      <Atom charge="-0.109302" name="C220" type="cD" />
+      <Atom charge="0.023723" name="H20R" type="hL" />
+      <Atom charge="0.023723" name="H20S" type="hL" />
+      <Atom charge="0.023723" name="H20T" type="hL" />
+      <Atom charge="0.025626" name="C33" type="cD" />
+      <Atom charge="0.025117" name="H3X" type="hL" />
+      <Atom charge="0.025117" name="H3Y" type="hL" />
+      <Atom charge="0.031382" name="C34" type="cD" />
+      <Atom charge="0.038708" name="H4X" type="hL" />
+      <Atom charge="0.038708" name="H4Y" type="hL" />
+      <Atom charge="-0.26789" name="C35" type="cB" />
+      <Atom charge="0.143577" name="H5X" type="hB" />
+      <Atom charge="-0.206786" name="C36" type="cB" />
+      <Atom charge="0.129858" name="H6X" type="hB" />
+      <Atom charge="0.055784" name="C37" type="cD" />
+      <Atom charge="0.062775" name="H7X" type="hL" />
+      <Atom charge="0.062775" name="H7Y" type="hL" />
+      <Atom charge="-0.228527" name="C38" type="cB" />
+      <Atom charge="0.134735" name="H8X" type="hB" />
+      <Atom charge="-0.228694" name="C39" type="cB" />
+      <Atom charge="0.132167" name="H9X" type="hB" />
+      <Atom charge="0.095406" name="C310" type="cD" />
+      <Atom charge="0.05114" name="H10X" type="hL" />
+      <Atom charge="0.05114" name="H10Y" type="hL" />
+      <Atom charge="-0.228704" name="C311" type="cB" />
+      <Atom charge="0.131341" name="H11X" type="hB" />
+      <Atom charge="-0.220164" name="C312" type="cB" />
+      <Atom charge="0.131986" name="H12X" type="hB" />
+      <Atom charge="0.058197" name="C313" type="cD" />
+      <Atom charge="0.06135" name="H13X" type="hL" />
+      <Atom charge="0.06135" name="H13Y" type="hL" />
+      <Atom charge="-0.224769" name="C314" type="cB" />
+      <Atom charge="0.129616" name="H14X" type="hB" />
+      <Atom charge="-0.244149" name="C315" type="cB" />
+      <Atom charge="0.132793" name="H15X" type="hB" />
+      <Atom charge="0.0391" name="C316" type="cD" />
+      <Atom charge="0.028848" name="H16X" type="hL" />
+      <Atom charge="0.028848" name="H16Y" type="hL" />
+      <Atom charge="-0.028398" name="C317" type="cD" />
+      <Atom charge="0.019581" name="H17X" type="hL" />
+      <Atom charge="0.019581" name="H17Y" type="hL" />
+      <Atom charge="-0.019772" name="C318" type="cD" />
+      <Atom charge="0.014218" name="H18X" type="hL" />
+      <Atom charge="0.014218" name="H18Y" type="hL" />
+      <Atom charge="0.024957" name="C319" type="cD" />
+      <Atom charge="0.005426" name="H19X" type="hL" />
+      <Atom charge="0.005426" name="H19Y" type="hL" />
+      <Atom charge="-0.109302" name="C320" type="cD" />
+      <Atom charge="0.023723" name="H20X" type="hL" />
+      <Atom charge="0.023723" name="H20Y" type="hL" />
+      <Atom charge="0.023723" name="H20Z" type="hL" />
+      <Bond atomName1="N" atomName2="C13" />
+      <Bond atomName1="N" atomName2="C14" />
+      <Bond atomName1="N" atomName2="C15" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="H13C" />
+      <Bond atomName1="C14" atomName2="H14A" />
+      <Bond atomName1="C14" atomName2="H14B" />
+      <Bond atomName1="C14" atomName2="H14C" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="H15C" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="C21" atomName2="O21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="H19S" />
+      <Bond atomName1="C220" atomName2="H20T" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="H20S" />
+      <Bond atomName1="C31" atomName2="O31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C318" atomName2="C319" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C319" atomName2="C320" />
+      <Bond atomName1="C319" atomName2="H19X" />
+      <Bond atomName1="C319" atomName2="H19Y" />
+      <Bond atomName1="C320" atomName2="H20Z" />
+      <Bond atomName1="C320" atomName2="H20X" />
+      <Bond atomName1="C320" atomName2="H20Y" />
+      </Residue>
+    <Residue name="CHL1">
+      <Atom charge="0.400362" name="C3" type="cA" />
+      <Atom charge="-0.00851" name="H3" type="hE" />
+      <Atom charge="-0.766581" name="O3" type="oH" />
+      <Atom charge="0.44297" name="H3'" type="hO" />
+      <Atom charge="-0.237134" name="C4" type="cA" />
+      <Atom charge="0.100619" name="H4A" type="hA" />
+      <Atom charge="0.100619" name="H4B" type="hA" />
+      <Atom charge="-0.257515" name="C5" type="cB" />
+      <Atom charge="-0.24373" name="C6" type="cB" />
+      <Atom charge="0.148607" name="H6" type="hB" />
+      <Atom charge="-0.075453" name="C7" type="cA" />
+      <Atom charge="0.051297" name="H7A" type="hA" />
+      <Atom charge="0.051297" name="H7B" type="hA" />
+      <Atom charge="0.017835" name="C8" type="cA" />
+      <Atom charge="0.02812" name="H8" type="hA" />
+      <Atom charge="0.013753" name="C14" type="cA" />
+      <Atom charge="0.004469" name="H14" type="hA" />
+      <Atom charge="-0.185047" name="C15" type="cA" />
+      <Atom charge="0.041228" name="H15A" type="hA" />
+      <Atom charge="0.041228" name="H15B" type="hA" />
+      <Atom charge="-0.082919" name="C16" type="cA" />
+      <Atom charge="0.027639" name="H16A" type="hA" />
+      <Atom charge="0.027639" name="H16B" type="hA" />
+      <Atom charge="-0.051767" name="C17" type="cA" />
+      <Atom charge="-0.030436" name="H17" type="hA" />
+      <Atom charge="0.583692" name="C13" type="cA" />
+      <Atom charge="-0.536004" name="C18" type="cA" />
+      <Atom charge="0.103623" name="H18A" type="hA" />
+      <Atom charge="0.103623" name="H18B" type="hA" />
+      <Atom charge="0.103623" name="H18C" type="hA" />
+      <Atom charge="-0.158054" name="C12" type="cA" />
+      <Atom charge="0.007687" name="H12A" type="hA" />
+      <Atom charge="0.007687" name="H12B" type="hA" />
+      <Atom charge="-0.127715" name="C11" type="cA" />
+      <Atom charge="0.040257" name="H11A" type="hA" />
+      <Atom charge="0.040257" name="H11B" type="hA" />
+      <Atom charge="-0.029839" name="C9" type="cA" />
+      <Atom charge="-0.003361" name="H9" type="hA" />
+      <Atom charge="0.54647" name="C10" type="cA" />
+      <Atom charge="-0.352218" name="C19" type="cA" />
+      <Atom charge="0.072469" name="H19A" type="hA" />
+      <Atom charge="0.072469" name="H19B" type="hA" />
+      <Atom charge="0.072469" name="H19C" type="hA" />
+      <Atom charge="-0.247736" name="C1" type="cA" />
+      <Atom charge="0.048772" name="H1A" type="hA" />
+      <Atom charge="0.048772" name="H1B" type="hA" />
+      <Atom charge="-0.061498" name="C2" type="cA" />
+      <Atom charge="0.048128" name="H2A" type="hA" />
+      <Atom charge="0.048128" name="H2B" type="hA" />
+      <Atom charge="0.178752" name="C20" type="cD" />
+      <Atom charge="-0.016015" name="H20" type="hL" />
+      <Atom charge="-0.427968" name="C21" type="cD" />
+      <Atom charge="0.099219" name="H21A" type="hL" />
+      <Atom charge="0.099219" name="H21B" type="hL" />
+      <Atom charge="0.099219" name="H21C" type="hL" />
+      <Atom charge="-0.050256" name="C22" type="cD" />
+      <Atom charge="0.009445" name="H22A" type="hL" />
+      <Atom charge="0.009445" name="H22B" type="hL" />
+      <Atom charge="0.078665" name="C23" type="cD" />
+      <Atom charge="-0.007957" name="H23A" type="hL" />
+      <Atom charge="-0.007957" name="H23B" type="hL" />
+      <Atom charge="-0.282133" name="C24" type="cD" />
+      <Atom charge="0.062972" name="H24A" type="hL" />
+      <Atom charge="0.062972" name="H24B" type="hL" />
+      <Atom charge="0.450601" name="C25" type="cD" />
+      <Atom charge="-0.049128" name="H25" type="hL" />
+      <Atom charge="-0.4493" name="C26" type="cD" />
+      <Atom charge="0.099869" name="H26A" type="hL" />
+      <Atom charge="0.099869" name="H26B" type="hL" />
+      <Atom charge="0.099869" name="H26C" type="hL" />
+      <Atom charge="-0.4493" name="C27" type="cD" />
+      <Atom charge="0.099869" name="H27A" type="hL" />
+      <Atom charge="0.099869" name="H27B" type="hL" />
+      <Atom charge="0.099869" name="H27C" type="hL" />
+      <Bond atomName1="C3" atomName2="O3" />
+      <Bond atomName1="C3" atomName2="H3" />
+      <Bond atomName1="O3" atomName2="H3'" />
+      <Bond atomName1="C3" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="H2A" />
+      <Bond atomName1="C2" atomName2="H2B" />
+      <Bond atomName1="C2" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="H1A" />
+      <Bond atomName1="C1" atomName2="H1B" />
+      <Bond atomName1="C3" atomName2="C4" />
+      <Bond atomName1="C4" atomName2="H4A" />
+      <Bond atomName1="C4" atomName2="H4B" />
+      <Bond atomName1="C4" atomName2="C5" />
+      <Bond atomName1="C5" atomName2="C10" />
+      <Bond atomName1="C10" atomName2="C1" />
+      <Bond atomName1="C10" atomName2="C19" />
+      <Bond atomName1="C19" atomName2="H19A" />
+      <Bond atomName1="C19" atomName2="H19B" />
+      <Bond atomName1="C19" atomName2="H19C" />
+      <Bond atomName1="C5" atomName2="C6" />
+      <Bond atomName1="C6" atomName2="H6" />
+      <Bond atomName1="C6" atomName2="C7" />
+      <Bond atomName1="C7" atomName2="H7A" />
+      <Bond atomName1="C7" atomName2="H7B" />
+      <Bond atomName1="C7" atomName2="C8" />
+      <Bond atomName1="C8" atomName2="H8" />
+      <Bond atomName1="C8" atomName2="C9" />
+      <Bond atomName1="C9" atomName2="H9" />
+      <Bond atomName1="C9" atomName2="C10" />
+      <Bond atomName1="C8" atomName2="C14" />
+      <Bond atomName1="C14" atomName2="H14" />
+      <Bond atomName1="C14" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="C9" />
+      <Bond atomName1="C13" atomName2="C18" />
+      <Bond atomName1="C18" atomName2="H18A" />
+      <Bond atomName1="C18" atomName2="H18B" />
+      <Bond atomName1="C18" atomName2="H18C" />
+      <Bond atomName1="C14" atomName2="C15" />
+      <Bond atomName1="C15" atomName2="H15A" />
+      <Bond atomName1="C15" atomName2="H15B" />
+      <Bond atomName1="C15" atomName2="C16" />
+      <Bond atomName1="C16" atomName2="H16A" />
+      <Bond atomName1="C16" atomName2="H16B" />
+      <Bond atomName1="C16" atomName2="C17" />
+      <Bond atomName1="C17" atomName2="H17" />
+      <Bond atomName1="C17" atomName2="C13" />
+      <Bond atomName1="C17" atomName2="C20" />
+      <Bond atomName1="C20" atomName2="H20" />
+      <Bond atomName1="C20" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="H21A" />
+      <Bond atomName1="C21" atomName2="H21B" />
+      <Bond atomName1="C21" atomName2="H21C" />
+      <Bond atomName1="C20" atomName2="C22" />
+      <Bond atomName1="C22" atomName2="H22A" />
+      <Bond atomName1="C22" atomName2="H22B" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H23A" />
+      <Bond atomName1="C23" atomName2="H23B" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H24A" />
+      <Bond atomName1="C24" atomName2="H24B" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H25" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H26A" />
+      <Bond atomName1="C26" atomName2="H26B" />
+      <Bond atomName1="C26" atomName2="H26C" />
+      <Bond atomName1="C25" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H27A" />
+      <Bond atomName1="C27" atomName2="H27B" />
+      <Bond atomName1="C27" atomName2="H27C" />
+      </Residue>
+    <Residue name="SDPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.142937" name="C22" type="cD" />
+      <Atom charge="0.037544" name="H2R" type="hL" />
+      <Atom charge="0.037544" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="0.120999" name="C23" type="cD" />
+      <Atom charge="0.026097" name="H3R" type="hL" />
+      <Atom charge="0.026097" name="H3S" type="hL" />
+      <Atom charge="-0.287059" name="C24" type="cB" />
+      <Atom charge="0.154038" name="H4R" type="hB" />
+      <Atom charge="-0.214845" name="C25" type="cB" />
+      <Atom charge="0.132504" name="H5R" type="hB" />
+      <Atom charge="0.060337" name="C26" type="cD" />
+      <Atom charge="0.063515" name="H6R" type="hL" />
+      <Atom charge="0.063515" name="H6S" type="hL" />
+      <Atom charge="-0.220895" name="C27" type="cB" />
+      <Atom charge="0.139863" name="H7R" type="hB" />
+      <Atom charge="-0.226254" name="C28" type="cB" />
+      <Atom charge="0.128147" name="H8R" type="hB" />
+      <Atom charge="0.089043" name="C29" type="cD" />
+      <Atom charge="0.054255" name="H9R" type="hL" />
+      <Atom charge="0.054255" name="H9S" type="hL" />
+      <Atom charge="-0.221433" name="C210" type="cB" />
+      <Atom charge="0.133628" name="H10R" type="hB" />
+      <Atom charge="-0.241205" name="C211" type="cB" />
+      <Atom charge="0.136308" name="H11R" type="hB" />
+      <Atom charge="0.085245" name="C212" type="cD" />
+      <Atom charge="0.053422" name="H12R" type="hL" />
+      <Atom charge="0.053422" name="H12S" type="hL" />
+      <Atom charge="-0.218668" name="C213" type="cB" />
+      <Atom charge="0.131575" name="H13R" type="hB" />
+      <Atom charge="-0.240419" name="C214" type="cB" />
+      <Atom charge="0.138337" name="H14R" type="hB" />
+      <Atom charge="0.069215" name="C215" type="cD" />
+      <Atom charge="0.058341" name="H15R" type="hL" />
+      <Atom charge="0.058341" name="H15S" type="hL" />
+      <Atom charge="-0.233897" name="C216" type="cB" />
+      <Atom charge="0.133812" name="H16R" type="hB" />
+      <Atom charge="-0.216499" name="C217" type="cB" />
+      <Atom charge="0.132121" name="H17R" type="hB" />
+      <Atom charge="0.092718" name="C218" type="cD" />
+      <Atom charge="0.053227" name="H18R" type="hL" />
+      <Atom charge="0.053227" name="H18S" type="hL" />
+      <Atom charge="-0.246833" name="C219" type="cB" />
+      <Atom charge="0.136323" name="H19R" type="hB" />
+      <Atom charge="-0.240216" name="C220" type="cB" />
+      <Atom charge="0.133048" name="H20R" type="hB" />
+      <Atom charge="0.122022" name="C221" type="cD" />
+      <Atom charge="0.010042" name="H21R" type="hL" />
+      <Atom charge="0.010042" name="H21S" type="hL" />
+      <Atom charge="-0.108913" name="C222" type="cD" />
+      <Atom charge="0.025968" name="H22R" type="hL" />
+      <Atom charge="0.025968" name="H22S" type="hL" />
+      <Atom charge="0.025968" name="H22T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="C221" />
+      <Bond atomName1="C221" atomName2="H21R" />
+      <Bond atomName1="C221" atomName2="H21S" />
+      <Bond atomName1="C221" atomName2="C222" />
+      <Bond atomName1="C222" atomName2="H22R" />
+      <Bond atomName1="C222" atomName2="H22S" />
+      <Bond atomName1="C222" atomName2="H22T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DAPE">
+      <Atom charge="-0.368132" name="N" type="nA" />
+      <Atom charge="0.348549" name="HN1" type="hN" />
+      <Atom charge="0.348549" name="HN2" type="hN" />
+      <Atom charge="0.348549" name="HN3" type="hN" />
+      <Atom charge="0.077319" name="C12" type="cA" />
+      <Atom charge="0.09163" name="H12A" type="hX" />
+      <Atom charge="0.09163" name="H12B" type="hX" />
+      <Atom charge="0.075159" name="C11" type="cA" />
+      <Atom charge="0.091516" name="H11A" type="hE" />
+      <Atom charge="0.091516" name="H11B" type="hE" />
+      <Atom charge="1.373656" name="P" type="pA" />
+      <Atom charge="-0.877447" name="O13" type="oP" />
+      <Atom charge="-0.877447" name="O14" type="oP" />
+      <Atom charge="-0.514542" name="O12" type="oT" />
+      <Atom charge="-0.546623" name="O11" type="oT" />
+      <Atom charge="0.040967" name="C1" type="cA" />
+      <Atom charge="0.090994" name="HA" type="hE" />
+      <Atom charge="0.090994" name="HB" type="hE" />
+      <Atom charge="0.339004" name="C2" type="cA" />
+      <Atom charge="0.032843" name="HS" type="hE" />
+      <Atom charge="-0.57548" name="O21" type="oS" />
+      <Atom charge="0.86934" name="C21" type="cC" />
+      <Atom charge="-0.649199" name="O22" type="oC" />
+      <Atom charge="-0.123935" name="C22" type="cD" />
+      <Atom charge="0.024535" name="H2R" type="hL" />
+      <Atom charge="0.024535" name="H2S" type="hL" />
+      <Atom charge="0.273776" name="C3" type="cA" />
+      <Atom charge="0.044574" name="HX" type="hE" />
+      <Atom charge="0.044574" name="HY" type="hE" />
+      <Atom charge="-0.593826" name="O31" type="oS" />
+      <Atom charge="0.888359" name="C31" type="cC" />
+      <Atom charge="-0.650802" name="O32" type="oC" />
+      <Atom charge="-0.123935" name="C32" type="cD" />
+      <Atom charge="0.024535" name="H2X" type="hL" />
+      <Atom charge="0.024535" name="H2Y" type="hL" />
+      <Atom charge="0.025626" name="C23" type="cD" />
+      <Atom charge="0.025117" name="H3R" type="hL" />
+      <Atom charge="0.025117" name="H3S" type="hL" />
+      <Atom charge="0.031382" name="C24" type="cD" />
+      <Atom charge="0.038708" name="H4R" type="hL" />
+      <Atom charge="0.038708" name="H4S" type="hL" />
+      <Atom charge="-0.26789" name="C25" type="cB" />
+      <Atom charge="0.143577" name="H5R" type="hB" />
+      <Atom charge="-0.206786" name="C26" type="cB" />
+      <Atom charge="0.129858" name="H6R" type="hB" />
+      <Atom charge="0.055784" name="C27" type="cD" />
+      <Atom charge="0.062775" name="H7R" type="hL" />
+      <Atom charge="0.062775" name="H7S" type="hL" />
+      <Atom charge="-0.228527" name="C28" type="cB" />
+      <Atom charge="0.134735" name="H8R" type="hB" />
+      <Atom charge="-0.228694" name="C29" type="cB" />
+      <Atom charge="0.132167" name="H9R" type="hB" />
+      <Atom charge="0.095406" name="C210" type="cD" />
+      <Atom charge="0.05114" name="H10R" type="hL" />
+      <Atom charge="0.05114" name="H10S" type="hL" />
+      <Atom charge="-0.228704" name="C211" type="cB" />
+      <Atom charge="0.131341" name="H11R" type="hB" />
+      <Atom charge="-0.220164" name="C212" type="cB" />
+      <Atom charge="0.131986" name="H12R" type="hB" />
+      <Atom charge="0.058197" name="C213" type="cD" />
+      <Atom charge="0.06135" name="H13R" type="hL" />
+      <Atom charge="0.06135" name="H13S" type="hL" />
+      <Atom charge="-0.224769" name="C214" type="cB" />
+      <Atom charge="0.129616" name="H14R" type="hB" />
+      <Atom charge="-0.244149" name="C215" type="cB" />
+      <Atom charge="0.132793" name="H15R" type="hB" />
+      <Atom charge="0.0391" name="C216" type="cD" />
+      <Atom charge="0.028848" name="H16R" type="hL" />
+      <Atom charge="0.028848" name="H16S" type="hL" />
+      <Atom charge="-0.028398" name="C217" type="cD" />
+      <Atom charge="0.019581" name="H17R" type="hL" />
+      <Atom charge="0.019581" name="H17S" type="hL" />
+      <Atom charge="-0.019772" name="C218" type="cD" />
+      <Atom charge="0.014218" name="H18R" type="hL" />
+      <Atom charge="0.014218" name="H18S" type="hL" />
+      <Atom charge="0.024957" name="C219" type="cD" />
+      <Atom charge="0.005426" name="H19R" type="hL" />
+      <Atom charge="0.005426" name="H19S" type="hL" />
+      <Atom charge="-0.109302" name="C220" type="cD" />
+      <Atom charge="0.023723" name="H20R" type="hL" />
+      <Atom charge="0.023723" name="H20S" type="hL" />
+      <Atom charge="0.023723" name="H20T" type="hL" />
+      <Atom charge="0.025626" name="C33" type="cD" />
+      <Atom charge="0.025117" name="H3X" type="hL" />
+      <Atom charge="0.025117" name="H3Y" type="hL" />
+      <Atom charge="0.031382" name="C34" type="cD" />
+      <Atom charge="0.038708" name="H4X" type="hL" />
+      <Atom charge="0.038708" name="H4Y" type="hL" />
+      <Atom charge="-0.26789" name="C35" type="cB" />
+      <Atom charge="0.143577" name="H5X" type="hB" />
+      <Atom charge="-0.206786" name="C36" type="cB" />
+      <Atom charge="0.129858" name="H6X" type="hB" />
+      <Atom charge="0.055784" name="C37" type="cD" />
+      <Atom charge="0.062775" name="H7X" type="hL" />
+      <Atom charge="0.062775" name="H7Y" type="hL" />
+      <Atom charge="-0.228527" name="C38" type="cB" />
+      <Atom charge="0.134735" name="H8X" type="hB" />
+      <Atom charge="-0.228694" name="C39" type="cB" />
+      <Atom charge="0.132167" name="H9X" type="hB" />
+      <Atom charge="0.095406" name="C310" type="cD" />
+      <Atom charge="0.05114" name="H10X" type="hL" />
+      <Atom charge="0.05114" name="H10Y" type="hL" />
+      <Atom charge="-0.228704" name="C311" type="cB" />
+      <Atom charge="0.131341" name="H11X" type="hB" />
+      <Atom charge="-0.220164" name="C312" type="cB" />
+      <Atom charge="0.131986" name="H12X" type="hB" />
+      <Atom charge="0.058197" name="C313" type="cD" />
+      <Atom charge="0.06135" name="H13X" type="hL" />
+      <Atom charge="0.06135" name="H13Y" type="hL" />
+      <Atom charge="-0.224769" name="C314" type="cB" />
+      <Atom charge="0.129616" name="H14X" type="hB" />
+      <Atom charge="-0.244149" name="C315" type="cB" />
+      <Atom charge="0.132793" name="H15X" type="hB" />
+      <Atom charge="0.0391" name="C316" type="cD" />
+      <Atom charge="0.028848" name="H16X" type="hL" />
+      <Atom charge="0.028848" name="H16Y" type="hL" />
+      <Atom charge="-0.028398" name="C317" type="cD" />
+      <Atom charge="0.019581" name="H17X" type="hL" />
+      <Atom charge="0.019581" name="H17Y" type="hL" />
+      <Atom charge="-0.019772" name="C318" type="cD" />
+      <Atom charge="0.014218" name="H18X" type="hL" />
+      <Atom charge="0.014218" name="H18Y" type="hL" />
+      <Atom charge="0.024957" name="C319" type="cD" />
+      <Atom charge="0.005426" name="H19X" type="hL" />
+      <Atom charge="0.005426" name="H19Y" type="hL" />
+      <Atom charge="-0.109302" name="C320" type="cD" />
+      <Atom charge="0.023723" name="H20X" type="hL" />
+      <Atom charge="0.023723" name="H20Y" type="hL" />
+      <Atom charge="0.023723" name="H20Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="H12B" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="C21" atomName2="O21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="H19S" />
+      <Bond atomName1="C220" atomName2="H20T" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="H20S" />
+      <Bond atomName1="C31" atomName2="O31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C318" atomName2="C319" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C319" atomName2="C320" />
+      <Bond atomName1="C319" atomName2="H19X" />
+      <Bond atomName1="C319" atomName2="H19Y" />
+      <Bond atomName1="C320" atomName2="H20Z" />
+      <Bond atomName1="C320" atomName2="H20X" />
+      <Bond atomName1="C320" atomName2="H20Y" />
+      </Residue>
+    <Residue name="SDPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.142937" name="C22" type="cD" />
+      <Atom charge="0.037544" name="H2R" type="hL" />
+      <Atom charge="0.037544" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="0.120999" name="C23" type="cD" />
+      <Atom charge="0.026097" name="H3R" type="hL" />
+      <Atom charge="0.026097" name="H3S" type="hL" />
+      <Atom charge="-0.287059" name="C24" type="cB" />
+      <Atom charge="0.154038" name="H4R" type="hB" />
+      <Atom charge="-0.214845" name="C25" type="cB" />
+      <Atom charge="0.132504" name="H5R" type="hB" />
+      <Atom charge="0.060337" name="C26" type="cD" />
+      <Atom charge="0.063515" name="H6R" type="hL" />
+      <Atom charge="0.063515" name="H6S" type="hL" />
+      <Atom charge="-0.220895" name="C27" type="cB" />
+      <Atom charge="0.139863" name="H7R" type="hB" />
+      <Atom charge="-0.226254" name="C28" type="cB" />
+      <Atom charge="0.128147" name="H8R" type="hB" />
+      <Atom charge="0.089043" name="C29" type="cD" />
+      <Atom charge="0.054255" name="H9R" type="hL" />
+      <Atom charge="0.054255" name="H9S" type="hL" />
+      <Atom charge="-0.221433" name="C210" type="cB" />
+      <Atom charge="0.133628" name="H10R" type="hB" />
+      <Atom charge="-0.241205" name="C211" type="cB" />
+      <Atom charge="0.136308" name="H11R" type="hB" />
+      <Atom charge="0.085245" name="C212" type="cD" />
+      <Atom charge="0.053422" name="H12R" type="hL" />
+      <Atom charge="0.053422" name="H12S" type="hL" />
+      <Atom charge="-0.218668" name="C213" type="cB" />
+      <Atom charge="0.131575" name="H13R" type="hB" />
+      <Atom charge="-0.240419" name="C214" type="cB" />
+      <Atom charge="0.138337" name="H14R" type="hB" />
+      <Atom charge="0.069215" name="C215" type="cD" />
+      <Atom charge="0.058341" name="H15R" type="hL" />
+      <Atom charge="0.058341" name="H15S" type="hL" />
+      <Atom charge="-0.233897" name="C216" type="cB" />
+      <Atom charge="0.133812" name="H16R" type="hB" />
+      <Atom charge="-0.216499" name="C217" type="cB" />
+      <Atom charge="0.132121" name="H17R" type="hB" />
+      <Atom charge="0.092718" name="C218" type="cD" />
+      <Atom charge="0.053227" name="H18R" type="hL" />
+      <Atom charge="0.053227" name="H18S" type="hL" />
+      <Atom charge="-0.246833" name="C219" type="cB" />
+      <Atom charge="0.136323" name="H19R" type="hB" />
+      <Atom charge="-0.240216" name="C220" type="cB" />
+      <Atom charge="0.133048" name="H20R" type="hB" />
+      <Atom charge="0.122022" name="C221" type="cD" />
+      <Atom charge="0.010042" name="H21R" type="hL" />
+      <Atom charge="0.010042" name="H21S" type="hL" />
+      <Atom charge="-0.108913" name="C222" type="cD" />
+      <Atom charge="0.025968" name="H22R" type="hL" />
+      <Atom charge="0.025968" name="H22S" type="hL" />
+      <Atom charge="0.025968" name="H22T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="C221" />
+      <Bond atomName1="C221" atomName2="H21R" />
+      <Bond atomName1="C221" atomName2="H21S" />
+      <Bond atomName1="C221" atomName2="C222" />
+      <Bond atomName1="C222" atomName2="H22R" />
+      <Bond atomName1="C222" atomName2="H22S" />
+      <Bond atomName1="C222" atomName2="H22T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+      </Residue>
+    <Residue name="DAPS">
+      <Atom charge="-0.414327" name="N" type="nA" />
+      <Atom charge="0.353866" name="HN1" type="hN" />
+      <Atom charge="0.353866" name="HN2" type="hN" />
+      <Atom charge="0.353866" name="HN3" type="hN" />
+      <Atom charge="0.039448" name="C12" type="cA" />
+      <Atom charge="0.090549" name="H12A" type="hX" />
+      <Atom charge="0.809867" name="C13" type="cC" />
+      <Atom charge="-0.815178" name="O13A" type="oO" />
+      <Atom charge="-0.815178" name="O13B" type="oO" />
+      <Atom charge="0.060375" name="C11" type="cA" />
+      <Atom charge="0.093484" name="H11A" type="hE" />
+      <Atom charge="0.093484" name="H11B" type="hE" />
+      <Atom charge="1.380208" name="P" type="pA" />
+      <Atom charge="-0.877922" name="O13" type="oP" />
+      <Atom charge="-0.877922" name="O14" type="oP" />
+      <Atom charge="-0.520128" name="O12" type="oT" />
+      <Atom charge="-0.556992" name="O11" type="oT" />
+      <Atom charge="0.012366" name="C1" type="cA" />
+      <Atom charge="0.097347" name="HA" type="hE" />
+      <Atom charge="0.097347" name="HB" type="hE" />
+      <Atom charge="0.44065" name="C2" type="cA" />
+      <Atom charge="0.002473" name="HS" type="hE" />
+      <Atom charge="-0.634381" name="O21" type="oS" />
+      <Atom charge="0.891897" name="C21" type="cC" />
+      <Atom charge="-0.650291" name="O22" type="oC" />
+      <Atom charge="-0.123935" name="C22" type="cD" />
+      <Atom charge="0.024535" name="H2R" type="hL" />
+      <Atom charge="0.024535" name="H2S" type="hL" />
+      <Atom charge="0.271173" name="C3" type="cA" />
+      <Atom charge="0.037454" name="HX" type="hE" />
+      <Atom charge="0.037454" name="HY" type="hE" />
+      <Atom charge="-0.579073" name="O31" type="oS" />
+      <Atom charge="0.887549" name="C31" type="cC" />
+      <Atom charge="-0.663331" name="O32" type="oC" />
+      <Atom charge="-0.123935" name="C32" type="cD" />
+      <Atom charge="0.024535" name="H2X" type="hL" />
+      <Atom charge="0.024535" name="H2Y" type="hL" />
+      <Atom charge="0.025626" name="C23" type="cD" />
+      <Atom charge="0.025117" name="H3R" type="hL" />
+      <Atom charge="0.025117" name="H3S" type="hL" />
+      <Atom charge="0.031382" name="C24" type="cD" />
+      <Atom charge="0.038708" name="H4R" type="hL" />
+      <Atom charge="0.038708" name="H4S" type="hL" />
+      <Atom charge="-0.26789" name="C25" type="cB" />
+      <Atom charge="0.143577" name="H5R" type="hB" />
+      <Atom charge="-0.206786" name="C26" type="cB" />
+      <Atom charge="0.129858" name="H6R" type="hB" />
+      <Atom charge="0.055784" name="C27" type="cD" />
+      <Atom charge="0.062775" name="H7R" type="hL" />
+      <Atom charge="0.062775" name="H7S" type="hL" />
+      <Atom charge="-0.228527" name="C28" type="cB" />
+      <Atom charge="0.134735" name="H8R" type="hB" />
+      <Atom charge="-0.228694" name="C29" type="cB" />
+      <Atom charge="0.132167" name="H9R" type="hB" />
+      <Atom charge="0.095406" name="C210" type="cD" />
+      <Atom charge="0.05114" name="H10R" type="hL" />
+      <Atom charge="0.05114" name="H10S" type="hL" />
+      <Atom charge="-0.228704" name="C211" type="cB" />
+      <Atom charge="0.131341" name="H11R" type="hB" />
+      <Atom charge="-0.220164" name="C212" type="cB" />
+      <Atom charge="0.131986" name="H12R" type="hB" />
+      <Atom charge="0.058197" name="C213" type="cD" />
+      <Atom charge="0.06135" name="H13R" type="hL" />
+      <Atom charge="0.06135" name="H13S" type="hL" />
+      <Atom charge="-0.224769" name="C214" type="cB" />
+      <Atom charge="0.129616" name="H14R" type="hB" />
+      <Atom charge="-0.244149" name="C215" type="cB" />
+      <Atom charge="0.132793" name="H15R" type="hB" />
+      <Atom charge="0.0391" name="C216" type="cD" />
+      <Atom charge="0.028848" name="H16R" type="hL" />
+      <Atom charge="0.028848" name="H16S" type="hL" />
+      <Atom charge="-0.028398" name="C217" type="cD" />
+      <Atom charge="0.019581" name="H17R" type="hL" />
+      <Atom charge="0.019581" name="H17S" type="hL" />
+      <Atom charge="-0.019772" name="C218" type="cD" />
+      <Atom charge="0.014218" name="H18R" type="hL" />
+      <Atom charge="0.014218" name="H18S" type="hL" />
+      <Atom charge="0.024957" name="C219" type="cD" />
+      <Atom charge="0.005426" name="H19R" type="hL" />
+      <Atom charge="0.005426" name="H19S" type="hL" />
+      <Atom charge="-0.109302" name="C220" type="cD" />
+      <Atom charge="0.023723" name="H20R" type="hL" />
+      <Atom charge="0.023723" name="H20S" type="hL" />
+      <Atom charge="0.023723" name="H20T" type="hL" />
+      <Atom charge="0.025626" name="C33" type="cD" />
+      <Atom charge="0.025117" name="H3X" type="hL" />
+      <Atom charge="0.025117" name="H3Y" type="hL" />
+      <Atom charge="0.031382" name="C34" type="cD" />
+      <Atom charge="0.038708" name="H4X" type="hL" />
+      <Atom charge="0.038708" name="H4Y" type="hL" />
+      <Atom charge="-0.26789" name="C35" type="cB" />
+      <Atom charge="0.143577" name="H5X" type="hB" />
+      <Atom charge="-0.206786" name="C36" type="cB" />
+      <Atom charge="0.129858" name="H6X" type="hB" />
+      <Atom charge="0.055784" name="C37" type="cD" />
+      <Atom charge="0.062775" name="H7X" type="hL" />
+      <Atom charge="0.062775" name="H7Y" type="hL" />
+      <Atom charge="-0.228527" name="C38" type="cB" />
+      <Atom charge="0.134735" name="H8X" type="hB" />
+      <Atom charge="-0.228694" name="C39" type="cB" />
+      <Atom charge="0.132167" name="H9X" type="hB" />
+      <Atom charge="0.095406" name="C310" type="cD" />
+      <Atom charge="0.05114" name="H10X" type="hL" />
+      <Atom charge="0.05114" name="H10Y" type="hL" />
+      <Atom charge="-0.228704" name="C311" type="cB" />
+      <Atom charge="0.131341" name="H11X" type="hB" />
+      <Atom charge="-0.220164" name="C312" type="cB" />
+      <Atom charge="0.131986" name="H12X" type="hB" />
+      <Atom charge="0.058197" name="C313" type="cD" />
+      <Atom charge="0.06135" name="H13X" type="hL" />
+      <Atom charge="0.06135" name="H13Y" type="hL" />
+      <Atom charge="-0.224769" name="C314" type="cB" />
+      <Atom charge="0.129616" name="H14X" type="hB" />
+      <Atom charge="-0.244149" name="C315" type="cB" />
+      <Atom charge="0.132793" name="H15X" type="hB" />
+      <Atom charge="0.0391" name="C316" type="cD" />
+      <Atom charge="0.028848" name="H16X" type="hL" />
+      <Atom charge="0.028848" name="H16Y" type="hL" />
+      <Atom charge="-0.028398" name="C317" type="cD" />
+      <Atom charge="0.019581" name="H17X" type="hL" />
+      <Atom charge="0.019581" name="H17Y" type="hL" />
+      <Atom charge="-0.019772" name="C318" type="cD" />
+      <Atom charge="0.014218" name="H18X" type="hL" />
+      <Atom charge="0.014218" name="H18Y" type="hL" />
+      <Atom charge="0.024957" name="C319" type="cD" />
+      <Atom charge="0.005426" name="H19X" type="hL" />
+      <Atom charge="0.005426" name="H19Y" type="hL" />
+      <Atom charge="-0.109302" name="C320" type="cD" />
+      <Atom charge="0.023723" name="H20X" type="hL" />
+      <Atom charge="0.023723" name="H20Y" type="hL" />
+      <Atom charge="0.023723" name="H20Z" type="hL" />
+      <Bond atomName1="N" atomName2="HN1" />
+      <Bond atomName1="N" atomName2="HN2" />
+      <Bond atomName1="N" atomName2="HN3" />
+      <Bond atomName1="N" atomName2="C12" />
+      <Bond atomName1="O13B" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="C13" atomName2="O13A" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C1" atomName2="O11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="C21" atomName2="O21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="H19S" />
+      <Bond atomName1="C220" atomName2="H20T" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="H20S" />
+      <Bond atomName1="C31" atomName2="O31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C318" atomName2="C319" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C319" atomName2="C320" />
+      <Bond atomName1="C319" atomName2="H19X" />
+      <Bond atomName1="C319" atomName2="H19Y" />
+      <Bond atomName1="C320" atomName2="H20Z" />
+      <Bond atomName1="C320" atomName2="H20X" />
+      <Bond atomName1="C320" atomName2="H20Y" />
+      </Residue>
+    <Residue name="SDPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.142937" name="C22" type="cD" />
+      <Atom charge="0.037544" name="H2R" type="hL" />
+      <Atom charge="0.037544" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="0.120999" name="C23" type="cD" />
+      <Atom charge="0.026097" name="H3R" type="hL" />
+      <Atom charge="0.026097" name="H3S" type="hL" />
+      <Atom charge="-0.287059" name="C24" type="cB" />
+      <Atom charge="0.154038" name="H4R" type="hB" />
+      <Atom charge="-0.214845" name="C25" type="cB" />
+      <Atom charge="0.132504" name="H5R" type="hB" />
+      <Atom charge="0.060337" name="C26" type="cD" />
+      <Atom charge="0.063515" name="H6R" type="hL" />
+      <Atom charge="0.063515" name="H6S" type="hL" />
+      <Atom charge="-0.220895" name="C27" type="cB" />
+      <Atom charge="0.139863" name="H7R" type="hB" />
+      <Atom charge="-0.226254" name="C28" type="cB" />
+      <Atom charge="0.128147" name="H8R" type="hB" />
+      <Atom charge="0.089043" name="C29" type="cD" />
+      <Atom charge="0.054255" name="H9R" type="hL" />
+      <Atom charge="0.054255" name="H9S" type="hL" />
+      <Atom charge="-0.221433" name="C210" type="cB" />
+      <Atom charge="0.133628" name="H10R" type="hB" />
+      <Atom charge="-0.241205" name="C211" type="cB" />
+      <Atom charge="0.136308" name="H11R" type="hB" />
+      <Atom charge="0.085245" name="C212" type="cD" />
+      <Atom charge="0.053422" name="H12R" type="hL" />
+      <Atom charge="0.053422" name="H12S" type="hL" />
+      <Atom charge="-0.218668" name="C213" type="cB" />
+      <Atom charge="0.131575" name="H13R" type="hB" />
+      <Atom charge="-0.240419" name="C214" type="cB" />
+      <Atom charge="0.138337" name="H14R" type="hB" />
+      <Atom charge="0.069215" name="C215" type="cD" />
+      <Atom charge="0.058341" name="H15R" type="hL" />
+      <Atom charge="0.058341" name="H15S" type="hL" />
+      <Atom charge="-0.233897" name="C216" type="cB" />
+      <Atom charge="0.133812" name="H16R" type="hB" />
+      <Atom charge="-0.216499" name="C217" type="cB" />
+      <Atom charge="0.132121" name="H17R" type="hB" />
+      <Atom charge="0.092718" name="C218" type="cD" />
+      <Atom charge="0.053227" name="H18R" type="hL" />
+      <Atom charge="0.053227" name="H18S" type="hL" />
+      <Atom charge="-0.246833" name="C219" type="cB" />
+      <Atom charge="0.136323" name="H19R" type="hB" />
+      <Atom charge="-0.240216" name="C220" type="cB" />
+      <Atom charge="0.133048" name="H20R" type="hB" />
+      <Atom charge="0.122022" name="C221" type="cD" />
+      <Atom charge="0.010042" name="H21R" type="hL" />
+      <Atom charge="0.010042" name="H21S" type="hL" />
+      <Atom charge="-0.108913" name="C222" type="cD" />
+      <Atom charge="0.025968" name="H22R" type="hL" />
+      <Atom charge="0.025968" name="H22S" type="hL" />
+      <Atom charge="0.025968" name="H22T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="C221" />
+      <Bond atomName1="C221" atomName2="H21R" />
+      <Bond atomName1="C221" atomName2="H21S" />
+      <Bond atomName1="C221" atomName2="C222" />
+      <Bond atomName1="C222" atomName2="H22R" />
+      <Bond atomName1="C222" atomName2="H22S" />
+      <Bond atomName1="C222" atomName2="H22T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+    </Residue>
+    <Residue name="DAPA">
+      <Atom charge="1.456663" name="P" type="pA" />
+      <Atom charge="-0.914158" name="O13" type="oP" />
+      <Atom charge="-0.914158" name="O14" type="oP" />
+      <Atom charge="-0.706197" name="O12" type="oH" />
+      <Atom charge="0.415628" name="H12" type="hO" />
+      <Atom charge="-0.594197" name="O11" type="oT" />
+      <Atom charge="0.081528" name="C1" type="cA" />
+      <Atom charge="0.083099" name="HA" type="hE" />
+      <Atom charge="0.083099" name="HB" type="hE" />
+      <Atom charge="0.283546" name="C2" type="cA" />
+      <Atom charge="0.063862" name="HS" type="hE" />
+      <Atom charge="-0.554487" name="O21" type="oS" />
+      <Atom charge="0.897502" name="C21" type="cC" />
+      <Atom charge="-0.671622" name="O22" type="oC" />
+      <Atom charge="-0.123935" name="C22" type="cD" />
+      <Atom charge="0.024535" name="H2R" type="hL" />
+      <Atom charge="0.024535" name="H2S" type="hL" />
+      <Atom charge="0.185299" name="C3" type="cA" />
+      <Atom charge="0.067676" name="HX" type="hE" />
+      <Atom charge="0.067676" name="HY" type="hE" />
+      <Atom charge="-0.547824" name="O31" type="oS" />
+      <Atom charge="0.888207" name="C31" type="cC" />
+      <Atom charge="-0.671142" name="O32" type="oC" />
+      <Atom charge="-0.123935" name="C32" type="cD" />
+      <Atom charge="0.024535" name="H2X" type="hL" />
+      <Atom charge="0.024535" name="H2Y" type="hL" />
+      <Atom charge="0.025626" name="C23" type="cD" />
+      <Atom charge="0.025117" name="H3R" type="hL" />
+      <Atom charge="0.025117" name="H3S" type="hL" />
+      <Atom charge="0.031382" name="C24" type="cD" />
+      <Atom charge="0.038708" name="H4R" type="hL" />
+      <Atom charge="0.038708" name="H4S" type="hL" />
+      <Atom charge="-0.26789" name="C25" type="cB" />
+      <Atom charge="0.143577" name="H5R" type="hB" />
+      <Atom charge="-0.206786" name="C26" type="cB" />
+      <Atom charge="0.129858" name="H6R" type="hB" />
+      <Atom charge="0.055784" name="C27" type="cD" />
+      <Atom charge="0.062775" name="H7R" type="hL" />
+      <Atom charge="0.062775" name="H7S" type="hL" />
+      <Atom charge="-0.228527" name="C28" type="cB" />
+      <Atom charge="0.134735" name="H8R" type="hB" />
+      <Atom charge="-0.228694" name="C29" type="cB" />
+      <Atom charge="0.132167" name="H9R" type="hB" />
+      <Atom charge="0.095406" name="C210" type="cD" />
+      <Atom charge="0.05114" name="H10R" type="hL" />
+      <Atom charge="0.05114" name="H10S" type="hL" />
+      <Atom charge="-0.228704" name="C211" type="cB" />
+      <Atom charge="0.131341" name="H11R" type="hB" />
+      <Atom charge="-0.220164" name="C212" type="cB" />
+      <Atom charge="0.131986" name="H12R" type="hB" />
+      <Atom charge="0.058197" name="C213" type="cD" />
+      <Atom charge="0.06135" name="H13R" type="hL" />
+      <Atom charge="0.06135" name="H13S" type="hL" />
+      <Atom charge="-0.224769" name="C214" type="cB" />
+      <Atom charge="0.129616" name="H14R" type="hB" />
+      <Atom charge="-0.244149" name="C215" type="cB" />
+      <Atom charge="0.132793" name="H15R" type="hB" />
+      <Atom charge="0.0391" name="C216" type="cD" />
+      <Atom charge="0.028848" name="H16R" type="hL" />
+      <Atom charge="0.028848" name="H16S" type="hL" />
+      <Atom charge="-0.028398" name="C217" type="cD" />
+      <Atom charge="0.019581" name="H17R" type="hL" />
+      <Atom charge="0.019581" name="H17S" type="hL" />
+      <Atom charge="-0.019772" name="C218" type="cD" />
+      <Atom charge="0.014218" name="H18R" type="hL" />
+      <Atom charge="0.014218" name="H18S" type="hL" />
+      <Atom charge="0.024957" name="C219" type="cD" />
+      <Atom charge="0.005426" name="H19R" type="hL" />
+      <Atom charge="0.005426" name="H19S" type="hL" />
+      <Atom charge="-0.109302" name="C220" type="cD" />
+      <Atom charge="0.023723" name="H20R" type="hL" />
+      <Atom charge="0.023723" name="H20S" type="hL" />
+      <Atom charge="0.023723" name="H20T" type="hL" />
+      <Atom charge="0.025626" name="C33" type="cD" />
+      <Atom charge="0.025117" name="H3X" type="hL" />
+      <Atom charge="0.025117" name="H3Y" type="hL" />
+      <Atom charge="0.031382" name="C34" type="cD" />
+      <Atom charge="0.038708" name="H4X" type="hL" />
+      <Atom charge="0.038708" name="H4Y" type="hL" />
+      <Atom charge="-0.26789" name="C35" type="cB" />
+      <Atom charge="0.143577" name="H5X" type="hB" />
+      <Atom charge="-0.206786" name="C36" type="cB" />
+      <Atom charge="0.129858" name="H6X" type="hB" />
+      <Atom charge="0.055784" name="C37" type="cD" />
+      <Atom charge="0.062775" name="H7X" type="hL" />
+      <Atom charge="0.062775" name="H7Y" type="hL" />
+      <Atom charge="-0.228527" name="C38" type="cB" />
+      <Atom charge="0.134735" name="H8X" type="hB" />
+      <Atom charge="-0.228694" name="C39" type="cB" />
+      <Atom charge="0.132167" name="H9X" type="hB" />
+      <Atom charge="0.095406" name="C310" type="cD" />
+      <Atom charge="0.05114" name="H10X" type="hL" />
+      <Atom charge="0.05114" name="H10Y" type="hL" />
+      <Atom charge="-0.228704" name="C311" type="cB" />
+      <Atom charge="0.131341" name="H11X" type="hB" />
+      <Atom charge="-0.220164" name="C312" type="cB" />
+      <Atom charge="0.131986" name="H12X" type="hB" />
+      <Atom charge="0.058197" name="C313" type="cD" />
+      <Atom charge="0.06135" name="H13X" type="hL" />
+      <Atom charge="0.06135" name="H13Y" type="hL" />
+      <Atom charge="-0.224769" name="C314" type="cB" />
+      <Atom charge="0.129616" name="H14X" type="hB" />
+      <Atom charge="-0.244149" name="C315" type="cB" />
+      <Atom charge="0.132793" name="H15X" type="hB" />
+      <Atom charge="0.0391" name="C316" type="cD" />
+      <Atom charge="0.028848" name="H16X" type="hL" />
+      <Atom charge="0.028848" name="H16Y" type="hL" />
+      <Atom charge="-0.028398" name="C317" type="cD" />
+      <Atom charge="0.019581" name="H17X" type="hL" />
+      <Atom charge="0.019581" name="H17Y" type="hL" />
+      <Atom charge="-0.019772" name="C318" type="cD" />
+      <Atom charge="0.014218" name="H18X" type="hL" />
+      <Atom charge="0.014218" name="H18Y" type="hL" />
+      <Atom charge="0.024957" name="C319" type="cD" />
+      <Atom charge="0.005426" name="H19X" type="hL" />
+      <Atom charge="0.005426" name="H19Y" type="hL" />
+      <Atom charge="-0.109302" name="C320" type="cD" />
+      <Atom charge="0.023723" name="H20X" type="hL" />
+      <Atom charge="0.023723" name="H20Y" type="hL" />
+      <Atom charge="0.023723" name="H20Z" type="hL" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="O12" atomName2="H12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="C21" atomName2="O21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="H19S" />
+      <Bond atomName1="C220" atomName2="H20T" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="H20S" />
+      <Bond atomName1="C31" atomName2="O31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C318" atomName2="C319" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C319" atomName2="C320" />
+      <Bond atomName1="C319" atomName2="H19X" />
+      <Bond atomName1="C319" atomName2="H19Y" />
+      <Bond atomName1="C320" atomName2="H20Z" />
+      <Bond atomName1="C320" atomName2="H20X" />
+      <Bond atomName1="C320" atomName2="H20Y" />
+    </Residue>
+    <Residue name="SDPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.142937" name="C22" type="cD" />
+      <Atom charge="0.037544" name="H2R" type="hL" />
+      <Atom charge="0.037544" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.11702" name="C32" type="cD" />
+      <Atom charge="0.051807" name="H2X" type="hL" />
+      <Atom charge="0.051807" name="H2Y" type="hL" />
+      <Atom charge="0.120999" name="C23" type="cD" />
+      <Atom charge="0.026097" name="H3R" type="hL" />
+      <Atom charge="0.026097" name="H3S" type="hL" />
+      <Atom charge="-0.287059" name="C24" type="cB" />
+      <Atom charge="0.154038" name="H4R" type="hB" />
+      <Atom charge="-0.214845" name="C25" type="cB" />
+      <Atom charge="0.132504" name="H5R" type="hB" />
+      <Atom charge="0.060337" name="C26" type="cD" />
+      <Atom charge="0.063515" name="H6R" type="hL" />
+      <Atom charge="0.063515" name="H6S" type="hL" />
+      <Atom charge="-0.220895" name="C27" type="cB" />
+      <Atom charge="0.139863" name="H7R" type="hB" />
+      <Atom charge="-0.226254" name="C28" type="cB" />
+      <Atom charge="0.128147" name="H8R" type="hB" />
+      <Atom charge="0.089043" name="C29" type="cD" />
+      <Atom charge="0.054255" name="H9R" type="hL" />
+      <Atom charge="0.054255" name="H9S" type="hL" />
+      <Atom charge="-0.221433" name="C210" type="cB" />
+      <Atom charge="0.133628" name="H10R" type="hB" />
+      <Atom charge="-0.241205" name="C211" type="cB" />
+      <Atom charge="0.136308" name="H11R" type="hB" />
+      <Atom charge="0.085245" name="C212" type="cD" />
+      <Atom charge="0.053422" name="H12R" type="hL" />
+      <Atom charge="0.053422" name="H12S" type="hL" />
+      <Atom charge="-0.218668" name="C213" type="cB" />
+      <Atom charge="0.131575" name="H13R" type="hB" />
+      <Atom charge="-0.240419" name="C214" type="cB" />
+      <Atom charge="0.138337" name="H14R" type="hB" />
+      <Atom charge="0.069215" name="C215" type="cD" />
+      <Atom charge="0.058341" name="H15R" type="hL" />
+      <Atom charge="0.058341" name="H15S" type="hL" />
+      <Atom charge="-0.233897" name="C216" type="cB" />
+      <Atom charge="0.133812" name="H16R" type="hB" />
+      <Atom charge="-0.216499" name="C217" type="cB" />
+      <Atom charge="0.132121" name="H17R" type="hB" />
+      <Atom charge="0.092718" name="C218" type="cD" />
+      <Atom charge="0.053227" name="H18R" type="hL" />
+      <Atom charge="0.053227" name="H18S" type="hL" />
+      <Atom charge="-0.246833" name="C219" type="cB" />
+      <Atom charge="0.136323" name="H19R" type="hB" />
+      <Atom charge="-0.240216" name="C220" type="cB" />
+      <Atom charge="0.133048" name="H20R" type="hB" />
+      <Atom charge="0.122022" name="C221" type="cD" />
+      <Atom charge="0.010042" name="H21R" type="hL" />
+      <Atom charge="0.010042" name="H21S" type="hL" />
+      <Atom charge="-0.108913" name="C222" type="cD" />
+      <Atom charge="0.025968" name="H22R" type="hL" />
+      <Atom charge="0.025968" name="H22S" type="hL" />
+      <Atom charge="0.025968" name="H22T" type="hL" />
+      <Atom charge="-0.000128" name="C33" type="cD" />
+      <Atom charge="0.013886" name="H3X" type="hL" />
+      <Atom charge="0.013886" name="H3Y" type="hL" />
+      <Atom charge="-0.059792" name="C34" type="cD" />
+      <Atom charge="0.024241" name="H4X" type="hL" />
+      <Atom charge="0.024241" name="H4Y" type="hL" />
+      <Atom charge="-0.013443" name="C35" type="cD" />
+      <Atom charge="0.008191" name="H5X" type="hL" />
+      <Atom charge="0.008191" name="H5Y" type="hL" />
+      <Atom charge="-0.037627" name="C36" type="cD" />
+      <Atom charge="0.01774" name="H6X" type="hL" />
+      <Atom charge="0.01774" name="H6Y" type="hL" />
+      <Atom charge="-0.019469" name="C37" type="cD" />
+      <Atom charge="0.009292" name="H7X" type="hL" />
+      <Atom charge="0.009292" name="H7Y" type="hL" />
+      <Atom charge="-0.014623" name="C38" type="cD" />
+      <Atom charge="0.007326" name="H8X" type="hL" />
+      <Atom charge="0.007326" name="H8Y" type="hL" />
+      <Atom charge="-0.017997" name="C39" type="cD" />
+      <Atom charge="0.009595" name="H9X" type="hL" />
+      <Atom charge="0.009595" name="H9Y" type="hL" />
+      <Atom charge="-0.026418" name="C310" type="cD" />
+      <Atom charge="0.010825" name="H10X" type="hL" />
+      <Atom charge="0.010825" name="H10Y" type="hL" />
+      <Atom charge="-0.017093" name="C311" type="cD" />
+      <Atom charge="0.010206" name="H11X" type="hL" />
+      <Atom charge="0.010206" name="H11Y" type="hL" />
+      <Atom charge="-0.019153" name="C312" type="cD" />
+      <Atom charge="0.008198" name="H12X" type="hL" />
+      <Atom charge="0.008198" name="H12Y" type="hL" />
+      <Atom charge="-0.01159" name="C313" type="cD" />
+      <Atom charge="0.006022" name="H13X" type="hL" />
+      <Atom charge="0.006022" name="H13Y" type="hL" />
+      <Atom charge="-0.013489" name="C314" type="cD" />
+      <Atom charge="0.010073" name="H14X" type="hL" />
+      <Atom charge="0.010073" name="H14Y" type="hL" />
+      <Atom charge="-0.032444" name="C315" type="cD" />
+      <Atom charge="0.010253" name="H15X" type="hL" />
+      <Atom charge="0.010253" name="H15Y" type="hL" />
+      <Atom charge="-0.027654" name="C316" type="cD" />
+      <Atom charge="0.015627" name="H16X" type="hL" />
+      <Atom charge="0.015627" name="H16Y" type="hL" />
+      <Atom charge="0.020665" name="C317" type="cD" />
+      <Atom charge="0.008483" name="H17X" type="hL" />
+      <Atom charge="0.008483" name="H17Y" type="hL" />
+      <Atom charge="-0.120069" name="C318" type="cD" />
+      <Atom charge="0.027938" name="H18X" type="hL" />
+      <Atom charge="0.027938" name="H18Y" type="hL" />
+      <Atom charge="0.027938" name="H18Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="O21" atomName2="C21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C26" atomName2="H6S" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C29" atomName2="H9S" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C212" atomName2="H12S" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C215" atomName2="H15S" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="C221" />
+      <Bond atomName1="C221" atomName2="H21R" />
+      <Bond atomName1="C221" atomName2="H21S" />
+      <Bond atomName1="C221" atomName2="C222" />
+      <Bond atomName1="C222" atomName2="H22R" />
+      <Bond atomName1="C222" atomName2="H22S" />
+      <Bond atomName1="C222" atomName2="H22T" />
+      <Bond atomName1="O31" atomName2="C31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C35" atomName2="H5Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C36" atomName2="H6Y" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C38" atomName2="H8Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C39" atomName2="H9Y" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C311" atomName2="H11Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C312" atomName2="H12Y" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C314" atomName2="H14Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C315" atomName2="H15Y" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C318" atomName2="H18Z" />
+    </Residue>
+    <Residue name="DAPG">
+      <Atom charge="0.193597" name="C13" type="cA" />
+      <Atom charge="0.034715" name="H13A" type="hE" />
+      <Atom charge="0.034715" name="H13B" type="hE" />
+      <Atom charge="-0.700871" name="OC3" type="oH" />
+      <Atom charge="0.423328" name="HO3" type="hO" />
+      <Atom charge="0.336816" name="C12" type="cA" />
+      <Atom charge="0.030042" name="H12A" type="hE" />
+      <Atom charge="-0.726192" name="OC2" type="oH" />
+      <Atom charge="0.439523" name="HO2" type="hO" />
+      <Atom charge="-0.056706" name="C11" type="cA" />
+      <Atom charge="0.093354" name="H11A" type="hE" />
+      <Atom charge="0.093354" name="H11B" type="hE" />
+      <Atom charge="1.380464" name="P" type="pA" />
+      <Atom charge="-0.873444" name="O13" type="oP" />
+      <Atom charge="-0.873444" name="O14" type="oP" />
+      <Atom charge="-0.534308" name="O12" type="oT" />
+      <Atom charge="-0.546098" name="O11" type="oT" />
+      <Atom charge="0.043713" name="C1" type="cA" />
+      <Atom charge="0.091041" name="HA" type="hE" />
+      <Atom charge="0.091041" name="HB" type="hE" />
+      <Atom charge="0.353807" name="C2" type="cA" />
+      <Atom charge="0.037488" name="HS" type="hE" />
+      <Atom charge="-0.599131" name="O21" type="oS" />
+      <Atom charge="0.883669" name="C21" type="cC" />
+      <Atom charge="-0.655762" name="O22" type="oC" />
+      <Atom charge="-0.123935" name="C22" type="cD" />
+      <Atom charge="0.024535" name="H2R" type="hL" />
+      <Atom charge="0.024535" name="H2S" type="hL" />
+      <Atom charge="0.295119" name="C3" type="cA" />
+      <Atom charge="0.033797" name="HX" type="hE" />
+      <Atom charge="0.033797" name="HY" type="hE" />
+      <Atom charge="-0.585165" name="O31" type="oS" />
+      <Atom charge="0.877006" name="C31" type="cC" />
+      <Atom charge="-0.649265" name="O32" type="oC" />
+      <Atom charge="-0.123935" name="C32" type="cD" />
+      <Atom charge="0.024535" name="H2X" type="hL" />
+      <Atom charge="0.024535" name="H2Y" type="hL" />
+      <Atom charge="0.025626" name="C23" type="cD" />
+      <Atom charge="0.025117" name="H3R" type="hL" />
+      <Atom charge="0.025117" name="H3S" type="hL" />
+      <Atom charge="0.031382" name="C24" type="cD" />
+      <Atom charge="0.038708" name="H4R" type="hL" />
+      <Atom charge="0.038708" name="H4S" type="hL" />
+      <Atom charge="-0.26789" name="C25" type="cB" />
+      <Atom charge="0.143577" name="H5R" type="hB" />
+      <Atom charge="-0.206786" name="C26" type="cB" />
+      <Atom charge="0.129858" name="H6R" type="hB" />
+      <Atom charge="0.055784" name="C27" type="cD" />
+      <Atom charge="0.062775" name="H7R" type="hL" />
+      <Atom charge="0.062775" name="H7S" type="hL" />
+      <Atom charge="-0.228527" name="C28" type="cB" />
+      <Atom charge="0.134735" name="H8R" type="hB" />
+      <Atom charge="-0.228694" name="C29" type="cB" />
+      <Atom charge="0.132167" name="H9R" type="hB" />
+      <Atom charge="0.095406" name="C210" type="cD" />
+      <Atom charge="0.05114" name="H10R" type="hL" />
+      <Atom charge="0.05114" name="H10S" type="hL" />
+      <Atom charge="-0.228704" name="C211" type="cB" />
+      <Atom charge="0.131341" name="H11R" type="hB" />
+      <Atom charge="-0.220164" name="C212" type="cB" />
+      <Atom charge="0.131986" name="H12R" type="hB" />
+      <Atom charge="0.058197" name="C213" type="cD" />
+      <Atom charge="0.06135" name="H13R" type="hL" />
+      <Atom charge="0.06135" name="H13S" type="hL" />
+      <Atom charge="-0.224769" name="C214" type="cB" />
+      <Atom charge="0.129616" name="H14R" type="hB" />
+      <Atom charge="-0.244149" name="C215" type="cB" />
+      <Atom charge="0.132793" name="H15R" type="hB" />
+      <Atom charge="0.0391" name="C216" type="cD" />
+      <Atom charge="0.028848" name="H16R" type="hL" />
+      <Atom charge="0.028848" name="H16S" type="hL" />
+      <Atom charge="-0.028398" name="C217" type="cD" />
+      <Atom charge="0.019581" name="H17R" type="hL" />
+      <Atom charge="0.019581" name="H17S" type="hL" />
+      <Atom charge="-0.019772" name="C218" type="cD" />
+      <Atom charge="0.014218" name="H18R" type="hL" />
+      <Atom charge="0.014218" name="H18S" type="hL" />
+      <Atom charge="0.024957" name="C219" type="cD" />
+      <Atom charge="0.005426" name="H19R" type="hL" />
+      <Atom charge="0.005426" name="H19S" type="hL" />
+      <Atom charge="-0.109302" name="C220" type="cD" />
+      <Atom charge="0.023723" name="H20R" type="hL" />
+      <Atom charge="0.023723" name="H20S" type="hL" />
+      <Atom charge="0.023723" name="H20T" type="hL" />
+      <Atom charge="0.025626" name="C33" type="cD" />
+      <Atom charge="0.025117" name="H3X" type="hL" />
+      <Atom charge="0.025117" name="H3Y" type="hL" />
+      <Atom charge="0.031382" name="C34" type="cD" />
+      <Atom charge="0.038708" name="H4X" type="hL" />
+      <Atom charge="0.038708" name="H4Y" type="hL" />
+      <Atom charge="-0.26789" name="C35" type="cB" />
+      <Atom charge="0.143577" name="H5X" type="hB" />
+      <Atom charge="-0.206786" name="C36" type="cB" />
+      <Atom charge="0.129858" name="H6X" type="hB" />
+      <Atom charge="0.055784" name="C37" type="cD" />
+      <Atom charge="0.062775" name="H7X" type="hL" />
+      <Atom charge="0.062775" name="H7Y" type="hL" />
+      <Atom charge="-0.228527" name="C38" type="cB" />
+      <Atom charge="0.134735" name="H8X" type="hB" />
+      <Atom charge="-0.228694" name="C39" type="cB" />
+      <Atom charge="0.132167" name="H9X" type="hB" />
+      <Atom charge="0.095406" name="C310" type="cD" />
+      <Atom charge="0.05114" name="H10X" type="hL" />
+      <Atom charge="0.05114" name="H10Y" type="hL" />
+      <Atom charge="-0.228704" name="C311" type="cB" />
+      <Atom charge="0.131341" name="H11X" type="hB" />
+      <Atom charge="-0.220164" name="C312" type="cB" />
+      <Atom charge="0.131986" name="H12X" type="hB" />
+      <Atom charge="0.058197" name="C313" type="cD" />
+      <Atom charge="0.06135" name="H13X" type="hL" />
+      <Atom charge="0.06135" name="H13Y" type="hL" />
+      <Atom charge="-0.224769" name="C314" type="cB" />
+      <Atom charge="0.129616" name="H14X" type="hB" />
+      <Atom charge="-0.244149" name="C315" type="cB" />
+      <Atom charge="0.132793" name="H15X" type="hB" />
+      <Atom charge="0.0391" name="C316" type="cD" />
+      <Atom charge="0.028848" name="H16X" type="hL" />
+      <Atom charge="0.028848" name="H16Y" type="hL" />
+      <Atom charge="-0.028398" name="C317" type="cD" />
+      <Atom charge="0.019581" name="H17X" type="hL" />
+      <Atom charge="0.019581" name="H17Y" type="hL" />
+      <Atom charge="-0.019772" name="C318" type="cD" />
+      <Atom charge="0.014218" name="H18X" type="hL" />
+      <Atom charge="0.014218" name="H18Y" type="hL" />
+      <Atom charge="0.024957" name="C319" type="cD" />
+      <Atom charge="0.005426" name="H19X" type="hL" />
+      <Atom charge="0.005426" name="H19Y" type="hL" />
+      <Atom charge="-0.109302" name="C320" type="cD" />
+      <Atom charge="0.023723" name="H20X" type="hL" />
+      <Atom charge="0.023723" name="H20Y" type="hL" />
+      <Atom charge="0.023723" name="H20Z" type="hL" />
+      <Bond atomName1="HO3" atomName2="OC3" />
+      <Bond atomName1="OC3" atomName2="C13" />
+      <Bond atomName1="C13" atomName2="H13A" />
+      <Bond atomName1="C13" atomName2="H13B" />
+      <Bond atomName1="C13" atomName2="C12" />
+      <Bond atomName1="HO2" atomName2="OC2" />
+      <Bond atomName1="OC2" atomName2="C12" />
+      <Bond atomName1="C12" atomName2="H12A" />
+      <Bond atomName1="C12" atomName2="C11" />
+      <Bond atomName1="C11" atomName2="H11A" />
+      <Bond atomName1="C11" atomName2="H11B" />
+      <Bond atomName1="C11" atomName2="O12" />
+      <Bond atomName1="O11" atomName2="C1" />
+      <Bond atomName1="O12" atomName2="P" />
+      <Bond atomName1="P" atomName2="O11" />
+      <Bond atomName1="P" atomName2="O13" />
+      <Bond atomName1="P" atomName2="O14" />
+      <Bond atomName1="C1" atomName2="HA" />
+      <Bond atomName1="C1" atomName2="HB" />
+      <Bond atomName1="C1" atomName2="C2" />
+      <Bond atomName1="C2" atomName2="HS" />
+      <Bond atomName1="C2" atomName2="C3" />
+      <Bond atomName1="C2" atomName2="O21" />
+      <Bond atomName1="C3" atomName2="HX" />
+      <Bond atomName1="C3" atomName2="HY" />
+      <Bond atomName1="C3" atomName2="O31" />
+      <Bond atomName1="C21" atomName2="O21" />
+      <Bond atomName1="C21" atomName2="C22" />
+      <Bond atomName1="C21" atomName2="O22" />
+      <Bond atomName1="C22" atomName2="C23" />
+      <Bond atomName1="C22" atomName2="H2R" />
+      <Bond atomName1="C22" atomName2="H2S" />
+      <Bond atomName1="C23" atomName2="C24" />
+      <Bond atomName1="C23" atomName2="H3R" />
+      <Bond atomName1="C23" atomName2="H3S" />
+      <Bond atomName1="C24" atomName2="C25" />
+      <Bond atomName1="C24" atomName2="H4R" />
+      <Bond atomName1="C24" atomName2="H4S" />
+      <Bond atomName1="C25" atomName2="C26" />
+      <Bond atomName1="C25" atomName2="H5R" />
+      <Bond atomName1="C26" atomName2="C27" />
+      <Bond atomName1="C26" atomName2="H6R" />
+      <Bond atomName1="C27" atomName2="C28" />
+      <Bond atomName1="C27" atomName2="H7R" />
+      <Bond atomName1="C27" atomName2="H7S" />
+      <Bond atomName1="C28" atomName2="C29" />
+      <Bond atomName1="C28" atomName2="H8R" />
+      <Bond atomName1="C29" atomName2="C210" />
+      <Bond atomName1="C29" atomName2="H9R" />
+      <Bond atomName1="C210" atomName2="C211" />
+      <Bond atomName1="C210" atomName2="H10R" />
+      <Bond atomName1="C210" atomName2="H10S" />
+      <Bond atomName1="C211" atomName2="C212" />
+      <Bond atomName1="C211" atomName2="H11R" />
+      <Bond atomName1="C212" atomName2="C213" />
+      <Bond atomName1="C212" atomName2="H12R" />
+      <Bond atomName1="C213" atomName2="C214" />
+      <Bond atomName1="C213" atomName2="H13R" />
+      <Bond atomName1="C213" atomName2="H13S" />
+      <Bond atomName1="C214" atomName2="C215" />
+      <Bond atomName1="C214" atomName2="H14R" />
+      <Bond atomName1="C215" atomName2="C216" />
+      <Bond atomName1="C215" atomName2="H15R" />
+      <Bond atomName1="C216" atomName2="C217" />
+      <Bond atomName1="C216" atomName2="H16R" />
+      <Bond atomName1="C216" atomName2="H16S" />
+      <Bond atomName1="C217" atomName2="C218" />
+      <Bond atomName1="C217" atomName2="H17R" />
+      <Bond atomName1="C217" atomName2="H17S" />
+      <Bond atomName1="C218" atomName2="C219" />
+      <Bond atomName1="C218" atomName2="H18R" />
+      <Bond atomName1="C218" atomName2="H18S" />
+      <Bond atomName1="C219" atomName2="C220" />
+      <Bond atomName1="C219" atomName2="H19R" />
+      <Bond atomName1="C219" atomName2="H19S" />
+      <Bond atomName1="C220" atomName2="H20T" />
+      <Bond atomName1="C220" atomName2="H20R" />
+      <Bond atomName1="C220" atomName2="H20S" />
+      <Bond atomName1="C31" atomName2="O31" />
+      <Bond atomName1="C31" atomName2="C32" />
+      <Bond atomName1="C31" atomName2="O32" />
+      <Bond atomName1="C32" atomName2="C33" />
+      <Bond atomName1="C32" atomName2="H2X" />
+      <Bond atomName1="C32" atomName2="H2Y" />
+      <Bond atomName1="C33" atomName2="C34" />
+      <Bond atomName1="C33" atomName2="H3X" />
+      <Bond atomName1="C33" atomName2="H3Y" />
+      <Bond atomName1="C34" atomName2="C35" />
+      <Bond atomName1="C34" atomName2="H4X" />
+      <Bond atomName1="C34" atomName2="H4Y" />
+      <Bond atomName1="C35" atomName2="C36" />
+      <Bond atomName1="C35" atomName2="H5X" />
+      <Bond atomName1="C36" atomName2="C37" />
+      <Bond atomName1="C36" atomName2="H6X" />
+      <Bond atomName1="C37" atomName2="C38" />
+      <Bond atomName1="C37" atomName2="H7X" />
+      <Bond atomName1="C37" atomName2="H7Y" />
+      <Bond atomName1="C38" atomName2="C39" />
+      <Bond atomName1="C38" atomName2="H8X" />
+      <Bond atomName1="C39" atomName2="C310" />
+      <Bond atomName1="C39" atomName2="H9X" />
+      <Bond atomName1="C310" atomName2="C311" />
+      <Bond atomName1="C310" atomName2="H10X" />
+      <Bond atomName1="C310" atomName2="H10Y" />
+      <Bond atomName1="C311" atomName2="C312" />
+      <Bond atomName1="C311" atomName2="H11X" />
+      <Bond atomName1="C312" atomName2="C313" />
+      <Bond atomName1="C312" atomName2="H12X" />
+      <Bond atomName1="C313" atomName2="C314" />
+      <Bond atomName1="C313" atomName2="H13X" />
+      <Bond atomName1="C313" atomName2="H13Y" />
+      <Bond atomName1="C314" atomName2="C315" />
+      <Bond atomName1="C314" atomName2="H14X" />
+      <Bond atomName1="C315" atomName2="C316" />
+      <Bond atomName1="C315" atomName2="H15X" />
+      <Bond atomName1="C316" atomName2="C317" />
+      <Bond atomName1="C316" atomName2="H16X" />
+      <Bond atomName1="C316" atomName2="H16Y" />
+      <Bond atomName1="C317" atomName2="C318" />
+      <Bond atomName1="C317" atomName2="H17X" />
+      <Bond atomName1="C317" atomName2="H17Y" />
+      <Bond atomName1="C318" atomName2="C319" />
+      <Bond atomName1="C318" atomName2="H18X" />
+      <Bond atomName1="C318" atomName2="H18Y" />
+      <Bond atomName1="C319" atomName2="C320" />
+      <Bond atomName1="C319" atomName2="H19X" />
+      <Bond atomName1="C319" atomName2="H19Y" />
+      <Bond atomName1="C320" atomName2="H20Z" />
+      <Bond atomName1="C320" atomName2="H20X" />
+      <Bond atomName1="C320" atomName2="H20Y" />
+    </Residue>
+    </Residues>
+  <HarmonicBondForce>
+    <Bond class1="cC" class2="cD" length="0.15080000000000002" k="274721.43999999994" />
+    <Bond class1="cD" class2="cD" length="0.1535" k="253634.07999999996" />
+    <Bond class1="cA" class2="cD" length="0.1535" k="253634.07999999996" />
+    <Bond class1="cC" class2="oC" length="0.12140000000000001" k="542246.3999999999" />
+    <Bond class1="oS" class2="cC" length="0.1343" k="344175.83999999997" />
+    <Bond class1="nA" class2="cA" length="0.1499" k="245684.47999999998" />
+    <Bond class1="cA" class2="cA" length="0.1535" k="253634.07999999996" />
+    <Bond class1="pA" class2="oT" length="0.16100000000000003" k="192463.99999999997" />
+    <Bond class1="pA" class2="oP" length="0.148" k="439319.99999999994" />
+    <Bond class1="cA" class2="oT" length="0.1439" k="252295.19999999995" />
+    <Bond class1="cA" class2="oS" length="0.1439" k="252295.19999999995" />
+    <Bond class1="cA" class2="hA" length="0.10920000000000002" k="282252.63999999996" />
+    <Bond class1="cD" class2="hL" length="0.10920000000000002" k="282252.63999999996" />
+    <Bond class1="cA" class2="hX" length="0.1091" k="283424.1599999999" />
+    <Bond class1="cA" class2="hE" length="0.10930000000000001" k="281081.11999999994" />
+    <Bond class1="cB" class2="cB" length="0.13240000000000002" k="493460.95999999996" />
+    <Bond class1="cB" class2="cD" length="0.15080000000000002" k="274721.43999999994" />
+    <Bond class1="cB" class2="cA" length="0.15080000000000002" k="274721.43999999994" />
+    <Bond class1="cB" class2="hB" length="0.1087" k="288110.23999999993" />
+    <Bond class1="cA" class2="cC" length="0.15080000000000002" k="274721.43999999994" />
+    <Bond class1="cC" class2="oO" length="0.12140000000000001" k="542246.3999999999" />
+    <Bond class1="hN" class2="nA" length="0.1033" k="308779.19999999995" />
+    <Bond class1="cA" class2="oH" length="0.1426" k="262838.87999999995" />
+    <Bond class1="hO" class2="oH" length="0.0974" k="309281.27999999997" />
+    <Bond class1="oH" class2="pA" length="0.1625" k="268780.1599999999" />
+    <Bond class1="cC" class2="nN" length="0.1345" k="400157.7599999999" />
+    <Bond class1="cA" class2="nN" length="0.146" k="276646.07999999996" />
+    <Bond class1="hN" class2="nN" length="0.10089999999999999" k="343255.3599999999" />
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle class1="cD" class2="cD" class3="cD" angle="1.9556414268596463" k="394.9696" />
+    <Angle class1="cD" class2="cC" class3="oC" angle="2.148674842130219" k="569.27504" />
+    <Angle class1="cD" class2="cC" class3="oS" angle="1.9540706305328512" k="579.5676800000001" />
+    <Angle class1="cD" class2="cD" class3="cC" angle="1.9291124222293325" k="533.79472" />
+    <Angle class1="hA" class2="cA" class3="hA" angle="1.8910642445358559" k="329.95024" />
+    <Angle class1="cA" class2="cA" class3="hA" angle="1.9207348418197596" k="388.02416" />
+    <Angle class1="cD" class2="cA" class3="hA" angle="1.9207348418197596" k="388.02416" />
+    <Angle class1="cA" class2="cD" class3="hL" angle="1.9207348418197596" k="388.02416" />
+    <Angle class1="cA" class2="cA" class3="cA" angle="1.9308577514813268" k="528.94128" />
+    <Angle class1="cD" class2="cD" class3="cA" angle="1.9308577514813268" k="528.94128" />
+    <Angle class1="cA" class2="cA" class3="cD" angle="1.9308577514813268" k="528.94128" />
+    <Angle class1="cA" class2="cA" class3="cB" angle="1.9449949184224808" k="531.61904" />
+    <Angle class1="cA" class2="cB" class3="cB" angle="2.1540853628114016" k="538.31344" />
+    <Angle class1="cA" class2="cB" class3="cA" angle="2.033657644423793" k="524.6736000000001" />
+    <Angle class1="cA" class2="cB" class3="hB" angle="2.0472712125893486" k="382.08288" />
+    <Angle class1="cB" class2="cA" class3="hA" angle="1.9284142905285346" k="393.54704000000004" />
+    <Angle class1="oS" class2="cC" class3="oC" angle="2.152514566484607" k="635.3822400000001" />
+    <Angle class1="oP" class2="pA" class3="oP" angle="2.092649773141201" k="1171.52" />
+    <Angle class1="cA" class2="nA" class3="cA" angle="1.9310322844065262" k="525.8451200000001" />
+    <Angle class1="cA" class2="cA" class3="nA" angle="1.9952604008799175" k="539.3176000000001" />
+    <Angle class1="oT" class2="pA" class3="oP" angle="1.888969849433463" k="836.8000000000001" />
+    <Angle class1="oT" class2="cA" class3="cA" angle="1.892285975012252" k="567.18304" />
+    <Angle class1="pA" class2="oT" class3="cA" angle="2.1031217486531673" k="836.8000000000001" />
+    <Angle class1="oT" class2="pA" class3="oT" angle="1.790707812546182" k="753.12" />
+    <Angle class1="cA" class2="cA" class3="oS" angle="1.892285975012252" k="567.18304" />
+    <Angle class1="cA" class2="oS" class3="cC" angle="2.0095721007462712" k="532.4558400000001" />
+    <Angle class1="hL" class2="cD" class3="cC" angle="1.9142771235873808" k="394.9696" />
+    <Angle class1="hL" class2="cD" class3="hL" angle="1.8910642445358559" k="329.95024" />
+    <Angle class1="hL" class2="cD" class3="cD" angle="1.9207348418197596" k="388.02416" />
+    <Angle class1="hX" class2="cA" class3="hX" angle="1.9327776136585204" k="326.68672" />
+    <Angle class1="nA" class2="cA" class3="hX" angle="1.8833847958270808" k="410.19936000000007" />
+    <Angle class1="hE" class2="cA" class3="cA" angle="1.9210839076701585" k="387.94048000000004" />
+    <Angle class1="hE" class2="cA" class3="hE" angle="1.912008195559788" k="327.85824" />
+    <Angle class1="cA" class2="cA" class3="hX" angle="1.9502309061784637" k="385.09536" />
+    <Angle class1="oT" class2="cA" class3="hE" angle="1.8992672920202294" k="425.42912000000007" />
+    <Angle class1="hE" class2="cA" class3="oS" angle="1.8992672920202294" k="425.42912000000007" />
+    <Angle class1="cB" class2="cB" class3="cD" angle="2.1540853628114016" k="538.31344" />
+    <Angle class1="cB" class2="cD" class3="hL" angle="1.9284142905285346" k="393.54704000000004" />
+    <Angle class1="cB" class2="cD" class3="cD" angle="1.9449949184224808" k="531.61904" />
+    <Angle class1="cB" class2="cB" class3="hB" angle="2.1108011973619423" k="418.73472" />
+    <Angle class1="cD" class2="cB" class3="hB" angle="2.0472712125893486" k="382.08288" />
+    <Angle class1="cA" class2="cC" class3="oO" angle="2.148674842130219" k="569.27504" />
+    <Angle class1="oO" class2="cC" class3="oO" angle="2.275560278750207" k="654.12656" />
+    <Angle class1="cA" class2="nA" class3="hN" angle="1.9217820393709562" k="386.51792" />
+    <Angle class1="hN" class2="nA" class3="hN" angle="1.8868754543310697" k="339.07136" />
+    <Angle class1="cA" class2="cA" class3="cC" angle="1.9291124222293325" k="533.79472" />
+    <Angle class1="cC" class2="cA" class3="nA" angle="1.9933405387027237" k="544.50576" />
+    <Angle class1="cC" class2="cA" class3="hX" angle="1.9118336626345886" k="395.22064" />
+    <Angle class1="hE" class2="cA" class3="oH" angle="1.9177677820913692" k="426.51696" />
+    <Angle class1="cA" class2="oH" class3="hO" angle="1.8877481189570668" k="394.04912" />
+    <Angle class1="cA" class2="cA" class3="oH" angle="1.909913800457395" k="566.68096" />
+    <Angle class1="hO" class2="oH" class3="pA" angle="1.9223056381465546" k="467.60384000000005" />
+    <Angle class1="oH" class2="pA" class3="oT" angle="1.7866935552665952" k="375.80688" />
+    <Angle class1="oP" class2="pA" class3="oH" angle="2.0116664958486643" k="366.43472" />
+    <Angle class1="cB" class2="cD" class3="cB" angle="1.9561650256352445" k="534.96624" />
+    <Angle class1="cA" class2="cA" class3="nN" angle="1.9570376902612416" k="551.0328" />
+    <Angle class1="cA" class2="nN" class3="cC" angle="2.117957047295119" k="534.88256" />
+    <Angle class1="cA" class2="nN" class3="hN" angle="2.0381955004789782" k="385.26272" />
+    <Angle class1="cC" class2="nN" class3="hN" angle="2.0675170319124825" k="411.78928" />
+    <Angle class1="cD" class2="cC" class3="nN" angle="2.0097466336714707" k="567.85248" />
+    <Angle class1="hE" class2="cA" class3="nN" angle="1.907993938280201" k="416.89376000000004" />
+    <Angle class1="nN" class2="cC" class3="oC" angle="2.12982528620868" k="634.54544" />
+    <Angle class1="cB" class2="cA" class3="oH" angle="1.9235273686229506" k="570.53024" />
+    <Angle class1="cB" class2="cA" class3="hE" angle="1.9278906917529364" k="393.54704000000004" />
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce ordering="amber">
+    <Proper class1="cD" class2="cD" class3="cD" class4="cD" periodicity1="5" phase1="0.0" k1="0.41840000000000005" periodicity2="4" phase2="0.0" k2="0.41840000000000005" periodicity3="3" phase3="0.0" k3="1.2552" periodicity4="2" phase4="0.0" k4="0.41840000000000005" periodicity5="1" phase5="0.0" k5="0.41840000000000005" />
+    <Proper class1="cA" class2="oT" class3="pA" class4="oP" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="0.0" periodicity4="2" phase4="0.0" k4="0.8368000000000001" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="hE" class2="cA" class3="oT" class4="pA" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="1.6024720000000001" periodicity4="2" phase4="0.0" k4="0.0" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="oS" class2="cA" class3="cA" class4="cA" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="0.0" periodicity4="2" phase4="0.0" k4="0.0" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="oT" class2="cA" class3="cA" class4="oS" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="0.0" periodicity4="2" phase4="0.0" k4="0.0" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="cC" class2="oS" class3="cA" class4="cA" periodicity1="3" phase1="5.235987755982989" k1="-0.8368000000000001" periodicity2="2" phase2="4.1887902047863905" k2="-1.2552" periodicity3="1" phase3="0.0" k3="-0.41840000000000005" />
+    <Proper class1="oS" class2="cA" class3="cA" class4="oS" periodicity1="3" phase1="0.0" k1="4.184" periodicity2="2" phase2="0.0" k2="1.2552" periodicity3="1" phase3="3.141592653589793" k3="-0.41840000000000005" />
+    <Proper class1="cA" class2="oT" class3="pA" class4="oT" periodicity1="3" phase1="0.0" k1="2.5104" periodicity2="2" phase2="0.0" k2="9.623199999999999" />
+    <Proper class1="cA" class2="cA" class3="oT" class4="pA" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="2" phase2="3.141592653589793" k2="-3.3472000000000004" />
+    <Proper class1="cA" class2="cA" class3="cA" class4="oT" periodicity1="3" phase1="1.0471975511965976" k1="1.6736000000000002" periodicity2="2" phase2="2.0943951023931953" k2="0.8368000000000001" periodicity3="1" phase3="3.141592653589793" k3="3.3472000000000004" />
+    <Proper class1="nA" class2="cA" class3="cA" class4="oT" periodicity1="3" phase1="0.0" k1="4.184" />
+    <Proper class1="cD" class2="cB" class3="cB" class4="cD" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="2.5104" periodicity4="2" phase4="3.141592653589793" k4="13.8072" periodicity5="1" phase5="3.141592653589793" k5="7.1128" />
+    <Proper class1="cA" class2="cB" class3="cB" class4="cA" periodicity1="2" phase1="3.141592653589793" k1="27.823600000000003" periodicity2="1" phase2="3.141592653589793" k2="7.9496" />
+    <Proper class1="cD" class2="cB" class3="cB" class4="cA" periodicity1="2" phase1="3.141592653589793" k1="27.823600000000003" periodicity2="1" phase2="3.141592653589793" k2="7.9496" />
+    <Proper class1="cB" class2="cB" class3="cD" class4="cD" periodicity1="5" phase1="3.141592653589793" k1="0.8368000000000001" periodicity2="4" phase2="3.141592653589793" k2="0.8368000000000001" periodicity3="3" phase3="3.141592653589793" k3="1.6736000000000002" periodicity4="2" phase4="3.141592653589793" k4="1.6736000000000002" periodicity5="1" phase5="0.0" k5="2.5104" />
+    <Proper class1="cA" class2="cA" class3="cB" class4="cB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cB" class2="cD" class3="cD" class4="cD" periodicity1="5" phase1="0.0" k1="0.41840000000000005" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="2.092" periodicity4="2" phase4="0.0" k4="0.0" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="cB" class2="cA" class3="cA" class4="cA" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="0.0" periodicity4="2" phase4="0.0" k4="0.0" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="cD" class2="cD" class3="cC" class4="oC" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="cD" class2="cD" class3="cC" class4="oS" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="cD" class2="cC" class3="oS" class4="cA" periodicity1="2" phase1="3.141592653589793" k1="11.296800000000001" />
+    <Proper class1="cC" class2="cD" class3="cD" class4="cD" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="cA" class2="cA" class3="nA" class4="cA" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="cA" class2="oS" class3="cC" class4="oC" periodicity1="2" phase1="3.141592653589793" k1="11.296800000000001" periodicity2="1" phase2="3.141592653589793" k2="5.8576" />
+    <Proper class1="hL" class2="cD" class3="cC" class4="oC" periodicity1="3" phase1="3.141592653589793" k1="0.33472" periodicity2="1" phase2="0.0" k2="3.3472000000000004" />
+    <Proper class1="hL" class2="cD" class3="cC" class4="oS" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="hL" class2="cD" class3="cD" class4="hL" periodicity1="3" phase1="0.0" k1="0.6276" />
+    <Proper class1="hL" class2="cD" class3="cD" class4="cC" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="hL" class2="cD" class3="cD" class4="cD" periodicity1="3" phase1="0.0" k1="0.66944" />
+    <Proper class1="hX" class2="cA" class3="nA" class4="cA" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="hX" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="nA" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="oT" class2="cA" class3="cA" class4="hX" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="oS" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="hE" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="oT" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046" />
+    <Proper class1="hE" class2="cA" class3="oS" class4="cC" periodicity1="3" phase1="0.0" k1="1.6024720000000001" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="cA" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="cD" class2="cD" class3="cB" class4="hB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="hB" class2="cB" class3="cD" class4="hL" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cB" class2="cD" class3="cD" class4="hL" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cD" class2="cB" class3="cB" class4="hB" periodicity1="2" phase1="3.141592653589793" k1="27.823600000000003" />
+    <Proper class1="cB" class2="cB" class3="cD" class4="hL" periodicity1="3" phase1="3.141592653589793" k1="1.58992" periodicity2="1" phase2="0.0" k2="4.811599999999999" />
+    <Proper class1="hB" class2="cB" class3="cB" class4="hB" periodicity1="2" phase1="3.141592653589793" k1="27.823600000000003" />
+    <Proper class1="cC" class2="cA" class3="nA" class4="hN" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="nA" class2="cA" class3="cC" class4="oO" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="hN" class2="nA" class3="cA" class4="hX" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="hX" class2="cA" class3="cC" class4="oO" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="cC" class2="cA" class3="cA" class4="hE" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cA" class2="cA" class3="nA" class4="hN" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cA" class2="cA" class3="cC" class4="oO" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="cC" class2="cA" class3="cA" class4="oT" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="hE" class2="cA" class3="oH" class4="hO" periodicity1="3" phase1="0.0" k1="2.092" />
+    <Proper class1="cA" class2="cA" class3="oH" class4="hO" periodicity1="3" phase1="0.0" k1="0.66944" periodicity2="1" phase2="0.0" k2="1.046" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="oH" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046" />
+    <Proper class1="cA" class2="cA" class3="cA" class4="oH" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="oH" class2="cA" class3="cA" class4="oT" periodicity1="3" phase1="0.0" k1="0.602496" periodicity2="2" phase2="0.0" k2="4.916200000000001" />
+    <Proper class1="oH" class2="cA" class3="cA" class4="oH" periodicity1="3" phase1="0.0" k1="0.602496" periodicity2="2" phase2="0.0" k2="4.916200000000001" />
+    <Proper class1="cA" class2="oT" class3="pA" class4="oH" periodicity1="3" phase1="0.0" k1="1.046" periodicity2="2" phase2="0.0" k2="5.0208" />
+    <Proper class1="hO" class2="oH" class3="pA" class4="oT" periodicity1="3" phase1="0.0" k1="2.2313272" />
+    <Proper class1="hO" class2="oH" class3="pA" class4="oP" periodicity1="3" phase1="0.0" k1="2.2313272" />
+    <Proper class1="cB" class2="cB" class3="cD" class4="cB" periodicity1="5" phase1="0.0" k1="0.0" periodicity2="4" phase2="0.0" k2="0.0" periodicity3="3" phase3="0.0" k3="0.0" periodicity4="2" phase4="0.0" k4="0.0" periodicity5="1" phase5="0.0" k5="0.0" />
+    <Proper class1="cB" class2="cD" class3="cB" class4="hB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cA" class2="cA" class3="cA" class4="cA" periodicity1="3" phase1="0.0" k1="0.75312" periodicity2="2" phase2="3.141592653589793" k2="1.046" periodicity3="1" phase3="3.141592653589793" k3="0.8368000000000001" />
+    <Proper class1="cA" class2="cA" class3="cA" class4="cD" periodicity1="3" phase1="0.0" k1="0.75312" periodicity2="2" phase2="3.141592653589793" k2="1.046" periodicity3="1" phase3="3.141592653589793" k3="0.8368000000000001" />
+    <Proper class1="cA" class2="cA" class3="cD" class4="cD" periodicity1="3" phase1="0.0" k1="0.75312" periodicity2="2" phase2="3.141592653589793" k2="1.046" periodicity3="1" phase3="3.141592653589793" k3="0.8368000000000001" />
+    <Proper class1="cA" class2="cD" class3="cD" class4="cD" periodicity1="3" phase1="0.0" k1="0.75312" periodicity2="2" phase2="3.141592653589793" k2="1.046" periodicity3="1" phase3="3.141592653589793" k3="0.8368000000000001" />
+    <Proper class1="cA" class2="cA" class3="cA" class4="hA" periodicity1="3" phase1="0.0" k1="0.66944" />
+    <Proper class1="cD" class2="cA" class3="cA" class4="hA" periodicity1="3" phase1="0.0" k1="0.66944" />
+    <Proper class1="cA" class2="cA" class3="cD" class4="hL" periodicity1="3" phase1="0.0" k1="0.66944" />
+    <Proper class1="hA" class2="cA" class3="cA" class4="hA" periodicity1="3" phase1="0.0" k1="0.6276" />
+    <Proper class1="hA" class2="cA" class3="cD" class4="hL" periodicity1="3" phase1="0.0" k1="0.6276" />
+    <Proper class1="cD" class2="cD" class3="cA" class4="hA" periodicity1="3" phase1="0.0" k1="0.66944" />
+    <Proper class1="cA" class2="cD" class3="cD" class4="hL" periodicity1="3" phase1="0.0" k1="0.66944" />
+    <Proper class1="cA" class2="cA" class3="cB" class4="cA" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cA" class2="cB" class3="cB" class4="hB" periodicity1="2" phase1="3.141592653589793" k1="27.823600000000003" />
+    <Proper class1="hA" class2="cA" class3="cB" class4="hB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cA" class2="cA" class3="cB" class4="hB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cB" class2="cA" class3="cA" class4="hA" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cB" class2="cA" class3="cA" class4="oH" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cB" class2="cB" class3="cA" class4="hA" periodicity1="3" phase1="3.141592653589793" k1="1.58992" periodicity2="1" phase2="0.0" k2="4.811599999999999" />
+    <Proper class1="hA" class2="cA" class3="cA" class4="oH" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046" />
+    <Proper class1="cA" class2="cB" class3="cA" class4="hA" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="hA" class2="cA" class3="cA" class4="hE" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cB" class2="cA" class3="cA" class4="hE" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Proper class1="cA" class2="cA" class3="nN" class4="cC" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cA" class2="cA" class3="nN" class4="hN" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cA" class2="nN" class3="cC" class4="cD" periodicity1="2" phase1="3.141592653589793" k1="10.46" />
+    <Proper class1="cA" class2="nN" class3="cC" class4="oC" periodicity1="2" phase1="3.141592653589793" k1="10.46" />
+    <Proper class1="cB" class2="cA" class3="cA" class4="nN" periodicity1="3" phase1="0.0" k1="10.0416" periodicity2="2" phase2="3.141592653589793" k2="5.4392000000000005" periodicity3="1" phase3="1.0471975511965976" k3="1.6736000000000002" />
+    <Proper class1="cC" class2="nN" class3="cA" class4="hE" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cD" class2="cC" class3="nN" class4="hN" periodicity1="2" phase1="3.141592653589793" k1="10.46" />
+    <Proper class1="cD" class2="cD" class3="cC" class4="nN" periodicity1="2" phase1="3.141592653589793" k1="0.0" />
+    <Proper class1="hE" class2="cA" class3="cA" class4="nN" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="hE" class2="cA" class3="nN" class4="hN" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="hL" class2="cD" class3="cC" class4="nN" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="hN" class2="nN" class3="cC" class4="oC" periodicity1="2" phase1="3.141592653589793" k1="10.46" />
+    <Proper class1="nN" class2="cA" class3="cA" class4="oH" periodicity1="3" phase1="0.0" k1="0.6527040000000001" />
+    <Proper class1="nN" class2="cA" class3="cA" class4="oT" periodicity1="3" phase1="0.0" k1="0.0" />
+    <Proper class1="cB" class2="cA" class3="oH" class4="hO" periodicity1="3" phase1="0.0" k1="0.66944" periodicity2="1" phase2="0.0" k2="1.046" />
+    <Proper class1="cB" class2="cB" class3="cA" class4="oH" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="hE" class2="cA" class3="cB" class4="cB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="hE" class2="cA" class3="cB" class4="hB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="oH" class2="cA" class3="cB" class4="hB" periodicity1="2" phase1="0.0" k1="0.0" />
+    <Proper class1="cC" class2="cD" class3="cD" class4="cB" periodicity1="3" phase1="0.0" k1="0.6510304" />
+    <Improper class1="cB" class2="cA" class3="cA" class4="cB" periodicity1="2" phase1="3.141592653589793" k1="4.6024" />
+    <Improper class1="cB" class2="cA" class3="cB" class4="hB" periodicity1="2" phase1="3.141592653589793" k1="4.6024" />
+    <Improper class1="nN" class2="cA" class3="cC" class4="hN" periodicity1="2" phase1="3.141592653589793" k1="4.6024" />
+    <Improper class1="cC" class2="cA" class3="oO" class4="oO" periodicity1="2" phase1="3.141592653589793" k1="4.6024" />
+    <Improper class1="cB" class2="cB" class3="cD" class4="hB" periodicity1="2" phase1="3.141592653589793" k1="4.6024" />
+    <Improper class1="cC" class2="cD" class3="nN" class4="oC" periodicity1="2" phase1="3.141592653589793" k1="4.6024" />
+    <Improper class1="cC" class2="cD" class3="oC" class4="oS" periodicity1="2" phase1="3.141592653589793" k1="43.932" />
+  </PeriodicTorsionForce>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge" />
+    <Atom class="cA" sigma="0.3399669508423535" epsilon="0.4577296" />
+    <Atom class="cB" sigma="0.3399669508423535" epsilon="0.359824" />
+    <Atom class="cC" sigma="0.3399669508423535" epsilon="0.359824" />
+    <Atom class="cD" sigma="0.3399669508423535" epsilon="0.4577296" />
+    <Atom class="hA" sigma="0.2649532787749369" epsilon="0.06568879999999999" />
+    <Atom class="hB" sigma="0.22272467953508485" epsilon="0.029288" />
+    <Atom class="hE" sigma="0.2471353044121301" epsilon="0.06568879999999999" />
+    <Atom class="hL" sigma="0.26014242569697904" epsilon="0.04184" />
+    <Atom class="hN" sigma="0.10690784617684071" epsilon="0.06568879999999999" />
+    <Atom class="hO" sigma="0.10690784617684071" epsilon="0.06568879999999999" />
+    <Atom class="hX" sigma="0.19599771799087468" epsilon="0.06568879999999999" />
+    <Atom class="nA" sigma="0.3249998523775958" epsilon="0.7112800000000001" />
+    <Atom class="nN" sigma="0.3249998523775958" epsilon="0.7112800000000001" />
+    <Atom class="oC" sigma="0.2959921901149463" epsilon="0.87864" />
+    <Atom class="oH" sigma="0.3066473387839048" epsilon="0.8803136" />
+    <Atom class="oO" sigma="0.2959921901149463" epsilon="0.87864" />
+    <Atom class="oP" sigma="0.2959921901149463" epsilon="0.87864" />
+    <Atom class="oS" sigma="0.3000012343465779" epsilon="0.7112800000000001" />
+    <Atom class="oT" sigma="0.3000012343465779" epsilon="0.7112800000000001" />
+    <Atom class="pA" sigma="0.37417746161894255" epsilon="0.8368000000000001" />
+  </NonbondedForce>
+  <Script>
+import openmm
+import openmm.unit
+
+scee_table = {
+}
+scnb_table = {
+    ('cD', 'cD', 'cD', 'cD'): 6.0,
+}
+
+atom_types = [data.atomType[atom] for atom in data.atoms]
+overridden_pairs = {}
+for atom_1, atom_2, atom_3, atom_4 in data.propers:
+    types_key = (atom_types[atom_1], atom_types[atom_2], atom_types[atom_3], atom_types[atom_4])
+    pairs_key = (min(atom_1, atom_4), max(atom_1, atom_4))
+    if types_key in scee_table:
+        overridden_pairs.setdefault(pairs_key, [1.2, 2.0])[0] = scee_table[types_key]
+    if types_key in scnb_table:
+        overridden_pairs.setdefault(pairs_key, [1.2, 2.0])[1] = scnb_table[types_key]
+
+for force in sys.getForces():
+    if isinstance(force, openmm.NonbondedForce):
+        charges, sigmas, epsilons = zip(*(force.getParticleParameters(index) for index in range(force.getNumParticles())))
+        for index in range(force.getNumExceptions()):
+            atom_1, atom_4, charge_prod, sigma, epsilon = force.getExceptionParameters(index)
+            if charge_prod or epsilon:
+                pairs_key = (min(atom_1, atom_4), max(atom_1, atom_4))
+                if pairs_key in overridden_pairs:
+                    scee, scnb = overridden_pairs[pairs_key]
+                    force.setExceptionParameters(index, atom_1, atom_4, charges[atom_1] * charges[atom_4] / scee, (sigmas[atom_1] + sigmas[atom_4]) / 2, openmm.unit.sqrt(epsilons[atom_1] * epsilons[atom_4]) / scnb)
+</Script>
+</ForceField>


### PR DESCRIPTION
Adds Lipid21 from https://github.com/openmm/openmmforcefields/pull/390.  (Presumably we shouldn't merge this PR before that one.)  In addition to adding Amber19 to the Modeller test, I've also manually checked that the updated `amber19-all.xml` can be used to add membranes of all Modeller-supported types, and to set up a stable membrane protein simulation.