### PR TITLE
Fix `AmoebaMultipoleForce::ForceInfo` particle groups used for molecule detection and atom reordering

### DIFF
--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
@@ -198,7 +198,7 @@ public:
         int particle = index / AmoebaMultipoleForce::CovalentEnd;
         int type = index - AmoebaMultipoleForce::CovalentEnd * particle;
         force.getCovalentMap(particle, AmoebaMultipoleForce::CovalentType(type), particles);
-        particles.insert(particles.begin(), particle);
+        particles.push_back(particle);
     }
     bool areGroupsIdentical(int group1, int group2) {
         return ((group1%AmoebaMultipoleForce::CovalentEnd) == (group2%AmoebaMultipoleForce::CovalentEnd));

--- a/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
+++ b/plugins/amoeba/platforms/common/src/AmoebaCommonKernels.cpp
@@ -192,15 +192,16 @@ public:
         return true;
     }
     int getNumParticleGroups() {
-        return 7*force.getNumMultipoles();
+        return AmoebaMultipoleForce::CovalentEnd * force.getNumMultipoles();
     }
     void getParticlesInGroup(int index, vector<int>& particles) {
-        int particle = index/7;
-        int type = index-7*particle;
+        int particle = index / AmoebaMultipoleForce::CovalentEnd;
+        int type = index - AmoebaMultipoleForce::CovalentEnd * particle;
         force.getCovalentMap(particle, AmoebaMultipoleForce::CovalentType(type), particles);
+        particles.insert(particles.begin(), particle);
     }
     bool areGroupsIdentical(int group1, int group2) {
-        return ((group1%7) == (group2%7));
+        return ((group1%AmoebaMultipoleForce::CovalentEnd) == (group2%AmoebaMultipoleForce::CovalentEnd));
     }
 private:
     const AmoebaMultipoleForce& force;


### PR DESCRIPTION
This PR fixes `AmoebaMultipoleForce::ForceInfo` so that molecule detection in `ComputeContext::findMoleculeGroups()` sees complete connectivity.

#Problem

`AmoebaMultipoleForce::ForceInfo::getParticlesInGroup()` currently returns only the covalent map entries, but omits the central particle. `findMoleculeGroups()` interprets each returned particle group as a connected chain and builds molecular connectivity from consecutive entries in that vector. Omitting the central particle can therefore split a real molecule into multiple connected components.

This becomes problematic on CUDA because `reorderAtoms()` reorders atoms by molecule. If molecule detection is wrong, atoms can be reordered across molecule boundaries, while precomputed exclusion tiles and covalent scaling tables still assume the original internal molecule structure.

Fixes #5300 

#Changes
- Replace hard-coded `7` with `AmoebaMultipoleForce::CovalentEnd`
- Include the central particle in `getParticlesInGroup()`

#Result
This restores correct molecule grouping and fixes the observed CPU/CUDA mismatch in our test case.