### PR TITLE
Retry error when checking for broken links

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -666,12 +666,12 @@ jobs:
           )")
           for d in api-c++ api-python developerguide userguide; do
             echo "::group:: Check ${d}"
-            npx linkinator@3.0.0 ./${d}/ --recurse --timeout=20000 --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
+            npx linkinator@3.0.0 ./${d}/ --recurse --timeout=20000 --retry-errors --skip "$SKIP_REGEX" --server-root ./build/api-docs --verbosity error
             ((exitcode+=$?))
             echo "::endgroup::"
           done
           echo "::group:: Check README"
-          npx linkinator@3.0.0 ./README.md --markdown --skip "$SKIP_REGEX"
+          npx linkinator@3.0.0 ./README.md --markdown --retry-errors --skip "$SKIP_REGEX"
           ((exitcode+=$?))
           echo "::endgroup::"
           exit $exitcode


### PR DESCRIPTION
The docs CI build frequently fails while trying to check for broken links.  I think this is usually due to network errors.  This attempts to make it more reliable by rechecking them and only reporting an error if they fail repeately.