### PR TITLE
Fix MonteCarloFlexibleBarostat pressure for triclinic boxes

### DIFF
--- a/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
@@ -197,8 +197,16 @@ double MonteCarloFlexibleBarostatImpl::computePressureComponent(ContextImpl& con
     if (component < 3) {
         scale[component] = 1.0+delta;
         kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, scale[0], scale[1], scale[2]);
+
+        // A uniaxial strain along a Cartesian axis must scale that Cartesian
+        // component of every box vector, not just the diagonal element.
+        // Otherwise the box deformation is inconsistent with the coordinate
+        // scaling for non-orthorhombic boxes.
+        for (int j = component; j < 3; j++)
+            newBox[j][component] *= 1.0+delta;
     }
-    newBox[scaleVec][scaleComponent] *= 1.0+delta;
+    else
+        newBox[scaleVec][scaleComponent] *= 1.0+delta;
     setBoxVectors(context, newBox[0], newBox[1], newBox[2]);
     double energy1 = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
 
@@ -207,8 +215,11 @@ double MonteCarloFlexibleBarostatImpl::computePressureComponent(ContextImpl& con
     if (component < 3) {
         scale[component] = (1.0-delta)/(1.0+delta);
         kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, scale[0], scale[1], scale[2]);
+        for (int j = component; j < 3; j++)
+            newBox[j][component] = box[j][component]*(1.0-delta);
     }
-    newBox[scaleVec][scaleComponent] = box[scaleVec][scaleComponent]*(1.0-delta);
+    else
+        newBox[scaleVec][scaleComponent] = box[scaleVec][scaleComponent]*(1.0-delta);
     setBoxVectors(context, newBox[0], newBox[1], newBox[2]);
     double energy2 = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
 

--- a/tests/TestMonteCarloFlexibleBarostat.h
+++ b/tests/TestMonteCarloFlexibleBarostat.h
@@ -300,6 +300,65 @@ void testRandomSeed() {
     }
 }
 
+void testTriclinicNormalPressure() {
+    // On a tilted (triclinic) box, the normal pressure components (xx, yy, zz)
+    // must match a consistent uniaxial strain finite difference, in which the
+    // atoms and every box vector are deformed by the same gradient.  The
+    // velocities are zero, so only the potential contribution is compared.
+
+    const int numParticles = 64;
+    System system;
+    Vec3 a(4.0, 0, 0), b(0, 4.0, 0), c(1.0, 0, 4.0); // c has an x-tilt
+    system.setDefaultPeriodicBoxVectors(a, b, c);
+    NonbondedForce* nb = new NonbondedForce();
+    nb->setNonbondedMethod(NonbondedForce::CutoffPeriodic);
+    nb->setCutoffDistance(1.4);
+    OpenMM_SFMT::SFMT sfmt;
+    init_gen_rand(0, sfmt);
+    vector<Vec3> positions(numParticles);
+    for (int i = 0; i < numParticles; i++) {
+        system.addParticle(1.0);
+        nb->addParticle(0.0, 0.3, 1.0);
+        Vec3 f(genrand_real2(sfmt), genrand_real2(sfmt), genrand_real2(sfmt));
+        positions[i] = a*f[0] + b*f[1] + c*f[2]; // fractional -> Cartesian
+    }
+    system.addForce(nb);
+    MonteCarloFlexibleBarostat* barostat = new MonteCarloFlexibleBarostat(1.0, 300.0, 0, false);
+    system.addForce(barostat);
+    VerletIntegrator integrator(0.001);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    context.setVelocities(vector<Vec3>(numParticles, Vec3(0, 0, 0)));
+
+    vector<double> pressure;
+    barostat->computeCurrentPressure(context, pressure);
+
+    // Reference: consistent uniaxial strain finite difference.
+
+    double delta = 1e-3;
+    Vec3 box0[3] = {a, b, c};
+    double volume = a[0]*b[1]*c[2];
+    for (int axis = 0; axis < 3; axis++) {
+        double energy[2];
+        for (int s = 0; s < 2; s++) {
+            double f = (s == 0 ? 1.0+delta : 1.0-delta);
+            Vec3 nbox[3] = {box0[0], box0[1], box0[2]};
+            for (int j = 0; j < 3; j++)
+                nbox[j][axis] *= f;
+            context.setPeriodicBoxVectors(nbox[0], nbox[1], nbox[2]);
+            vector<Vec3> p(numParticles);
+            for (int i = 0; i < numParticles; i++) {
+                p[i] = positions[i];
+                p[i][axis] *= f;
+            }
+            context.setPositions(p);
+            energy[s] = context.getState(State::Energy).getPotentialEnergy();
+        }
+        double ref = -((energy[0]-energy[1])/(2*delta))/volume/(AVOGADRO*1e-25);
+        ASSERT_EQUAL_TOL(ref, pressure[axis], 1e-2);
+    }
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -311,6 +370,7 @@ int main(int argc, char* argv[]) {
         testMolecularGas(true);
         testMolecularGas(false);
         testRandomSeed();
+        testTriclinicNormalPressure();
         runPlatformTests();
     }
     catch(const exception& e) {

--- a/tests/TestMonteCarloFlexibleBarostat.h
+++ b/tests/TestMonteCarloFlexibleBarostat.h
@@ -313,6 +313,14 @@ void testTriclinicNormalPressure() {
     NonbondedForce* nb = new NonbondedForce();
     nb->setNonbondedMethod(NonbondedForce::CutoffPeriodic);
     nb->setCutoffDistance(1.4);
+
+    // Use a switching function so the potential is smooth.  A hard cutoff makes
+    // the energy discontinuous, and on a tilted box the finite-difference
+    // strain in computeCurrentPressure() (which deforms via the GPU
+    // scaleCoordinates kernel) can land a borderline pair on the opposite side
+    // of the cutoff from the reference, producing a spurious step.
+    nb->setUseSwitchingFunction(true);
+    nb->setSwitchingDistance(1.1);
     OpenMM_SFMT::SFMT sfmt;
     init_gen_rand(0, sfmt);
     vector<Vec3> positions(numParticles);


### PR DESCRIPTION
`computePressureComponent` scaled every atom's coordinate along a Cartesian axis but only scaled the diagonal box element, leaving b_x/c_x (etc.) unscaled. For non-orthorhombic boxes the box deformation no longer matched
the coordinate scaling, so the finite-difference normal stress components (xx/yy/zz) were wrong, with the error growing with the tilt.

This scales the matching Cartesian component of every box vector for the normal components so the deformation is a consistent uniaxial strain. Adds a triclinic regression test (fails on current `master`, passes with this change;
verified on the Reference platform).

Fixes part of #5315

This PR fixes only the **normal** stress components (xx/yy/zz) of `computeCurrentPressure()` for triclinic boxes. The off-diagonal **shear** components (xy/xz/yz) are still incorrect, they need a true coordinate shear (e.g. `x += g*z`) that the current `scaleCoordinates(sx, sy, sz)` kernel can't express, so they're left as a follow-up that also needs a convention decision.