### PR TITLE
Install benchmarks and extras

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,3 +2,5 @@
 
 ADD_SUBDIRECTORY(cpp-examples)
 ADD_SUBDIRECTORY(python-examples)
+INSTALL(DIRECTORY benchmarks DESTINATION examples)
+INSTALL(DIRECTORY extras DESTINATION examples)


### PR DESCRIPTION
A side effect of reorganizing the examples directory is that some of its subdirectories don't get installed.  That breaks the conda builds, which run the benchmark script as a test.  This fixes it.