### PR TITLE
Minor optimization to PME

### DIFF
--- a/platforms/common/src/kernels/pme.cc
+++ b/platforms/common/src/kernels/pme.cc
@@ -102,7 +102,7 @@ KERNEL void gridSpreadCharge(GLOBAL const real4* RESTRICT posq,
                 ybase = ybase*GRID_SIZE_Z;
                 int index = xbase + ybase + zindex;
                 real add = dzdx*data[iy].y;
-                if (add > 2.3e-10f || add < -2.3e-10f) { // Smallest value representable in 64 bit fixed point
+                if (fabs(add) > 2.3e-10f) { // Smallest value representable in 64 bit fixed point
 #ifdef USE_FIXED_POINT_CHARGE_SPREADING
                     ATOMIC_ADD(&pmeGrid[index], (mm_ulong) realToFixedPoint(add));
 #if defined(__GFX12__)


### PR DESCRIPTION
This avoids a few unnecessary atomic operations in charge spreading.  Running the standard benchmarks on RTX 4080, I get an overall speedup in the range of 1%.  Not a big deal, but still consistent improvement.