### PR TITLE
Avoid host wait for PME post-computation synchronization

### DIFF
--- a/platforms/common/src/CommonCalcNonbondedForce.cpp
+++ b/platforms/common/src/CommonCalcNonbondedForce.cpp
@@ -194,7 +194,9 @@ public:
     }
     double computeForceAndEnergy(bool includeForces, bool includeEnergy, int groups) {
         if ((groups&(1<<forceGroup)) != 0) {
-            event->wait();
+            // Keep the dependency on reciprocal-space work, but avoid stalling the host
+            // when the default queue can wait for the PME queue asynchronously.
+            event->queueWait(cc.getCurrentQueue());
             if (includeEnergy)
                 addEnergyKernel->execute(pmeEnergyBuffer.getSize());
         }

--- a/platforms/common/src/CommonCalcNonbondedForce.cpp
+++ b/platforms/common/src/CommonCalcNonbondedForce.cpp
@@ -194,8 +194,6 @@ public:
     }
     double computeForceAndEnergy(bool includeForces, bool includeEnergy, int groups) {
         if ((groups&(1<<forceGroup)) != 0) {
-            // Keep the dependency on reciprocal-space work, but avoid stalling the host
-            // when the default queue can wait for the PME queue asynchronously.
             event->queueWait(cc.getCurrentQueue());
             if (includeEnergy)
                 addEnergyKernel->execute(pmeEnergyBuffer.getSize());


### PR DESCRIPTION
This replaces the host-side wait in `SyncQueuePostComputation` with a queue-side wait.

When PME runs on a separate queue, the post-computation step only needs to ensure that later work on the default queue does not run until the PME queue has completed. Enqueuing a wait on the current queue preserves that dependency, while avoiding a CPU-side stall. The `addEnergy` kernel is still launched after the wait, so the PME energy buffer is not consumed until the reciprocal-space work has finished.

Before the common NonbondedForce implementation in #4922, the CUDA, HIP, and OpenCL implementations used queue/stream-side synchronization for this step (`cuStreamWaitEvent`, `hipStreamWaitEvent`, and an OpenCL barrier wait list). This change restores the same synchronization pattern through the common `ComputeEvent::queueWait()` API.