### PR TITLE
Fix uninitialized buffers in QTB

### DIFF
--- a/platforms/common/src/CommonIntegrateQTBStepKernel.cpp
+++ b/platforms/common/src/CommonIntegrateQTBStepKernel.cpp
@@ -51,7 +51,9 @@ void CommonIntegrateQTBStepKernel::initialize(const System& system, const QTBInt
     noise.upload(noiseVec);
     int elementSize = (cc.getUseMixedPrecision() || cc.getUseDoublePrecision() ? sizeof(double) : sizeof(float));
     randomForce.initialize(cc, 3*segmentLength*numParticles, elementSize, "randomForce");
+    cc.clearBuffer(randomForce);
     segmentVelocity.initialize(cc, 3*segmentLength*numParticles, elementSize, "segmentVelocity");
+    cc.clearBuffer(segmentVelocity);
     oldDelta.initialize(cc, cc.getPaddedNumAtoms(), 4*elementSize, "oldDelta");
     thetad.initialize(cc, numFreq, elementSize, "thetad");
     workspace.initialize(cc, 18*segmentLength*cc.getNumThreadBlocks(), elementSize, "workspace");


### PR DESCRIPTION
`adaptFrictionPart1` is executed first, it reads `randomForce` and `segmentVelocity` buffers before other kernels write them so they can contain garbage after allocation (cuMemAlloc/hipMalloc/clCreateBuffer do not clear allocated memory).

The errors are observed on HIP and OpenCL in `testRandomSeed` of TestQTBIntegrator:
```
 56/195 Test #342: TestHipQTBIntegratorSingle ....................***Failed   26.18 sec
exception: Assertion failure at TestQTBIntegrator.h:393.  Expected 1.94472, found 1.9414

176/195 Test #343: TestHipQTBIntegratorMixed .....................***Failed   26.40 sec
exception: Assertion failure at TestQTBIntegrator.h:393.  Expected 1.88941, found 1.94636

162/195 Test #344: TestHipQTBIntegratorDouble ....................***Failed   25.85 sec
exception: Assertion failure at TestQTBIntegrator.h:393.  Expected 1.9588, found 1.94636
```