### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -382,7 +382,7 @@ jobs:
         env:
           CMAKE_FLAGS: ${{ matrix.CMAKE_FLAGS }}
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           mkdir build
           cd build
           cmake -G "NMake Makefiles JOM" ^
@@ -403,7 +403,7 @@ jobs:
       - name: "Build OpenMM"
         shell: cmd /C call {0}
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd build
           jom -j 2
           if errorlevel 1 exit 1
@@ -414,7 +414,7 @@ jobs:
         shell: cmd /C call {0}
         if: ${{ !contains(matrix.CMAKE_FLAGS, 'OPENMM_BUILD_PYTHON_WRAPPERS=OFF') }}
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd build
           jom -j 2 PythonInstall
 

--- a/openmmapi/src/Integrator.cpp
+++ b/openmmapi/src/Integrator.cpp
@@ -104,7 +104,8 @@ std::vector<Vec3> Integrator::getVelocitiesForTemperature(const System &system, 
         double mass = system.getParticleMass(i);
         if (mass != 0) {
             double velocityScale = sqrt(BOLTZ*temperature/mass);
-            velocities[i] = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*velocityScale;
+            velocities[i] = Vec3(randoms[nextRandom], randoms[nextRandom+1], randoms[nextRandom+2])*velocityScale;
+            nextRandom += 3;
         }
     }
     return velocities;

--- a/plugins/drude/openmmapi/src/DrudeHelpers.cpp
+++ b/plugins/drude/openmmapi/src/DrudeHelpers.cpp
@@ -125,7 +125,8 @@ vector<Vec3> assignDrudeVelocities(const ContextImpl& context, double temperatur
         double mass = system.getParticleMass(atom);
         if (mass != 0) {
             double velocityScale = sqrt(BOLTZ*temperature/mass);
-            velocities[atom] = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*velocityScale;
+            velocities[atom] = Vec3(randoms[nextRandom], randoms[nextRandom+1], randoms[nextRandom+2])*velocityScale;
+            nextRandom += 3;
         }
     }
     // Now the particle-Drude pairs
@@ -139,14 +140,16 @@ vector<Vec3> assignDrudeVelocities(const ContextImpl& context, double temperatur
             double redMass = mass1 * mass2 * invMass;
             double fracM1 = mass1 * invMass;
             double fracM2 = mass2 * invMass;
-            Vec3 comVelocity = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*sqrt(BOLTZ*temperature*invMass);
-            Vec3 relVelocity = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*sqrt(BOLTZ*drudeTemperature/redMass);
+            Vec3 comVelocity = Vec3(randoms[nextRandom], randoms[nextRandom+1], randoms[nextRandom+2])*sqrt(BOLTZ*temperature*invMass);
+            Vec3 relVelocity = Vec3(randoms[nextRandom+3], randoms[nextRandom+4], randoms[nextRandom+5])*sqrt(BOLTZ*drudeTemperature/redMass);
+            nextRandom += 6;
             velocities[atom1] = comVelocity - fracM2 * relVelocity;
             velocities[atom2] = comVelocity + fracM1 * relVelocity;
         }
         else if (mass2 != 0) {
             double velocityScale = sqrt(BOLTZ*temperature/mass2);
-            velocities[atom2] = Vec3(randoms[nextRandom++], randoms[nextRandom++], randoms[nextRandom++])*velocityScale;
+            velocities[atom2] = Vec3(randoms[nextRandom], randoms[nextRandom+1], randoms[nextRandom+2])*velocityScale;
+            nextRandom += 3;
         }
     }
     return velocities;


### PR DESCRIPTION
CI for Windows has been broken since the [Visual Studio version was updated](https://github.com/actions/runner-images/issues/14017), so this updates the path to `vcvarsall.bat`.