### PR TITLE
Add pythonforce.i to SWIG input files.

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SWIG_INPUT_FILES2
     "${SWIG_OPENMM_DIR}/swig_lib/python/features.i"
     "${SWIG_OPENMM_DIR}/swig_lib/python/header.i"
     "${SWIG_OPENMM_DIR}/swig_lib/python/pythoncode.i"
+    "${SWIG_OPENMM_DIR}/swig_lib/python/pythonforce.i"
     "${SWIG_OPENMM_DIR}/swig_lib/python/typemaps.i"
 )
 


### PR DESCRIPTION
Added pythonforce.i to SWIG input files for Python. The lack of this file resulted in a failure when using single core compilation, as `pythonforce.i` could not be found.