### PR TITLE
Fix compilation error on CUDA 13

### DIFF
--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -142,7 +142,13 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
             else
                 flags += CU_CTX_SCHED_SPIN;
 
-            if (cuCtxCreate(&context, flags, device) == CUDA_SUCCESS) {
+#if CUDA_VERSION < 13000
+            CUresult result = cuCtxCreate(&context, flags, device);
+#else
+            CUctxCreateParams params = {};
+            CUresult result = cuCtxCreate(&context, &params, flags, device);
+#endif
+            if (result == CUDA_SUCCESS) {
                 this->deviceIndex = trialDeviceIndex;
                 CUcontext popped;
                 cuCtxPopCurrent(&popped);


### PR DESCRIPTION
CUDA 13 changed a function signature in a way that broke source compatibility.