### PR TITLE
Refactor reference PME

### DIFF
--- a/platforms/reference/include/ReferenceConstantPotential.h
+++ b/platforms/reference/include/ReferenceConstantPotential.h
@@ -90,14 +90,14 @@ public:
      * @param elecToSys              mapping from electrode particle indices to system particle indices
      * @param electrodeParamArray    electrode particle parameters
      * @param conp                   constant potential derivative evaluation class
-     * @param pmeData                reference PME solver
+     * @param pme                    reference PME solver
      */
     virtual void solve(int numParticles, int numElectrodeParticles,
         const std::vector<Vec3>& posData, std::vector<double>& charges,
         const std::vector<std::set<int>>& exclusions,
         const std::vector<int>& sysToElec, const std::vector<int>& elecToSys,
         const std::vector<std::array<double, 3> >& electrodeParamArray,
-        ReferenceConstantPotential& conp, pme_t pmeData) = 0;
+        ReferenceConstantPotential& conp, ReferencePME& pme) = 0;
 };
 
 /**
@@ -149,14 +149,14 @@ public:
      * @param elecToSys              mapping from electrode particle indices to system particle indices
      * @param electrodeParamArray    electrode particle parameters
      * @param conp                   constant potential derivative evaluation class
-     * @param pmeData                reference PME solver
+     * @param pme                    reference PME solver
      */
     void solve(int numParticles, int numElectrodeParticles,
         const std::vector<Vec3>& posData, std::vector<double>& charges,
         const std::vector<std::set<int>>& exclusions,
         const std::vector<int>& sysToElec, const std::vector<int>& elecToSys,
         const std::vector<std::array<double, 3> >& electrodeParamArray,
-        ReferenceConstantPotential& conp, pme_t pmeData);
+        ReferenceConstantPotential& conp, ReferencePME& pme);
 };
 
 /**
@@ -208,14 +208,14 @@ public:
      * @param elecToSys              mapping from electrode particle indices to system particle indices
      * @param electrodeParamArray    electrode particle parameters
      * @param conp                   constant potential derivative evaluation class
-     * @param pmeData                reference PME solver
+     * @param pme                    reference PME solver
      */
     void solve(int numParticles, int numElectrodeParticles,
         const std::vector<Vec3>& posData, std::vector<double>& charges,
         const std::vector<std::set<int>>& exclusions,
         const std::vector<int>& sysToElec, const std::vector<int>& elecToSys,
         const std::vector<std::array<double, 3> >& electrodeParamArray,
-        ReferenceConstantPotential& conp, pme_t pmeData);
+        ReferenceConstantPotential& conp, ReferencePME& pme);
 };
 
 /**
@@ -313,7 +313,7 @@ private:
      * @param elecToSys              mapping from electrode particle indices to system particle indices
      * @param electrodeParamArray    electrode particle parameters
      * @param energy                 output system energy
-     * @param pmeData                reference PME solver
+     * @param pme                    reference PME solver
      */
     void getEnergyForces(int numParticles, int numElectrodeParticles,
         const std::vector<Vec3>& posData, std::vector<Vec3>& forceData,
@@ -321,7 +321,7 @@ private:
         const std::vector<std::set<int>>& exclusions,
         const std::vector<int>& sysToElec, const std::vector<int>& elecToSys,
         const std::vector<std::array<double, 3> >& electrodeParamArray,
-        double* energy, pme_t pmeData);
+        double* energy, ReferencePME& pme);
     /**
      * Computes energy derivatives with respect to charges.
      * 
@@ -334,14 +334,14 @@ private:
      * @param elecToSys              mapping from electrode particle indices to system particle indices
      * @param electrodeParamArray    electrode particle parameters
      * @param chargeDerivatives      output charge derivatives
-     * @param pmeData                reference PME solver
+     * @param pme                    reference PME solver
      */
     void getDerivatives(int numParticles, int numElectrodeParticles,
         const std::vector<Vec3>& posData, std::vector<double>& charges,
         const std::vector<std::set<int>>& exclusions,
         const std::vector<int>& sysToElec, const std::vector<int>& elecToSys,
         const std::vector<std::array<double, 3> >& electrodeParamArray,
-        std::vector<double>& chargeDerivatives, pme_t pmeData);
+        std::vector<double>& chargeDerivatives, ReferencePME& pme);
 };
 
 } // namespace OpenMM

--- a/platforms/reference/include/ReferencePME.h
+++ b/platforms/reference/include/ReferencePME.h
@@ -1,7 +1,7 @@
 /* 
  * Reference implementation of PME reciprocal space interactions.
  * 
- * Copyright (c) 2009, Erik Lindahl, Rossen Apostolov, Szilard Pall
+ * Copyright (c) 2009-2025 Erik Lindahl, Rossen Apostolov, Szilard Pall, Peter Eastman
  * All rights reserved.
  * Contact: lindahl@cbr.su.se Stockholm University, Sweden.
  * 
@@ -34,101 +34,117 @@
 
 #include "openmm/Vec3.h"
 #include "openmm/internal/windowsExport.h"
+#include <array>
+#include <complex>
 #include <vector>
 
 namespace OpenMM {
 
-typedef double rvec[3];
+class OPENMM_EXPORT ReferencePME {
+public:
+    /*
+     * Initialize a PME calculation and set up data structures
+     *
+     * Arguments:
+     * 
+     * ewaldcoeff  Coefficient derived from the beta factor to participate
+     *             direct/reciprocal space. See gromacs code for documentation!
+     *             We assume that you are using nm units...
+     * natoms      Number of atoms to set up data structure sof
+     * ngrid       Size of the full pme grid
+     * pme_order   Interpolation order, almost always 4
+     * epsilon_r   Dielectric coefficient, typically 1.0.
+     */
+    ReferencePME(double ewaldcoeff, int natoms, const int ngrid[3], int pme_order, double epsilon_r);
 
+    /*
+     * Evaluate reciprocal space PME energy and forces.
+     *
+     * Args:
+     *
+     * atomCoordinates     Pointer to coordinate data array (nm)
+     * forces              Pointer to force data array (will be written as kJ/mol/nm)
+     * charges             Array of charges (units of e)
+     * periodicBoxVectors  Simulation cell dimensions (nm)
+     * energy              Total energy (will be written in units of kJ/mol)
+     */
+    void exec(const std::vector<OpenMM::Vec3>& atomCoordinates, std::vector<OpenMM::Vec3>& forces, const std::vector<double>& charges,
+            const OpenMM::Vec3 periodicBoxVectors[3], double& energy);
 
-typedef struct pme *
-pme_t;
+    /*
+     * Evaluate reciprocal space PME energy and charge derivatives.
+     *
+     * Args:
+     *
+     * atomCoordinates     Pointer to coordinate data array (nm)
+     * chargeDerivatives   Pointer to charge derivative data array (will be written as kJ/mol/e)
+     * chargeIndices       Pointer to array of indices of particles to compute charge derivatives for
+     * charges             Array of charges (units of e)
+     * periodicBoxVectors  Simulation cell dimensions (nm)
+     */
+    void exec_charge_derivatives(const std::vector<OpenMM::Vec3>& atomCoordinates, std::vector<double>& chargeDerivatives,
+            const std::vector<int>& chargeIndices, const std::vector<double>& charges, const OpenMM::Vec3 periodicBoxVectors[3]);
 
-/*
- * Initialize a PME calculation and set up data structures
- *
- * Arguments:
- * 
- * ppme        Pointer to an opaque pme_t object
- * ewaldcoeff  Coefficient derived from the beta factor to participate
- *             direct/reciprocal space. See gromacs code for documentation!
- *             We assume that you are using nm units...
- * natoms      Number of atoms to set up data structure sof
- * ngrid       Size of the full pme grid
- * pme_order   Interpolation order, almost always 4
- * epsilon_r   Dielectric coefficient, typically 1.0.
- */
-int OPENMM_EXPORT
-pme_init(pme_t* ppme,
-         double ewaldcoeff,
-         int natoms,
-         const int ngrid[3],
-         int pme_order,
-         double epsilon_r);
+    /**
+     * Evaluate reciprocal space PME dispersion energy and forces.
+     *
+     * Args:
+     *
+     * atomCoordinates     Pointer to coordinate data array (nm)
+     * forces              Pointer to force data array (will be written as kJ/mol/nm)
+     * c6s                 Array of c6 coefficients (units of sqrt(kJ/mol).nm^3 )
+     * periodicBoxVectors  Simulation cell dimensions (nm)
+     * energy              Total energy (will be written in units of kJ/mol)
+     */
+    void exec_dpme(const std::vector<OpenMM::Vec3>& atomCoordinates, std::vector<OpenMM::Vec3>& forces, const std::vector<double>& c6s,
+            const OpenMM::Vec3 periodicBoxVectors[3], double& energy);
+private:
+    void calculate_bsplines_moduli();
+    void update_grid_index_and_fraction(const std::vector<Vec3>& atomCoordinates, const Vec3 recipBoxVectors[3]);
+    void update_bsplines();
+    void grid_spread_charge(const std::vector<double>& charges);
+    void pme_reciprocal_convolution(const Vec3 periodicBoxVectors[3], const Vec3 recipBoxVectors[3], double& energy);
+    void dpme_reciprocal_convolution(const Vec3 periodicBoxVectors[3], const Vec3 recipBoxVectors[3], double& energy);
+    void grid_interpolate_force(const Vec3 recipBoxVectors[3], const std::vector<double>& charges, std::vector<Vec3>& forces);
+    void grid_interpolate_charge_derivatives(const Vec3 recipBoxVectors[3], const std::vector<double>& charges,
+            std::vector<double>& chargeDerivatives, const std::vector<int>& chargeIndices);
+    int natoms;
+    double ewaldcoeff;
+    std::vector<std::complex<double> > grid; /* Memory for the grid we spread charges on.
+                                              * Element (i,j,k) is accessed as:
+                                              * grid[i*ngrid[1]*ngrid[2] + j*ngrid[2] + k] */
+    int ngrid[3];             /* Total grid dimensions (all data is complex!) */
+    int order;                /* PME interpolation order. Almost always 4 */
 
-/*
- * Evaluate reciprocal space PME energy and forces.
- *
- * Args:
- *
- * pme                 Opaque pme_t object, must have been initialized with pme_init()
- * atomCoordinates     Pointer to coordinate data array (nm)
- * forces              Pointer to force data array (will be written as kJ/mol/nm)
- * charges             Array of charges (units of e)
- * periodicBoxVectors  Simulation cell dimensions (nm)
- * energy              Total energy (will be written in units of kJ/mol)
- */
-int OPENMM_EXPORT
-pme_exec(pme_t pme,
-         const std::vector<OpenMM::Vec3>& atomCoordinates,
-         std::vector<OpenMM::Vec3>& forces,
-         const std::vector<double>& charges,
-         const OpenMM::Vec3 periodicBoxVectors[3],
-         double* energy);
+    /* Data for bspline interpolation, see the Essman PME paper */
+    std::vector<double> bsplines_moduli[3];   /* 3 pointers, to x/y/z bspline moduli, each of length ngrid[x/y/z]   */
+    std::vector<double> bsplines_theta[3];    /* each of x/y/z has length order*natoms */
+    std::vector<double> bsplines_dtheta[3];   /* each of x/y/z has length order*natoms */
 
-/*
- * Evaluate reciprocal space PME energy and charge derivatives.
- *
- * Args:
- *
- * pme                 Opaque pme_t object, must have been initialized with pme_init()
- * atomCoordinates     Pointer to coordinate data array (nm)
- * chargeDerivatives   Pointer to charge derivative data array (will be written as kJ/mol/e)
- * chargeIndices       Pointer to array of indices of particles to compute charge derivatives for
- * charges             Array of charges (units of e)
- * periodicBoxVectors  Simulation cell dimensions (nm)
- */
-int OPENMM_EXPORT
-pme_exec_charge_derivatives(pme_t pme,
-                            const std::vector<OpenMM::Vec3>& atomCoordinates,
-                            std::vector<double>& chargeDerivatives,
-                            const std::vector<int>& chargeIndices,
-                            const std::vector<double>& charges,
-                            const OpenMM::Vec3 periodicBoxVectors[3]);
+    std::vector<std::array<int, 3> > particleindex; /* Array of length natoms. Each element is
+                                                     * three ints that specify the grid
+                                                     * indices for that particular atom. Updated every step! */
+    std::vector<Vec3> particlefraction; /* Array of length natoms. Fractional offset in the grid for
+                                         * each atom in all three dimensions. */
 
-/**
- * Evaluate reciprocal space PME dispersion energy and forces.
- *
- * Args:
- *
- * pme                 Opaque pme_t object, must have been initialized with pme_init()
- * atomCoordinates     Pointer to coordinate data array (nm)
- * forces              Pointer to force data array (will be written as kJ/mol/nm)
- * c6s                 Array of c6 coefficients (units of sqrt(kJ/mol).nm^3 )
- * periodicBoxVectors  Simulation cell dimensions (nm)
- * energy              Total energy (will be written in units of kJ/mol)
- */
-int OPENMM_EXPORT
-pme_exec_dpme(pme_t pme,
-              const std::vector<OpenMM::Vec3>& atomCoordinates,
-              std::vector<OpenMM::Vec3>& forces,
-              const std::vector<double>& c6s,
-              const OpenMM::Vec3 periodicBoxVectors[3],
-              double* energy);
+    /* Further explanation of index/fraction:
+     *
+     * Assume we have a cell of size 10*10*10nm, and a total grid dimension of 100*100*100 cells.
+     * In other words, each cell is 0.1*0.1*0.1 nm.
+     *
+     * If particle i has coordinates { 0.543 , 6.235 , -0.73 }, we will get:
+     *
+     * particleindex[i]    = { 5 , 62 , 92 }         (-0.73 + 10 = 9.27, we always apply PBC for grid calculations!)
+     * particlefraction[i] = { 0.43 , 0.35 , 0.7 }   (this is the fraction of the cell length where the atom is)
+     *
+     * (The reason for precaculating / storing these is that it gets a bit more complex for triclinic cells :-)
+     *
+     * In the current code version we might assume that a particle is not more than a whole box length away from
+     * the central cell, i.e., in this case we would assume all coordinates fall in -10 nm < x,y,z < 20 nm.
+     */
 
-/* Release all memory in pme structure */
-int OPENMM_EXPORT
-pme_destroy(pme_t    pme);
+    double epsilon_r; /* Dielectric coefficient to use, typically 1.0 */
+};
 
 } // namespace OpenMM
 

--- a/platforms/reference/tests/TestReferenceEwald.cpp
+++ b/platforms/reference/tests/TestReferenceEwald.cpp
@@ -59,14 +59,13 @@ void testReferencePmeDerivatives() {
     double ewaldAlpha = 1.752;
     int gridSize[3] = {54, 49, 43};
 
-    pme_t pme;
-    pme_init(&pme, ewaldAlpha, numParticles, gridSize, 5, 1);
+    ReferencePME pme(ewaldAlpha, numParticles, gridSize, 5, 1);
 
     double dummyEnergy=0;
     vector<Vec3> dummyForces(numParticles);
 
     vector<Vec3> testForces(numParticles);
-    pme_exec(pme, positions, testForces, charges, boxVectors, &dummyEnergy);
+    pme.exec(positions, testForces, charges, boxVectors, dummyEnergy);
 
     for (int i = 0; i < numParticles; i++) {
         for (int j = 0; j < 3; j++) {
@@ -74,11 +73,11 @@ void testReferencePmeDerivatives() {
 
             double energyLess = 0.0;
             positions[i][j] = referencePosition - DELTA;
-            pme_exec(pme, positions, dummyForces, charges, boxVectors, &energyLess);
+            pme.exec(positions, dummyForces, charges, boxVectors, energyLess);
 
             double energyMore = 0.0;
             positions[i][j] = referencePosition + DELTA;
-            pme_exec(pme, positions, dummyForces, charges, boxVectors, &energyMore);
+            pme.exec(positions, dummyForces, charges, boxVectors, energyMore);
 
             positions[i][j] = referencePosition;
 
@@ -87,25 +86,23 @@ void testReferencePmeDerivatives() {
     }
 
     vector<double> testDerivatives(numParticles);
-    pme_exec_charge_derivatives(pme, positions, testDerivatives, indices, charges, boxVectors);
+    pme.exec_charge_derivatives(positions, testDerivatives, indices, charges, boxVectors);
 
     for (int i = 0; i < numParticles; i++) {
         double referenceCharge = charges[i];
 
         double energyLess = 0.0;
         charges[i] = referenceCharge - DELTA;
-        pme_exec(pme, positions, dummyForces, charges, boxVectors, &energyLess);
+        pme.exec(positions, dummyForces, charges, boxVectors, energyLess);
 
         double energyMore = 0.0;
         charges[i] = referenceCharge + DELTA;
-        pme_exec(pme, positions, dummyForces, charges, boxVectors, &energyMore);
+        pme.exec(positions, dummyForces, charges, boxVectors, energyMore);
 
         charges[i] = referenceCharge;
 
         ASSERT_EQUAL_TOL((energyMore - energyLess) / (2 * DELTA), testDerivatives[i], EPSILON);
     }
-
-    pme_destroy(pme);
 }
 
 void runPlatformTests() {

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceHippoNonbondedForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceHippoNonbondedForce.cpp
@@ -2873,8 +2873,7 @@ double AmoebaReferencePmeHippoNonbondedForce::calculateDispersionPairIxn(const M
 }
 
 double AmoebaReferencePmeHippoNonbondedForce::computeReciprocalSpaceDispersionForceAndEnergy(const vector<MultipoleParticleData>& particleData, vector<Vec3>& forces) const {
-    pme_t pmedata;
-    pme_init(&pmedata, _dalphaEwald, _numParticles, _dpmeGridDimensions, 5, 1);
+    ReferencePME pme(_dalphaEwald, _numParticles, _dpmeGridDimensions, 5, 1);
     vector<double> charges(_numParticles);
     vector<Vec3> dpmeforces(_numParticles, Vec3()), coords;
     for (int i = 0; i < _numParticles; i++) {
@@ -2882,8 +2881,7 @@ double AmoebaReferencePmeHippoNonbondedForce::computeReciprocalSpaceDispersionFo
         coords.push_back(particleData[i].position);
     }
     double recipDispersionEnergy;
-    pme_exec_dpme(pmedata, coords, dpmeforces, charges, _periodicBoxVectors, &recipDispersionEnergy);
-    pme_destroy(pmedata);
+    pme.exec_dpme(coords, dpmeforces, charges, _periodicBoxVectors, recipDispersionEnergy);
     for (int i = 0; i < _numParticles; i++)
         forces[i] += dpmeforces[i];
     return recipDispersionEnergy;

--- a/plugins/cpupme/tests/TestCpuPme.cpp
+++ b/plugins/cpupme/tests/TestCpuPme.cpp
@@ -650,12 +650,10 @@ void testPME(bool triclinic, bool nonNeutral) {
 
     // Get charge derivatives from the reference PME implementation.
 
-    pme_t referencePme;
     int gridSize[3] = {gridx, gridy, gridz};
-    pme_init(&referencePme, alpha, numParticles, gridSize, 5, 1);
+    ReferencePME referencePme(alpha, numParticles, gridSize, 5, 1);
     vector<double> testDerivatives(numParticles);
-    pme_exec_charge_derivatives(referencePme, positions, testDerivatives, testIndices, testCharges, boxVectors);
-    pme_destroy(referencePme);
+    referencePme.exec_charge_derivatives(positions, testDerivatives, testIndices, testCharges, boxVectors);
 
     // See if they match.
     for (int i = 0; i < numParticles; i++) {


### PR DESCRIPTION
The reference PME implementation was originally adapted from Gromacs, and it was still mostly written in C.  This modernizes it and converts it to C++.  ReferencePME is now a class, memory management is done automatically, there are no more mallocs, etc.