### PR TITLE
Handle hipErrorFileNotFound gracefully in ROCm 7

### DIFF
--- a/platforms/hip/src/HipContext.cpp
+++ b/platforms/hip/src/HipContext.cpp
@@ -184,7 +184,7 @@ HipContext::HipContext(const System& system, int deviceIndex, bool useBlockingSy
 
     hostMallocFlags = hipHostMallocDefault;
 #if !defined(WIN32)
-    // hipHostMallocNumaUser may not be allowed in some conditions, for example, if docker container 
+    // hipHostMallocNumaUser may not be allowed in some conditions, for example, if docker container
     // is created without --security-opt seccomp=unconfined or --cap-add=SYS_NICE
     int* tmpHostBuffer;
     if(hipHostMalloc(&tmpHostBuffer, sizeof(*tmpHostBuffer), hipHostMallocNumaUser) == hipSuccess) {
@@ -588,6 +588,16 @@ hipModule_t HipContext::createModule(const string source, const map<string, stri
     if (hipModuleLoad(&module, cacheFile.c_str()) == hipSuccess) {
         loadedModules.push_back(module);
         return module;
+    }
+    else {
+        // Need to call hipGetLastError to clear the error code
+        hipError_t last_error = hipGetLastError();
+        if (last_error != hipErrorFileNotFound) {
+            std::ostringstream msg;
+            msg << "Detected HIP error: " << hipGetErrorString(last_error)
+                << "(" << last_error << ") at " << __FILE__ << ":" << __LINE__;
+            throw OpenMMException(msg.str());
+        }
     }
 
     // Select names for the various temporary files.


### PR DESCRIPTION
Following [changes in ROCm 7](https://rocm.docs.amd.com/projects/HIP/en/docs-7.0.0/hip-7-changes.html#update-hipgetlasterror) to `hipGetLastError()`, we encountered an issue downstream wherein some other chunk of code was checking `hipGetLastError()` and getting tripped up on the (innocuous) `hipErrorFileNotFound` coming from the caching logic in `HipContext.cpp`. This checks `hipGetLastError()` for the `hipErrorFileNotFound` error, thereby clearing the error code, and raises a descriptive exception if any other error is found.