### PR TITLE
Avoid incorrectly adding plasma correction

### DIFF
--- a/platforms/common/src/CommonCalcNonbondedForce.cpp
+++ b/platforms/common/src/CommonCalcNonbondedForce.cpp
@@ -909,7 +909,7 @@ double CommonCalcNonbondedForceKernel::execute(ContextImpl& context, bool includ
             // The Ewald self energy was computed in the kernel.
 
             energy = 0.0;
-            if (pmeGrid1.isInitialized() || cosSinSums.isInitialized()) {
+            if ((pmeGrid1.isInitialized() || cosSinSums.isInitialized()) && includeReciprocal) {
                 // Invoke a kernel to compute the correction for the neutralizing plasma.
 
                 Vec3 a, b, c;


### PR DESCRIPTION
This fixes an edge case in computing the neutralizing plasma self energy.  If a NonbondedForce included offsets, then the GPU platforms would always include the plasma self energy, even when you requested a different force group.

Fixes #5116.