### PR TITLE
Workaround for incorrect FFT results on Intel CPU OpenCL 2025.3

### DIFF
--- a/platforms/opencl/src/OpenCLFFT3D.cpp
+++ b/platforms/opencl/src/OpenCLFFT3D.cpp
@@ -59,6 +59,8 @@ OpenCLFFT3D::OpenCLFFT3D(OpenCLContext& context, int xsize, int ysize, int zsize
     if (platformVendor.size() >= 5 && platformVendor.substr(0, 5) == "Intel") {
         // Intel's OpenCL uses low accuracy trig functions, so tell VkFFT to use lookup tables instead.
         config.useLUT = 1;
+        // Version 2025.3 of Intel's OpenCL generates incorrect results when Y and Z sizes are 33 or 39; this is a workaround.
+        config.fixMinRaderPrimeMult = 11;
     }
     VkFFTResult result = initializeVkFFT(&app, config);
     if (result != VKFFT_SUCCESS)

--- a/platforms/opencl/tests/TestOpenCLFFT.cpp
+++ b/platforms/opencl/tests/TestOpenCLFFT.cpp
@@ -122,6 +122,9 @@ int main(int argc, char* argv[]) {
             testTransform<mm_double2>(true, 25, 28, 25);
             testTransform<mm_double2>(true, 25, 25, 28);
             testTransform<mm_double2>(true, 21, 25, 27);
+            testTransform<mm_double2>(true, 32, 33, 33);
+            testTransform<mm_double2>(true, 32, 33, 39);
+            testTransform<mm_double2>(true, 32, 39, 39);
         }
         else {
             testTransform<mm_float2>(false, 28, 25, 30);
@@ -129,6 +132,9 @@ int main(int argc, char* argv[]) {
             testTransform<mm_float2>(true, 25, 28, 25);
             testTransform<mm_float2>(true, 25, 25, 28);
             testTransform<mm_float2>(true, 21, 25, 27);
+            testTransform<mm_float2>(true, 32, 33, 33);
+            testTransform<mm_float2>(true, 32, 33, 39);
+            testTransform<mm_float2>(true, 32, 39, 39);
         }
     }
     catch(const exception& e) {


### PR DESCRIPTION
Fixes #5134.

I didn't add a check to try to test for the buggy versions.  There is theoretically a way to distinguish between them by calling `clGetDeviceInfo` with `CL_DRIVER_VERSION`, but the result doesn't correspond directly with the installed version of Intel OpenCL:

- Release `2025.2.1-7` returns `2025.20.8.0.06_160000`
- Release `2025.3.0-639` returns `2025.20.10.0.10_160000`
- Release `2025.3.1-760` returns `2025.20.10.0.23_160000`

Even if we assume that version `2025.20.10.0.*_*` and up are bad, we'd have to parse this string, which would break if Intel ever changes the format of it in the future.