### PR TITLE
Fixed errors in computeCurrentPressure()

### DIFF
--- a/platforms/common/src/kernels/monteCarloBarostat.cc
+++ b/platforms/common/src/kernels/monteCarloBarostat.cc
@@ -79,7 +79,7 @@ KERNEL void computeMolecularKineticEnergy(int numMolecules, GLOBAL mixed4* RESTR
             molVel += mass*trimTo3(v);
             molMass += mass;
         }
-        molVel *= RECIP((mixed) molMass);
+        molVel *= (molMass == 0 ? 0 : RECIP((mixed) molMass));
 #if COMPONENTS == 1
         ke[0] += 0.5f*molMass*dot(molVel, molVel);
 #else

--- a/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
@@ -133,7 +133,8 @@ void ReferenceMonteCarloBarostat::computeMolecularKineticEnergy(const vector<Vec
             molVel += masses[atom]*velocities[atom];
             molMass += masses[atom];
         }
-        molVel /= molMass;
+        if (molMass != 0)
+            molVel /= molMass;
         if (components == 1)
             ke[0] += 0.5*molMass*molVel.dot(molVel);
         else {

--- a/tests/TestMonteCarloBarostat.h
+++ b/tests/TestMonteCarloBarostat.h
@@ -164,9 +164,18 @@ void testMolecularGas() {
     OpenMM_SFMT::SFMT sfmt;
     init_gen_rand(0, sfmt);
     for (int i = 0; i < numMolecules; ++i) {
-        system.addParticle(1.0);
-        system.addParticle(2.0);
-        system.addParticle(3.0);
+        if (i == 0) {
+            // Make one molecule massless to make sure that doesn't cause any problems.
+
+            system.addParticle(0.0);
+            system.addParticle(0.0);
+            system.addParticle(0.0);
+        }
+        else {
+            system.addParticle(1.0);
+            system.addParticle(2.0);
+            system.addParticle(3.0);
+        }
         Vec3 pos(initialLength*genrand_real2(sfmt), 0.5*initialLength*genrand_real2(sfmt), 2*initialLength*genrand_real2(sfmt));
         bonds->addBond(positions.size(), positions.size()+1, 0.1, 10.0);
         system.addConstraint(positions.size(), positions.size()+2, 0.1);

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -493,6 +493,7 @@ UNITS = {
 ("MonteCarloMembraneBarostat", "MonteCarloMembraneBarostat") : (None, ("unit.bar", "unit.bar*unit.nanometer", "unit.kelvin", None, None, None)),
 ("MonteCarloMembraneBarostat", "getXYMode") : (None, ()),
 ("MonteCarloMembraneBarostat", "getZMode") : (None, ()),
+("*", "computeCurrentPressure") : ("unit.bar", ()),
 ("CustomIntegrator", "CustomIntegrator") : (None, ("unit.picosecond",)),
 ("BrownianIntegrator", "BrownianIntegrator") : (None, ("unit.kelvin", "unit.picosecond**-1", "unit.picosecond")),
 ("LangevinIntegrator", "LangevinIntegrator") : (None, ("unit.kelvin", "unit.picosecond**-1", "unit.picosecond")),


### PR DESCRIPTION
This fixes two problems in `computeCurrentPressure()`.  First, if the system contained any massless molecule it would return nan.  Second, the Python API was not adding units to the return values.

Fixes #5113.