### PR TITLE
Fixed bug in calculating plasma self energy correction with offsets

### DIFF
--- a/platforms/common/src/CommonCalcNonbondedForce.cpp
+++ b/platforms/common/src/CommonCalcNonbondedForce.cpp
@@ -317,6 +317,7 @@ void CommonCalcNonbondedForceKernel::commonInitialize(const System& system, cons
     paramsDefines["ONE_4PI_EPS0"] = cc.doubleToString(ONE_4PI_EPS0);
     paramsDefines["EPSILON0"] = cc.doubleToString(EPSILON0);
     paramsDefines["WORK_GROUP_SIZE"] = cc.intToString(cc.ThreadBlockSize);
+    paramsDefines["CHARGE_BUFFER_SIZE"] = cc.intToString(cc.getNumThreadBlocks());
     hasOffsets = (force.getNumParticleParameterOffsets() > 0 || force.getNumExceptionParameterOffsets() > 0);
     if (hasOffsets)
         paramsDefines["HAS_OFFSETS"] = "1";

--- a/platforms/common/src/kernels/nonbondedParameters.cc
+++ b/platforms/common/src/kernels/nonbondedParameters.cc
@@ -115,7 +115,7 @@ KERNEL void computePlasmaCorrection(GLOBAL real* RESTRICT chargeBuffer, GLOBAL m
         real alpha, real volume) {
     LOCAL real temp[WORK_GROUP_SIZE];
     real sum = 0;
-    for (unsigned int index = LOCAL_ID; index < NUM_GROUPS; index += LOCAL_SIZE)
+    for (unsigned int index = LOCAL_ID; index < CHARGE_BUFFER_SIZE; index += LOCAL_SIZE)
         sum += chargeBuffer[index];
     temp[LOCAL_ID] = sum;
     for (int i = 1; i < WORK_GROUP_SIZE; i *= 2) {


### PR DESCRIPTION
Fixes #5067.  On the GPU platforms, if a NonbondedForce used PME and included parameter offsets, the neutralizing plasma self energy would be computed incorrectly.