### PR TITLE
docs: document atom-to-particle index correspondence

### DIFF
--- a/wrappers/python/openmm/app/forcefield.py
+++ b/wrappers/python/openmm/app/forcefield.py
@@ -1286,6 +1286,12 @@ class ForceField(object):
         -------
         system
             the newly created System
+
+        Notes
+        -----
+        The constructed System contains one particle for each atom in the Topology,
+        and the particles are in the same order as the atoms.  An atom's index in the
+        Topology is therefore also the index of its corresponding particle in the System.
         """
         args['switchDistance'] = switchDistance
         args['flexibleConstraints'] = flexibleConstraints

--- a/wrappers/python/openmm/app/topology.py
+++ b/wrappers/python/openmm/app/topology.py
@@ -74,6 +74,10 @@ class Topology(object):
     pairs are bonded to each other, and the dimensions of the crystallographic unit cell.
 
     Atom and residue names should follow the PDB 3.0 nomenclature for all molecules for which one exists.
+
+    When a System is constructed from a Topology (for example with ForceField.createSystem()),
+    each atom is converted to a corresponding particle in the System.  The particles are in the
+    same order as the atoms, so an atom's index in the Topology is also the index of its particle.
     """
 
     _standardBonds = {}


### PR DESCRIPTION
Closes #3680. Documents that a System constructed from a Topology contains one particle per atom in the same order, so an atom's Topology index is also its particle index, addressing the maintainer's request: "Sounds good. I added the documentation label. A PR would be welcome!" The notes are added to ForceField.createSystem() and the Topology class docstrings as the reporter suggested.