### PR TITLE
Update runner used for Intel Mac CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,7 @@ jobs:
 
           - name: MacOS Intel Python 3.13
             python-version: "3.13"
-            os: macos-13
+            os: macos-15-intel
             env: macos
             OPENCL: false
             cuda-version: ""


### PR DESCRIPTION
Github is getting ready to shut down the runner we use for Intel Mac CI builds.  This updates it to a newer one.