### PR TITLE
Bug fix to QTBIntegrator

### DIFF
--- a/platforms/common/src/CommonIntegrateQTBStepKernel.cpp
+++ b/platforms/common/src/CommonIntegrateQTBStepKernel.cpp
@@ -121,10 +121,8 @@ void CommonIntegrateQTBStepKernel::execute(ContextImpl& context, const QTBIntegr
             kernel1->addArg(dt);
         else
             kernel1->addArg((float) dt);
-        kernel1->addArg();
         kernel1->addArg(cc.getVelm());
         kernel1->addArg(cc.getLongForceBuffer());
-        kernel1->addArg(segmentVelocity);
         kernel1->addArg(cc.getAtomIndexArray());
         kernel2->addArg(numAtoms);
         if (useDouble) {
@@ -140,6 +138,7 @@ void CommonIntegrateQTBStepKernel::execute(ContextImpl& context, const QTBIntegr
         kernel2->addArg(integration.getPosDelta());
         kernel2->addArg(oldDelta);
         kernel2->addArg(randomForce);
+        kernel2->addArg(segmentVelocity);
         kernel2->addArg(cc.getAtomIndexArray());
         kernel3->addArg(numAtoms);
         if (useDouble)
@@ -217,7 +216,6 @@ void CommonIntegrateQTBStepKernel::execute(ContextImpl& context, const QTBIntegr
 
     // Perform the integration.
 
-    kernel1->setArg(3, stepIndex);
     kernel2->setArg(3, stepIndex);
     kernel1->execute(numAtoms);
     integration.applyVelocityConstraints(integrator.getConstraintTolerance());

--- a/platforms/reference/src/SimTKReference/ReferenceQTBDynamics.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceQTBDynamics.cpp
@@ -75,7 +75,6 @@ ReferenceQTBDynamics::~ReferenceQTBDynamics() {
 
 void ReferenceQTBDynamics::updatePart1(int numParticles, vector<Vec3>& velocities, vector<Vec3>& forces) {
     for (int i = 0; i < numParticles; i++) {
-        segmentVelocity[i*segmentLength+stepIndex] = velocities[i];
         if (inverseMasses[i] != 0.0)
             velocities[i] += (getDeltaT()*inverseMasses[i])*forces[i];
     }
@@ -86,11 +85,14 @@ void ReferenceQTBDynamics::updatePart2(int numParticles, vector<Vec3>& atomCoord
     const double dt = getDeltaT();
     const double halfdt = 0.5*dt;
     const double vscale = exp(-dt*friction);
+    const double halfvscale = exp(-halfdt*friction);
 
     for (int i = 0; i < numParticles; i++) {
         if (inverseMasses[i] != 0.0) {
+            Vec3 dv = inverseMasses[i]*dt*randomForce[segmentLength*i+stepIndex];
+            segmentVelocity[i*segmentLength+stepIndex] = halfvscale*velocities[i] + 0.5*dv;
             xPrime[i] = atomCoordinates[i] + velocities[i]*halfdt;
-            velocities[i] = vscale*velocities[i] + inverseMasses[i]*dt*randomForce[segmentLength*i+stepIndex];
+            velocities[i] = vscale*velocities[i] + dv;
             xPrime[i] = xPrime[i] + velocities[i]*halfdt;
             oldx[i] = xPrime[i];
         }


### PR DESCRIPTION
This fixes a subtle bug: it needs to record the velocities half way through the step instead of at the beginning.  This caused the adaptation mechanism to produce incorrect results at high frequencies.