### PR TITLE
Add computeStressTensor() to MonteCarloFlexibleBarostat.

### DIFF
--- a/docs-source/usersguide/references.bib
+++ b/docs-source/usersguide/references.bib
@@ -618,6 +618,18 @@
    type = {Journal Article}
 }
 
+@article{Thompson2009
+   author = {Thompson, Aidan P. and Plimpton, Steven J. and Mattson, William},
+   title = {General formulation of pressure and stress tensor for arbitrary many-body interaction potentials under periodic boundary conditions},
+   journal = {Journal of Chemical Physics},
+   volume = {131},
+   number = {15},
+   pages = {154107},
+   year = {2009},
+   doi = {10.1063/1.3245303},
+   type = {Journal Article}
+}
+
 @misc{Tinker
    author = {Ponder, Jay W.},
    title = {{TINKER - Software Tools for Molecular Design, 4.2}},

--- a/docs-source/usersguide/theory/02_standard_forces.rst
+++ b/docs-source/usersguide/theory/02_standard_forces.rst
@@ -909,22 +909,26 @@ The six non-zero elements are as follows.
 * The elements below the diagonal reflect the pressure acting to change the box
   angles.  In equilibrium they should average to zero.
 
-computeStressTensor()
-^^^^^^^^^^^^^^^^^^^^^
+MonteCarloFlexibleBarostat can also compute the stress tensor, which measures the
+mechanical stress in a material.\ :cite:`Thompson2009`  It is defined as the
+derivative of the energy with respect to a uniform strain of the system: if a
+small strain :math:`\epsilon_{jk}` is applied to both the atomic coordinates and
+the periodic box, the stress is
 
-MonteCarloFlexibleBarostat also provides computeStressTensor(), which estimates
-the stress tensor from a consistent strain finite difference.  For each of the
-six independent tensor components, a small deformation gradient is applied to
-both the atomic coordinates and all three box vectors.  The potential energy
-is evaluated at positive and negative strain, and the corresponding stress
-component is obtained from the central difference.
+.. math::
 
-The method returns the six independent elements in the order
-(XX, YY, ZZ, XY, XZ, YZ), in bar.  Tension is positive.  By default only the
-configurational (potential energy) contribution is included.  If includeKinetic
-is set to true, the kinetic contribution is added as well.  When
-getScaleMoleculesAsRigid() is true, coordinates are deformed by moving each
-molecule as a rigid unit.
+   \sigma_{jk} = -\frac{1}{V} \frac{\partial E}{\partial \epsilon_{jk}}
+
+where :math:`V` is the volume.  The stress tensor is symmetric, so it has six
+independent elements: three normal components that describe stretching or
+compression along each axis, and three shear components that describe the
+response to a shape change.  A positive value corresponds to tension.
+
+The stress tensor is the quantity needed to study the mechanical response of a
+material.  For example, applying a known deformation to a crystal and measuring
+the resulting stress gives the elastic constants, and monitoring the stress
+during a simulation indicates whether a structure is under residual tension or
+compression.
 
 CMMotionRemover
 ***************

--- a/docs-source/usersguide/theory/02_standard_forces.rst
+++ b/docs-source/usersguide/theory/02_standard_forces.rst
@@ -909,6 +909,23 @@ The six non-zero elements are as follows.
 * The elements below the diagonal reflect the pressure acting to change the box
   angles.  In equilibrium they should average to zero.
 
+computeStressTensor()
+^^^^^^^^^^^^^^^^^^^^^
+
+MonteCarloFlexibleBarostat also provides computeStressTensor(), which estimates
+the stress tensor from a consistent strain finite difference.  For each of the
+six independent tensor components, a small deformation gradient is applied to
+both the atomic coordinates and all three box vectors.  The potential energy
+is evaluated at positive and negative strain, and the corresponding stress
+component is obtained from the central difference.
+
+The method returns the six independent elements in the order
+(XX, YY, ZZ, XY, XZ, YZ), in bar.  Tension is positive.  By default only the
+configurational (potential energy) contribution is included.  If includeKinetic
+is set to true, the kinetic contribution is added as well.  When
+getScaleMoleculesAsRigid() is true, coordinates are deformed by moving each
+molecule as a rigid unit.
+
 CMMotionRemover
 ***************
 

--- a/olla/include/openmm/kernels.h
+++ b/olla/include/openmm/kernels.h
@@ -1746,7 +1746,14 @@ public:
     virtual void saveCoordinates(ContextImpl& context) = 0;
     /**
      * Attempt a Monte Carlo step, scaling particle positions (or cluster centers) by a specified value.
-     * This version scales the x, y, and z positions independently.
+     * The transformation applied to each position (or cluster center) r is the upper triangular deformation
+     *
+     *     x' = scaleX*x + scaleXY*y + scaleXZ*z
+     *     y' =            scaleY*y  + scaleYZ*z
+     *     z' =                        scaleZ*z
+     *
+     * When the three shear factors are left at their default value of zero, this reduces to scaling the x, y,
+     * and z positions independently.  The shear factors are used when computing the full stress tensor.
      * This is called BEFORE the periodic box size is modified.  It should begin by translating each particle
      * or cluster into the first periodic box, so that coordinates will still be correct after the box size
      * is changed.
@@ -1755,8 +1762,12 @@ public:
      * @param scaleX     the scale factor by which to multiply particle x-coordinate
      * @param scaleY     the scale factor by which to multiply particle y-coordinate
      * @param scaleZ     the scale factor by which to multiply particle z-coordinate
+     * @param scaleXY    the factor by which the y-coordinate contributes to the new x-coordinate
+     * @param scaleXZ    the factor by which the z-coordinate contributes to the new x-coordinate
+     * @param scaleYZ    the factor by which the z-coordinate contributes to the new y-coordinate
      */
-    virtual void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ) = 0;
+    virtual void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
+                                  double scaleXY=0, double scaleXZ=0, double scaleYZ=0) = 0;
     /**
      * Reject the most recent Monte Carlo step, restoring the particle positions to where they were when
      * saveCoordinates() was last called.

--- a/openmmapi/include/openmm/MonteCarloFlexibleBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloFlexibleBarostat.h
@@ -190,6 +190,23 @@ public:
      *                   pressure tensor in the order (XX, YY, ZZ, XY, XZ, YZ)
      */
     void computeCurrentPressure(Context& context, std::vector<double>& pressure) const;
+    /**
+     * Compute the instantaneous stress tensor of a system to which this barostat is applied.
+     * The stress is estimated by a consistent strain finite difference: for each tensor
+     * component, a small deformation gradient is applied to both the atomic coordinates
+     * and all box vectors, and the potential energy is differentiated with respect to
+     * the strain.
+     *
+     * The returned values are in bar, with tension positive.  When includeKinetic is
+     * true, the kinetic contribution is included as well.  When getScaleMoleculesAsRigid()
+     * is true, coordinates are deformed by moving each molecule as a rigid unit.
+     *
+     * @param context         the Context for which to compute the stress tensor
+     * @param stress          on exit, the six independent elements in the order
+     *                        (XX, YY, ZZ, XY, XZ, YZ), in bar
+     * @param includeKinetic  if true, include the kinetic contribution to the stress tensor
+     */
+    void computeStressTensor(Context& context, std::vector<double>& stress, bool includeKinetic=false) const;
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/MonteCarloFlexibleBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloFlexibleBarostat.h
@@ -198,7 +198,7 @@ public:
      * the strain.
      *
      * The returned values are in bar, with tension positive.  When includeKinetic is
-     * true, the kinetic contribution is included as well.  When getScaleMoleculesAsRigid()
+     * true, the kinetic energy contribution is included as well.  When getScaleMoleculesAsRigid()
      * is true, coordinates are deformed by moving each molecule as a rigid unit.
      *
      * @param context         the Context for which to compute the stress tensor

--- a/openmmapi/include/openmm/internal/MonteCarloFlexibleBarostatImpl.h
+++ b/openmmapi/include/openmm/internal/MonteCarloFlexibleBarostatImpl.h
@@ -56,8 +56,10 @@ public:
     std::map<std::string, double> getDefaultParameters();
     std::vector<std::string> getKernelNames();
     void computeCurrentPressure(ContextImpl& context, std::vector<double>& pressure);
+    void computeStressTensor(ContextImpl& context, std::vector<double>& stress, bool includeKinetic);
 private:
     double computePressureComponent(ContextImpl& context, double delta, int component);
+    double computeStressComponent(ContextImpl& context, double delta, int component);
     void setBoxVectors(ContextImpl& context, Vec3 a, Vec3 b, Vec3 c);
     const MonteCarloFlexibleBarostat& owner;
     int step, numAttempted, numAccepted;

--- a/openmmapi/src/MonteCarloFlexibleBarostat.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostat.cpp
@@ -60,6 +60,10 @@ void MonteCarloFlexibleBarostat::computeCurrentPressure(Context& context, std::v
     dynamic_cast<MonteCarloFlexibleBarostatImpl&>(getImplInContext(context)).computeCurrentPressure(getContextImpl(context), pressure);
 }
 
+void MonteCarloFlexibleBarostat::computeStressTensor(Context& context, std::vector<double>& stress, bool includeKinetic) const {
+    dynamic_cast<MonteCarloFlexibleBarostatImpl&>(getImplInContext(context)).computeStressTensor(getContextImpl(context), stress, includeKinetic);
+}
+
 ForceImpl* MonteCarloFlexibleBarostat::createImpl() const {
     return new MonteCarloFlexibleBarostatImpl(*this);
 }

--- a/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
@@ -260,46 +260,55 @@ double MonteCarloFlexibleBarostatImpl::computeStressComponent(ContextImpl& conte
     context.getPeriodicBoxVectors(box[0], box[1], box[2]);
     double volume = box[0][0]*box[1][1]*box[2][2];
 
-    double energy[2];
-    double sign[2] = {1.0, -1.0};
-    for (int s = 0; s < 2; s++) {
-        double d = sign[s]*delta;
+    int shearIndex = -1;
+    if (i != j)
+        shearIndex = (i == 0 && j == 1) ? 0 : (i == 0 && j == 2) ? 1 : 2;
 
-        // Build the deformed box.  The same deformation gradient (F = I + d*e_i (x) e_j) is
-        // applied to the box vectors and, through scaleCoordinates(), to the particle positions.
+    // The same deformation gradient (F = I + d*e_i (x) e_j) is applied to the box vectors and,
+    // through scaleCoordinates(), to the particle positions.  Saving and restoring the
+    // coordinates around each energy evaluation resulted in an inaccurate finite difference
+    // energy, so we instead deform the coordinates continuously (forward, then to the opposite
+    // strain, then back), mimicking computePressureComponent().
 
-        Vec3 newBox[3];
-        for (int k = 0; k < 3; k++) {
-            newBox[k] = box[k];
-            newBox[k][i] += d*box[k][j];
-        }
-
-        // Express the deformation gradient as the scale and shear factors used by
-        // scaleCoordinates().  Diagonal components are an axial scaling; off-diagonal
-        // components are a shear.
-
-        double scale[3] = {1.0, 1.0, 1.0};
-        double shear[3] = {0.0, 0.0, 0.0}; // (xy, xz, yz)
-        if (i == j)
-            scale[i] = 1.0+d;
-        else {
-            int shearIndex = (i == 0 && j == 1) ? 0 : (i == 0 && j == 2) ? 1 : 2;
-            shear[shearIndex] = d;
-        }
-
-        // Apply the deformation on the GPU.  saveCoordinates()/restoreCoordinates() bracket the
-        // energy evaluation so the context is left unchanged, and so that scaleCoordinates() never
-        // compounds across the two finite difference steps.
-
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().saveCoordinates(context);
-        setBoxVectors(context, newBox[0], newBox[1], newBox[2]);
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, scale[0], scale[1], scale[2], shear[0], shear[1], shear[2]);
-        energy[s] = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
-        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
-        context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+    Vec3 plusBox[3], minusBox[3];
+    for (int k = 0; k < 3; k++) {
+        plusBox[k] = box[k];
+        plusBox[k][i] += delta*box[k][j];
+        minusBox[k] = box[k];
+        minusBox[k][i] -= delta*box[k][j];
     }
 
-    return (energy[0]-energy[1])/(volume*2*delta);
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().saveCoordinates(context);
+
+    // Apply the +delta strain (relative to the original coordinates) and evaluate the energy.
+
+    double scale[3] = {1.0, 1.0, 1.0}, shear[3] = {0.0, 0.0, 0.0};
+    if (i == j)
+        scale[i] = 1.0+delta;
+    else
+        shear[shearIndex] = delta;
+    setBoxVectors(context, plusBox[0], plusBox[1], plusBox[2]);
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, scale[0], scale[1], scale[2], shear[0], shear[1], shear[2]);
+    double energyPlus = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
+
+    // Apply the strain that carries the +delta state to the -delta state, and evaluate again.
+
+    scale[0] = scale[1] = scale[2] = 1.0;
+    shear[0] = shear[1] = shear[2] = 0.0;
+    if (i == j)
+        scale[i] = (1.0-delta)/(1.0+delta);
+    else
+        shear[shearIndex] = -2.0*delta;
+    setBoxVectors(context, minusBox[0], minusBox[1], minusBox[2]);
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, scale[0], scale[1], scale[2], shear[0], shear[1], shear[2]);
+    double energyMinus = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
+
+    // Restore the original coordinates and box.
+
+    kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
+    context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+
+    return (energyPlus-energyMinus)/(volume*2*delta);
 }
 
 void MonteCarloFlexibleBarostatImpl::setBoxVectors(ContextImpl& context, Vec3 a, Vec3 b, Vec3 c) {

--- a/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
@@ -166,6 +166,28 @@ void MonteCarloFlexibleBarostatImpl::computeCurrentPressure(ContextImpl& context
     kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
 }
 
+void MonteCarloFlexibleBarostatImpl::computeStressTensor(ContextImpl& context, vector<double>& stress, bool includeKinetic) {
+    stress.resize(6);
+    Vec3 box[3];
+    context.getPeriodicBoxVectors(box[0], box[1], box[2]);
+    double volume = box[0][0]*box[1][1]*box[2][2];
+    double delta = 1e-3;
+    vector<double> ke;
+    if (includeKinetic) {
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().saveCoordinates(context);
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().computeKineticEnergy(context, ke);
+    }
+
+    for (int component = 0; component < 6; component++) {
+        stress[component] = computeStressComponent(context, delta, component)/(AVOGADRO*1e-25);
+        if (includeKinetic)
+            stress[component] += -2.0*ke[component]/volume/(AVOGADRO*1e-25);
+    }
+
+    if (includeKinetic)
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
+}
+
 double MonteCarloFlexibleBarostatImpl::computePressureComponent(ContextImpl& context, double delta, int component) {
     Vec3 box[3], newBox[3];
     context.getPeriodicBoxVectors(box[0], box[1], box[2]);
@@ -224,6 +246,64 @@ double MonteCarloFlexibleBarostatImpl::computePressureComponent(ContextImpl& con
 
     double volume = box[0][0]*box[1][1]*box[2][2];
     return (energy1-energy2)/(volume*2*delta);
+}
+
+double MonteCarloFlexibleBarostatImpl::computeStressComponent(ContextImpl& context, double delta, int component) {
+    static const int icomp[6] = {0, 1, 2, 0, 0, 1};
+    static const int jcomp[6] = {0, 1, 2, 1, 2, 2};
+    if (component < 0 || component > 5)
+        throw OpenMMException("Illegal component index");
+    int i = icomp[component], j = jcomp[component];
+    int groups = context.getIntegrator().getIntegrationForceGroups();
+
+    Vec3 box[3];
+    context.getPeriodicBoxVectors(box[0], box[1], box[2]);
+    vector<Vec3> pos0 = context.getOwner().getState(State::Positions).getPositions();
+    int numParticles = pos0.size();
+
+    vector<vector<int> > singleAtoms;
+    const vector<vector<int> >* scaledUnits;
+    if (owner.getScaleMoleculesAsRigid())
+        scaledUnits = &context.getMolecules();
+    else {
+        singleAtoms.resize(numParticles);
+        for (int a = 0; a < numParticles; a++)
+            singleAtoms[a].push_back(a);
+        scaledUnits = &singleAtoms;
+    }
+
+    double energy[2];
+    double sign[2] = {1.0, -1.0};
+    for (int s = 0; s < 2; s++) {
+        double d = sign[s]*delta;
+
+        Vec3 newBox[3];
+        for (int k = 0; k < 3; k++) {
+            newBox[k] = box[k];
+            newBox[k][i] += d*box[k][j];
+        }
+        setBoxVectors(context, newBox[0], newBox[1], newBox[2]);
+
+        vector<Vec3> pos = pos0;
+        for (const vector<int>& unit : *scaledUnits) {
+            Vec3 center(0, 0, 0);
+            for (int atom : unit)
+                center += pos0[atom];
+            center /= unit.size();
+            double offset = d*center[j];
+            for (int atom : unit)
+                pos[atom][i] += offset;
+        }
+        context.getOwner().setPositions(pos);
+
+        energy[s] = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
+    }
+
+    context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
+    context.getOwner().setPositions(pos0);
+
+    double volume = box[0][0]*box[1][1]*box[2][2];
+    return (energy[0]-energy[1])/(volume*2*delta);
 }
 
 void MonteCarloFlexibleBarostatImpl::setBoxVectors(ContextImpl& context, Vec3 a, Vec3 b, Vec3 c) {

--- a/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloFlexibleBarostatImpl.cpp
@@ -258,51 +258,47 @@ double MonteCarloFlexibleBarostatImpl::computeStressComponent(ContextImpl& conte
 
     Vec3 box[3];
     context.getPeriodicBoxVectors(box[0], box[1], box[2]);
-    vector<Vec3> pos0 = context.getOwner().getState(State::Positions).getPositions();
-    int numParticles = pos0.size();
-
-    vector<vector<int> > singleAtoms;
-    const vector<vector<int> >* scaledUnits;
-    if (owner.getScaleMoleculesAsRigid())
-        scaledUnits = &context.getMolecules();
-    else {
-        singleAtoms.resize(numParticles);
-        for (int a = 0; a < numParticles; a++)
-            singleAtoms[a].push_back(a);
-        scaledUnits = &singleAtoms;
-    }
+    double volume = box[0][0]*box[1][1]*box[2][2];
 
     double energy[2];
     double sign[2] = {1.0, -1.0};
     for (int s = 0; s < 2; s++) {
         double d = sign[s]*delta;
 
+        // Build the deformed box.  The same deformation gradient (F = I + d*e_i (x) e_j) is
+        // applied to the box vectors and, through scaleCoordinates(), to the particle positions.
+
         Vec3 newBox[3];
         for (int k = 0; k < 3; k++) {
             newBox[k] = box[k];
             newBox[k][i] += d*box[k][j];
         }
-        setBoxVectors(context, newBox[0], newBox[1], newBox[2]);
 
-        vector<Vec3> pos = pos0;
-        for (const vector<int>& unit : *scaledUnits) {
-            Vec3 center(0, 0, 0);
-            for (int atom : unit)
-                center += pos0[atom];
-            center /= unit.size();
-            double offset = d*center[j];
-            for (int atom : unit)
-                pos[atom][i] += offset;
+        // Express the deformation gradient as the scale and shear factors used by
+        // scaleCoordinates().  Diagonal components are an axial scaling; off-diagonal
+        // components are a shear.
+
+        double scale[3] = {1.0, 1.0, 1.0};
+        double shear[3] = {0.0, 0.0, 0.0}; // (xy, xz, yz)
+        if (i == j)
+            scale[i] = 1.0+d;
+        else {
+            int shearIndex = (i == 0 && j == 1) ? 0 : (i == 0 && j == 2) ? 1 : 2;
+            shear[shearIndex] = d;
         }
-        context.getOwner().setPositions(pos);
 
+        // Apply the deformation on the GPU.  saveCoordinates()/restoreCoordinates() bracket the
+        // energy evaluation so the context is left unchanged, and so that scaleCoordinates() never
+        // compounds across the two finite difference steps.
+
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().saveCoordinates(context);
+        setBoxVectors(context, newBox[0], newBox[1], newBox[2]);
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().scaleCoordinates(context, scale[0], scale[1], scale[2], shear[0], shear[1], shear[2]);
         energy[s] = context.getOwner().getState(State::Energy, false, groups).getPotentialEnergy();
+        kernel.getAs<ApplyMonteCarloBarostatKernel>().restoreCoordinates(context);
+        context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
     }
 
-    context.getOwner().setPeriodicBoxVectors(box[0], box[1], box[2]);
-    context.getOwner().setPositions(pos0);
-
-    double volume = box[0][0]*box[1][1]*box[2][2];
     return (energy[0]-energy[1])/(volume*2*delta);
 }
 

--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -1359,7 +1359,8 @@ public:
      * @param scaleY     the scale factor by which to multiply particle y-coordinate
      * @param scaleZ     the scale factor by which to multiply particle z-coordinate
      */
-    void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ);
+    void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
+                          double scaleXY=0, double scaleXZ=0, double scaleYZ=0);
     /**
      * Reject the most recent Monte Carlo step, restoring the particle positions to where they were when
      * saveCoordinates() was last called.

--- a/platforms/common/include/openmm/common/CommonKernels.h
+++ b/platforms/common/include/openmm/common/CommonKernels.h
@@ -1358,6 +1358,9 @@ public:
      * @param scaleX     the scale factor by which to multiply particle x-coordinate
      * @param scaleY     the scale factor by which to multiply particle y-coordinate
      * @param scaleZ     the scale factor by which to multiply particle z-coordinate
+     * @param scaleXY    the factor by which the y-coordinate contributes to the new x-coordinate
+     * @param scaleXZ    the factor by which the z-coordinate contributes to the new x-coordinate
+     * @param scaleYZ    the factor by which the z-coordinate contributes to the new y-coordinate
      */
     void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
                           double scaleXY=0, double scaleXZ=0, double scaleYZ=0);

--- a/platforms/common/src/CommonKernels.cpp
+++ b/platforms/common/src/CommonKernels.cpp
@@ -4315,6 +4315,9 @@ void CommonApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& context) 
         kernel->addArg();
         kernel->addArg();
         kernel->addArg();
+        kernel->addArg();
+        kernel->addArg();
+        kernel->addArg();
         kernel->addArg(numMolecules);
         for (int i = 0; i < 5; i++)
             kernel->addArg();
@@ -4337,7 +4340,8 @@ void CommonApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& context) 
     lastAtomOrder = cc.getAtomIndex();
 }
 
-void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ) {
+void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
+        double scaleXY, double scaleXZ, double scaleYZ) {
     ContextSelector selector(cc);
 
     // check if atoms were reordered from energy evaluation before scaling
@@ -4345,7 +4349,10 @@ void CommonApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context,
     kernel->setArg(0, (float) scaleX);
     kernel->setArg(1, (float) scaleY);
     kernel->setArg(2, (float) scaleZ);
-    setPeriodicBoxArgs(cc, kernel, 4);
+    kernel->setArg(3, (float) scaleXY);
+    kernel->setArg(4, (float) scaleXZ);
+    kernel->setArg(5, (float) scaleYZ);
+    setPeriodicBoxArgs(cc, kernel, 7);
     kernel->execute(numMolecules);
 }
 

--- a/platforms/common/src/kernels/monteCarloBarostat.cc
+++ b/platforms/common/src/kernels/monteCarloBarostat.cc
@@ -1,8 +1,10 @@
 /**
- * Scale the particle positions with each axis independent.
+ * Apply an upper triangular deformation to the molecule centers.  When the shear factors
+ * (scaleXY, scaleXZ, scaleYZ) are zero this reduces to scaling each axis independently.
  */
 
-KERNEL void scalePositions(float scaleX, float scaleY, float scaleZ, int numMolecules, real4 periodicBoxSize,
+KERNEL void scalePositions(float scaleX, float scaleY, float scaleZ, float scaleXY, float scaleXZ, float scaleYZ,
+        int numMolecules, real4 periodicBoxSize,
         real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, GLOBAL real4* RESTRICT posq,
         GLOBAL const int* RESTRICT moleculeAtoms, GLOBAL const int* RESTRICT moleculeStartIndex) {
     for (int index = GLOBAL_ID; index < numMolecules; index += GLOBAL_SIZE) {
@@ -24,11 +26,11 @@ KERNEL void scalePositions(float scaleX, float scaleY, float scaleZ, int numMole
         center.y *= invNumAtoms;
         center.z *= invNumAtoms;
 
-        // Now scale the position of the molecule center.
+        // Now apply the deformation to the position of the molecule center.
 
         real3 delta;
-        delta.x = center.x*(scaleX-1);
-        delta.y = center.y*(scaleY-1);
+        delta.x = center.x*(scaleX-1) + center.y*scaleXY + center.z*scaleXZ;
+        delta.y = center.y*(scaleY-1) + center.z*scaleYZ;
         delta.z = center.z*(scaleZ-1);
         for (int atom = first; atom < last; atom++) {
             real4 pos = posq[moleculeAtoms[atom]];

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -1881,7 +1881,8 @@ public:
      * @param scaleY     the scale factor by which to multiply particle y-coordinate
      * @param scaleZ     the scale factor by which to multiply particle z-coordinate
      */
-    void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ);
+    void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
+                          double scaleXY=0, double scaleXZ=0, double scaleYZ=0);
     /**
      * Reject the most recent Monte Carlo step, restoring the particle positions to where they were when
      * saveCoordinates() was last called.

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -1880,6 +1880,9 @@ public:
      * @param scaleX     the scale factor by which to multiply particle x-coordinate
      * @param scaleY     the scale factor by which to multiply particle y-coordinate
      * @param scaleZ     the scale factor by which to multiply particle z-coordinate
+     * @param scaleXY    the factor by which the y-coordinate contributes to the new x-coordinate
+     * @param scaleXZ    the factor by which the z-coordinate contributes to the new x-coordinate
+     * @param scaleYZ    the factor by which the z-coordinate contributes to the new y-coordinate
      */
     void scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
                           double scaleXY=0, double scaleXZ=0, double scaleYZ=0);

--- a/platforms/reference/include/ReferenceMonteCarloBarostat.h
+++ b/platforms/reference/include/ReferenceMonteCarloBarostat.h
@@ -69,17 +69,23 @@ class ReferenceMonteCarloBarostat {
 
       /**---------------------------------------------------------------------------------------
 
-         Apply the barostat at the start of a time step, scaling x, y, and z coordinates independently.
+         Apply the barostat at the start of a time step, applying an upper triangular deformation
+         to the x, y, and z coordinates.  When the shear factors are zero this reduces to scaling
+         the x, y, and z coordinates independently.
 
          @param atomPositions      atom positions
          @param boxVectors         the periodic box vectors
          @param scaleX             the factor by which to scale atomic x coordinates
          @param scaleY             the factor by which to scale atomic y coordinates
          @param scaleZ             the factor by which to scale atomic z coordinates
+         @param scaleXY            the factor by which the y coordinate contributes to the new x coordinate
+         @param scaleXZ            the factor by which the z coordinate contributes to the new x coordinate
+         @param scaleYZ            the factor by which the z coordinate contributes to the new y coordinate
 
          --------------------------------------------------------------------------------------- */
 
-      void applyBarostat(std::vector<OpenMM::Vec3>& atomPositions, const OpenMM::Vec3* boxVectors, double scaleX, double scaleY, double scaleZ);
+      void applyBarostat(std::vector<OpenMM::Vec3>& atomPositions, const OpenMM::Vec3* boxVectors, double scaleX, double scaleY, double scaleZ,
+                         double scaleXY=0, double scaleXZ=0, double scaleYZ=0);
 
       /**---------------------------------------------------------------------------------------
 

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -3326,10 +3326,11 @@ void ReferenceApplyMonteCarloBarostatKernel::saveCoordinates(ContextImpl& contex
     barostat->savePositions(posData);
 }
 
-void ReferenceApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ) {
+void ReferenceApplyMonteCarloBarostatKernel::scaleCoordinates(ContextImpl& context, double scaleX, double scaleY, double scaleZ,
+        double scaleXY, double scaleXZ, double scaleYZ) {
     vector<Vec3>& posData = extractPositions(context);
     Vec3* boxVectors = extractBoxVectors(context);
-    barostat->applyBarostat(posData, boxVectors, scaleX, scaleY, scaleZ);
+    barostat->applyBarostat(posData, boxVectors, scaleX, scaleY, scaleZ, scaleXY, scaleXZ, scaleYZ);
 }
 
 void ReferenceApplyMonteCarloBarostatKernel::restoreCoordinates(ContextImpl& context) {

--- a/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceMonteCarloBarostat.cpp
@@ -77,10 +77,14 @@ void ReferenceMonteCarloBarostat::savePositions(vector<Vec3>& atomPositions) {
   @param scaleX             the factor by which to scale atom x-coordinates
   @param scaleY             the factor by which to scale atom y-coordinates
   @param scaleZ             the factor by which to scale atom z-coordinates
+  @param scaleXY            the factor by which the y-coordinate contributes to the new x-coordinate
+  @param scaleXZ            the factor by which the z-coordinate contributes to the new x-coordinate
+  @param scaleYZ            the factor by which the z-coordinate contributes to the new y-coordinate
 
   --------------------------------------------------------------------------------------- */
 
-void ReferenceMonteCarloBarostat::applyBarostat(vector<Vec3>& atomPositions, const Vec3* boxVectors, double scaleX, double scaleY, double scaleZ) {
+void ReferenceMonteCarloBarostat::applyBarostat(vector<Vec3>& atomPositions, const Vec3* boxVectors, double scaleX, double scaleY, double scaleZ,
+        double scaleXY, double scaleXZ, double scaleYZ) {
     // Loop over molecules.
 
     for (auto& molecule : molecules) {
@@ -93,12 +97,13 @@ void ReferenceMonteCarloBarostat::applyBarostat(vector<Vec3>& atomPositions, con
         }
         pos /= molecule.size();
 
-        // Now scale the position of the molecule center.
+        // Now apply the deformation to the position of the molecule center.  When the shear
+        // factors are zero this is just an independent scaling of the x, y, and z coordinates.
 
         Vec3 newPos = pos;
-        newPos[0] *= scaleX;
-        newPos[1] *= scaleY;
-        newPos[2] *= scaleZ;
+        newPos[0] = scaleX*pos[0] + scaleXY*pos[1] + scaleXZ*pos[2];
+        newPos[1] = scaleY*pos[1] + scaleYZ*pos[2];
+        newPos[2] = scaleZ*pos[2];
         Vec3 offset = newPos-pos;
         for (int atom : molecule) {
             Vec3& atomPos = atomPositions[atom];

--- a/tests/TestMonteCarloFlexibleBarostat.h
+++ b/tests/TestMonteCarloFlexibleBarostat.h
@@ -300,6 +300,68 @@ void testRandomSeed() {
     }
 }
 
+void testTriclinicStressTensor() {
+    // On a fully tilted (triclinic) box, all six stress components must match a
+    // consistent strain finite difference in which the atoms and every box vector
+    // are deformed by the same deformation gradient.  Velocities are zero and
+    // includeKinetic is false, so only the potential contribution is compared.
+
+    const int numParticles = 64;
+    System system;
+    Vec3 a(4.0, 0, 0), b(0.5, 4.0, 0), c(1.0, 0.7, 4.0);
+    system.setDefaultPeriodicBoxVectors(a, b, c);
+    NonbondedForce* nb = new NonbondedForce();
+    nb->setNonbondedMethod(NonbondedForce::CutoffPeriodic);
+    nb->setCutoffDistance(1.4);
+    nb->setUseSwitchingFunction(true);
+    nb->setSwitchingDistance(1.1);
+    OpenMM_SFMT::SFMT sfmt;
+    init_gen_rand(0, sfmt);
+    vector<Vec3> positions(numParticles);
+    for (int i = 0; i < numParticles; i++) {
+        system.addParticle(1.0);
+        nb->addParticle(0.0, 0.3, 1.0);
+        Vec3 f(genrand_real2(sfmt), genrand_real2(sfmt), genrand_real2(sfmt));
+        positions[i] = a*f[0] + b*f[1] + c*f[2];
+    }
+    system.addForce(nb);
+    MonteCarloFlexibleBarostat* barostat = new MonteCarloFlexibleBarostat(1.0, 300.0, 0, false);
+    system.addForce(barostat);
+    VerletIntegrator integrator(0.001);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    context.setVelocities(vector<Vec3>(numParticles, Vec3(0, 0, 0)));
+
+    vector<double> stress;
+    barostat->computeStressTensor(context, stress, false);
+
+    static const int icomp[6] = {0, 1, 2, 0, 0, 1};
+    static const int jcomp[6] = {0, 1, 2, 1, 2, 2};
+    double delta = 1e-3;
+    Vec3 box0[3] = {a, b, c};
+    double volume = a[0]*b[1]*c[2];
+    for (int component = 0; component < 6; component++) {
+        int i = icomp[component], j = jcomp[component];
+        double energy[2];
+        for (int s = 0; s < 2; s++) {
+            double d = (s == 0 ? delta : -delta);
+            Vec3 nbox[3] = {box0[0], box0[1], box0[2]};
+            for (int k = 0; k < 3; k++)
+                nbox[k][i] += d*box0[k][j];
+            context.setPeriodicBoxVectors(nbox[0], nbox[1], nbox[2]);
+            vector<Vec3> p = positions;
+            for (int atom = 0; atom < numParticles; atom++)
+                p[atom][i] += d*positions[atom][j];
+            context.setPositions(p);
+            energy[s] = context.getState(State::Energy).getPotentialEnergy();
+        }
+        context.setPeriodicBoxVectors(box0[0], box0[1], box0[2]);
+        context.setPositions(positions);
+        double ref = (energy[0]-energy[1])/(2*delta*volume)/(AVOGADRO*1e-25);
+        ASSERT_EQUAL_TOL(ref, stress[component], 1e-2);
+    }
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -311,6 +373,7 @@ int main(int argc, char* argv[]) {
         testMolecularGas(true);
         testMolecularGas(false);
         testRandomSeed();
+        testTriclinicStressTensor();
         runPlatformTests();
     }
     catch(const exception& e) {

--- a/tests/TestMonteCarloFlexibleBarostat.h
+++ b/tests/TestMonteCarloFlexibleBarostat.h
@@ -300,6 +300,113 @@ void testRandomSeed() {
     }
 }
 
+void testTwoParticleStressTensor() {
+    // Two particles connected by a harmonic bond have a stress tensor that is known
+    // analytically.  For a bond with force constant k, equilibrium length r0, and
+    // separation vector r (length L), the configurational stress is
+    //
+    //     sigma_ij = k (L - r0) r_i r_j / (L V)
+    //
+    // This is an independent check of computeStressTensor(): it does not reuse the
+    // finite difference logic of the implementation.  The bond is tilted in all three
+    // directions so that every one of the six components is nonzero.
+
+    const double k = 500.0;   // kJ/mol/nm^2
+    const double r0 = 0.15;   // nm
+    System system;
+    Vec3 a(4.0, 0, 0), b(0, 4.0, 0), c(0, 0, 5.0);
+    system.setDefaultPeriodicBoxVectors(a, b, c);
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    HarmonicBondForce* bonds = new HarmonicBondForce();
+    bonds->setUsesPeriodicBoundaryConditions(true);
+    bonds->addBond(0, 1, r0, k);
+    system.addForce(bonds);
+    MonteCarloFlexibleBarostat* barostat = new MonteCarloFlexibleBarostat(1.0, 300.0, 0, false);
+    system.addForce(barostat);
+    VerletIntegrator integrator(0.001);
+    Context context(system, integrator, platform);
+    vector<Vec3> positions = {Vec3(0, 0, 0), Vec3(0.05, 0.03, 0.20)};
+    context.setPositions(positions);
+    context.setVelocities(vector<Vec3>(2, Vec3(0, 0, 0)));
+
+    vector<double> stress;
+    barostat->computeStressTensor(context, stress, false);
+
+    static const int icomp[6] = {0, 1, 2, 0, 0, 1};
+    static const int jcomp[6] = {0, 1, 2, 1, 2, 2};
+    Vec3 d = positions[1]-positions[0];
+    double L = sqrt(d.dot(d));
+    double volume = a[0]*b[1]*c[2];
+    for (int component = 0; component < 6; component++) {
+        int i = icomp[component], j = jcomp[component];
+        double ref = (k*(L-r0)*d[i]*d[j])/(L*volume)/(AVOGADRO*1e-25);
+        ASSERT_EQUAL_TOL(ref, stress[component], 1e-3);
+    }
+}
+
+void testStressTensorAgainstLammps() {
+    // Cross-code validation against LAMMPS.  An asymmetric six atom Lennard-Jones
+    // cluster is placed in a large cubic box so that every real pair is well inside
+    // the cutoff and every periodic image is far beyond it.  The configurational
+    // (virial) stress computed here is compared against values computed independently
+    // by LAMMPS for the identical system.
+    //
+    // The LAMMPS reference values were produced with LAMMPS (19 Nov 2024) using metal
+    // units (Angstrom, eV, bar) and the input script
+    //   cuda_mace_env_recreation_2/validation_scripts/lammps_stress_crosscheck/in.lj_stress
+    // with pair_style lj/cut and "compute pressure NULL virial" (virial term only, no
+    // kinetic contribution).  The OpenMM parameters below map to that system as
+    //   sigma   = 0.3 nm   = 3.0 Angstrom
+    //   epsilon = 1.0 kJ/mol = 0.0103642697 eV
+    //   box     = 4.0 nm   = 40 Angstrom
+    //   positions_nm = positions_Angstrom / 10
+    // LAMMPS reports the pressure tensor (compression positive); OpenMM's stress
+    // tensor is tension positive, so the expected OpenMM values are the negatives of
+    // the LAMMPS pressure components.
+
+    const double sigma = 0.3;     // nm
+    const double epsilon = 1.0;   // kJ/mol
+    const double boxLength = 4.0; // nm
+    const double cutoff = 1.5;    // nm
+
+    System system;
+    system.setDefaultPeriodicBoxVectors(Vec3(boxLength, 0, 0), Vec3(0, boxLength, 0), Vec3(0, 0, boxLength));
+    NonbondedForce* nb = new NonbondedForce();
+    nb->setNonbondedMethod(NonbondedForce::CutoffPeriodic);
+    nb->setCutoffDistance(cutoff);
+    nb->setUseSwitchingFunction(false);
+    nb->setUseDispersionCorrection(false);
+    vector<Vec3> positions = {
+        Vec3(0.00, 0.00, 0.00),
+        Vec3(0.32, 0.04, 0.01),
+        Vec3(0.05, 0.30, 0.06),
+        Vec3(0.02, 0.07, 0.33),
+        Vec3(0.30, 0.31, 0.09),
+        Vec3(0.11, 0.20, 0.25)
+    };
+    for (int i = 0; i < (int) positions.size(); i++) {
+        system.addParticle(1.0);
+        nb->addParticle(0.0, sigma, epsilon);
+    }
+    system.addForce(nb);
+    MonteCarloFlexibleBarostat* barostat = new MonteCarloFlexibleBarostat(1.0, 300.0, 0, false);
+    system.addForce(barostat);
+    VerletIntegrator integrator(0.001);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    context.setVelocities(vector<Vec3>(positions.size(), Vec3(0, 0, 0)));
+
+    vector<double> stress;
+    barostat->computeStressTensor(context, stress, false);
+
+    // LAMMPS pressure tensor (bar) in the order (XX, YY, ZZ, XY, XZ, YZ).
+    double lammpsPressure[6] = {1869.08676851, 3740.91201516, 1681.44462233,
+                                2481.14075422, -1459.42106406, -2393.77198342};
+    for (int component = 0; component < 6; component++)
+        ASSERT_EQUAL_TOL(-lammpsPressure[component], stress[component], 1e-3);
+}
+
 void testTriclinicStressTensor() {
     // On a fully tilted (triclinic) box, all six stress components must match a
     // consistent strain finite difference in which the atoms and every box vector
@@ -373,6 +480,8 @@ int main(int argc, char* argv[]) {
         testMolecularGas(true);
         testMolecularGas(false);
         testRandomSeed();
+        testTwoParticleStressTensor();
+        testStressTensorAgainstLammps();
         testTriclinicStressTensor();
         runPlatformTests();
     }

--- a/tests/TestMonteCarloFlexibleBarostat.h
+++ b/tests/TestMonteCarloFlexibleBarostat.h
@@ -306,10 +306,8 @@ void testTwoParticleStressTensor() {
     // separation vector r (length L), the configurational stress is
     //
     //     sigma_ij = k (L - r0) r_i r_j / (L V)
-    //
-    // This is an independent check of computeStressTensor(): it does not reuse the
-    // finite difference logic of the implementation.  The bond is tilted in all three
-    // directions so that every one of the six components is nonzero.
+    // The bond is tilted in all three directions so that every one of the six
+    // components is nonzero.
 
     const double k = 500.0;   // kJ/mol/nm^2
     const double r0 = 0.15;   // nm
@@ -353,8 +351,7 @@ void testStressTensorAgainstLammps() {
     // by LAMMPS for the identical system.
     //
     // The LAMMPS reference values were produced with LAMMPS (19 Nov 2024) using metal
-    // units (Angstrom, eV, bar) and the input script
-    //   cuda_mace_env_recreation_2/validation_scripts/lammps_stress_crosscheck/in.lj_stress
+    // units (Angstrom, eV, bar)
     // with pair_style lj/cut and "compute pressure NULL virial" (virial term only, no
     // kinetic contribution).  The OpenMM parameters below map to that system as
     //   sigma   = 0.3 nm   = 3.0 Angstrom
@@ -403,6 +400,70 @@ void testStressTensorAgainstLammps() {
     // LAMMPS pressure tensor (bar) in the order (XX, YY, ZZ, XY, XZ, YZ).
     double lammpsPressure[6] = {1869.08676851, 3740.91201516, 1681.44462233,
                                 2481.14075422, -1459.42106406, -2393.77198342};
+    for (int component = 0; component < 6; component++)
+        ASSERT_EQUAL_TOL(-lammpsPressure[component], stress[component], 1e-3);
+}
+
+void testKineticStressTensorAgainstLammps() {
+    // Cross-code validation of the includeKinetic=true option.  Same six atom
+    // Lennard-Jones cluster as testStressTensorAgainstLammps(), but every atom is
+    // given a nonzero velocity so the full (virial + kinetic) stress tensor is
+    // exercised.  The velocities are chosen large enough that the kinetic term is
+    // comparable to the virial term (otherwise it would be a ~0.01% perturbation
+    // that a relative tolerance could not detect).
+    //
+    // The LAMMPS reference values were produced with LAMMPS (19 Nov 2024), metal
+    // units, pair_style lj/cut, and "compute pressure" with a temperature compute
+    // (kinetic + virial).  OpenMM velocities are in nm/ps; the LAMMPS velocities are
+    // ten times larger (Angstrom/ps).  As before, OpenMM's stress tensor is tension
+    // positive, so the expected values are the negatives of the LAMMPS pressure.
+
+    const double sigma = 0.3;     // nm
+    const double epsilon = 1.0;   // kJ/mol
+    const double boxLength = 4.0; // nm
+    const double cutoff = 1.5;    // nm
+
+    System system;
+    system.setDefaultPeriodicBoxVectors(Vec3(boxLength, 0, 0), Vec3(0, boxLength, 0), Vec3(0, 0, boxLength));
+    NonbondedForce* nb = new NonbondedForce();
+    nb->setNonbondedMethod(NonbondedForce::CutoffPeriodic);
+    nb->setCutoffDistance(cutoff);
+    nb->setUseSwitchingFunction(false);
+    nb->setUseDispersionCorrection(false);
+    vector<Vec3> positions = {
+        Vec3(0.00, 0.00, 0.00),
+        Vec3(0.32, 0.04, 0.01),
+        Vec3(0.05, 0.30, 0.06),
+        Vec3(0.02, 0.07, 0.33),
+        Vec3(0.30, 0.31, 0.09),
+        Vec3(0.11, 0.20, 0.25)
+    };
+    vector<Vec3> velocities = {   // nm/ps  (LAMMPS Angstrom/ps values / 10)
+        Vec3( 50, -30,  20),
+        Vec3(-40,  60, -10),
+        Vec3( 20,  10,  70),
+        Vec3(-30, -50,  40),
+        Vec3( 60,  20, -30),
+        Vec3(-10,  40,  50)
+    };
+    for (int i = 0; i < (int) positions.size(); i++) {
+        system.addParticle(1.0);
+        nb->addParticle(0.0, sigma, epsilon);
+    }
+    system.addForce(nb);
+    MonteCarloFlexibleBarostat* barostat = new MonteCarloFlexibleBarostat(1.0, 300.0, 0, false);
+    system.addForce(barostat);
+    VerletIntegrator integrator(0.001);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    context.setVelocities(velocities);
+
+    vector<double> stress;
+    barostat->computeStressTensor(context, stress, true);
+
+    // Full LAMMPS pressure tensor (bar), order (XX, YY, ZZ, XY, XZ, YZ).
+    double lammpsPressure[6] = {4230.16540767, 6101.99065433, 4379.82020995,
+                                2117.89788666, -1641.04249785, -2679.17709365};
     for (int component = 0; component < 6; component++)
         ASSERT_EQUAL_TOL(-lammpsPressure[component], stress[component], 1e-3);
 }
@@ -482,6 +543,7 @@ int main(int argc, char* argv[]) {
         testRandomSeed();
         testTwoParticleStressTensor();
         testStressTensorAgainstLammps();
+        testKineticStressTensorAgainstLammps();
         testTriclinicStressTensor();
         runPlatformTests();
     }

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -177,6 +177,7 @@ UNITS = {
 ("*", "getDefaultSurfaceTension") : ("unit.bar*unit.nanometer", ()),
 ("*", "setDefaultSurfaceTension") : (None, ("unit.bar*unit.nanometer",)),
 ("*", "computeCurrentPressure") : ("unit.bar", ()),
+("*", "computeStressTensor") : ("unit.bar", ()),
 ("*", "getDefaultTemperature") : ("unit.kelvin", ()),
 ("*", "setDefaultTemperature") : (None, ("unit.kelvin",)),
 ("*", "getRelativeTemperature") : ("unit.kelvin", ()),


### PR DESCRIPTION
This is a new finite-difference stress-tensor API that applies a consistent strain to both the atomic coordinates and box vectors, while leaving computeCurrentPressure() unchanged. It also adds a triclinic regression test, Python unit metadata, and user-guide/API documentation.

Closes #5315 