### PR TITLE
Fix memory error in PythonForce

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythonforce.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythonforce.i
@@ -12,6 +12,10 @@ namespace OpenMM {
     class ComputationWrapper : public PythonForceComputation {
     public:
         ComputationWrapper(PyObject* computation) : computation(computation) {
+            Py_INCREF(computation);
+        }
+        ~ComputationWrapper() {
+            Py_XDECREF(computation);
         }
         void compute(const State& state, double& energy, void* forces, bool forcesAreDouble) const {
             PyGILState_STATE gstate;


### PR DESCRIPTION
PythonForce didn't prevent its computation function from being freed.  This could lead to various confusing errors.