### PR TITLE
Prevent running out of disk space in OpenCL CI build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -197,8 +197,6 @@ jobs:
         if: matrix.OPENCL == true && startsWith(matrix.os, 'ubuntu')
         run: |
           rm -rf /opt/hostedtoolcache/*
-          rm -rf /usr/local/.ghcup
-          rm -rf /usr/local/lib/android
 
       - name: "Install CUDA on Ubuntu (if needed)"
         if: matrix.cuda-version != '' && startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
The CPU OpenCL build has started running out of disk space.  This attempts to fix it.