### PR TITLE
Use standard OpenCL C++ header

### DIFF
--- a/platforms/opencl/CMakeLists.txt
+++ b/platforms/opencl/CMakeLists.txt
@@ -17,6 +17,12 @@ if(BUILD_TESTING AND OPENMM_BUILD_OPENCL_TESTS)
     SUBDIRS (tests)
 endif(BUILD_TESTING AND OPENMM_BUILD_OPENCL_TESTS)
 
+find_file(OPENCL_HPP_PATH opencl.hpp "${OPENCL_INCLUDE_DIR}/CL")
+mark_as_advanced(OPENCL_HPP_PATH)
+if(OPENCL_HPP_PATH)
+    ADD_DEFINITIONS(-DHAS_OPENCL_HPP)
+endif()
+
 # The source is organized into subdirectories, but we handle them all from
 # this CMakeLists file rather than letting CMake visit them as SUBDIRS.
 SET(OPENMM_SOURCE_SUBDIRS . ../common)

--- a/platforms/opencl/include/OpenCLArray.h
+++ b/platforms/opencl/include/OpenCLArray.h
@@ -25,17 +25,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#define CL_HPP_ENABLE_EXCEPTIONS
-#define CL_HPP_TARGET_OPENCL_VERSION 120
-#define CL_HPP_MINIMUM_OPENCL_VERSION 120
 #include "openmm/OpenMMException.h"
 #include "openmm/common/windowsExportCommon.h"
 #include "openmm/common/ArrayInterface.h"
-#ifdef __APPLE__
-  #include "opencl.hpp"
-#else
-  #include <CL/opencl.hpp>
-#endif
+#include "OpenCLIncludes.h"
 #include <iostream>
 #include <sstream>
 #include <vector>

--- a/platforms/opencl/include/OpenCLArray.h
+++ b/platforms/opencl/include/OpenCLArray.h
@@ -7,7 +7,7 @@
  * This is part of the OpenMM molecular simulation toolkit.                   *
  * See https://openmm.org/development.                                        *
  *                                                                            *
- * Portions copyright (c) 2009-2022 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2026 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -31,7 +31,11 @@
 #include "openmm/OpenMMException.h"
 #include "openmm/common/windowsExportCommon.h"
 #include "openmm/common/ArrayInterface.h"
-#include "opencl.hpp"
+#ifdef __APPLE__
+  #include "opencl.hpp"
+#else
+  #include <CL/opencl.hpp>
+#endif
 #include <iostream>
 #include <sstream>
 #include <vector>

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -7,7 +7,7 @@
  * This is part of the OpenMM molecular simulation toolkit.                   *
  * See https://openmm.org/development.                                        *
  *                                                                            *
- * Portions copyright (c) 2009-2025 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2026 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -46,7 +46,11 @@
     // Prevent Windows from defining macros that interfere with other code.
     #define NOMINMAX
 #endif
-#include "opencl.hpp"
+#ifdef __APPLE__
+  #include "opencl.hpp"
+#else
+  #include <CL/opencl.hpp>
+#endif
 #include "openmm/common/windowsExportCommon.h"
 #include "OpenCLArray.h"
 #include "OpenCLBondedUtilities.h"

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -46,11 +46,6 @@
     // Prevent Windows from defining macros that interfere with other code.
     #define NOMINMAX
 #endif
-#ifdef __APPLE__
-  #include "opencl.hpp"
-#else
-  #include <CL/opencl.hpp>
-#endif
 #include "openmm/common/windowsExportCommon.h"
 #include "OpenCLArray.h"
 #include "OpenCLBondedUtilities.h"

--- a/platforms/opencl/include/OpenCLIncludes.h
+++ b/platforms/opencl/include/OpenCLIncludes.h
@@ -1,13 +1,10 @@
-#ifndef OPENMM_OPENCLQUEUE_H_
-#define OPENMM_OPENCLQUEUE_H_
-
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
  * This is part of the OpenMM molecular simulation toolkit.                   *
  * See https://openmm.org/development.                                        *
  *                                                                            *
- * Portions copyright (c) 2025-2026 Stanford University and the Authors.      *
+ * Portions copyright (c) 2026 Stanford University and the Authors.           *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -25,32 +22,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#include "openmm/common/ComputeQueue.h"
-#include "OpenCLIncludes.h"
+// Include the OpenCL C and C++ APIs.
 
-namespace OpenMM {
-
-/**
- * This is the OpenCL implementation of the ComputeQueue interface.  It wraps a cl::CommandQueue.
- */
-
-class OpenCLQueue : public ComputeQueueImpl {
-public:
-    /**
-     * Create an OpenCLQueue that wraps a cl::CommandQueue.
-     */
-    OpenCLQueue(cl::CommandQueue queue) : queue(queue) {
-    }
-    /**
-     * Get the cl::CommandQueue.
-     */
-    cl::CommandQueue getQueue() {
-        return queue;
-    }
-private:
-    cl::CommandQueue queue;
-};
-
-} // namespace OpenMM
-
-#endif /*OPENMM_OPENCLQUEUE_H_*/
+#ifdef __APPLE__
+    #include <OpenCL/opencl.h>
+#else
+    #include <CL/opencl.h>
+#endif
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#ifdef CL_API_SUFFIX__VERSION_3_0
+  #include <CL/opencl.hpp>
+#else
+  #include "opencl.hpp"
+#endif

--- a/platforms/opencl/include/OpenCLIncludes.h
+++ b/platforms/opencl/include/OpenCLIncludes.h
@@ -32,7 +32,7 @@
 #define CL_HPP_ENABLE_EXCEPTIONS
 #define CL_HPP_TARGET_OPENCL_VERSION 120
 #define CL_HPP_MINIMUM_OPENCL_VERSION 120
-#ifdef CL_API_SUFFIX__VERSION_3_0
+#ifdef HAS_OPENCL_HPP
   #include <CL/opencl.hpp>
 #else
   #include "opencl.hpp"

--- a/platforms/opencl/include/OpenCLQueue.h
+++ b/platforms/opencl/include/OpenCLQueue.h
@@ -7,7 +7,7 @@
  * This is part of the OpenMM molecular simulation toolkit.                   *
  * See https://openmm.org/development.                                        *
  *                                                                            *
- * Portions copyright (c) 2025 Stanford University and the Authors.           *
+ * Portions copyright (c) 2025-2026 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -26,7 +26,11 @@
  * -------------------------------------------------------------------------- */
 
 #include "openmm/common/ComputeQueue.h"
-#include "opencl.hpp"
+#ifdef __APPLE__
+  #include "opencl.hpp"
+#else
+  #include <CL/opencl.hpp>
+#endif
 
 namespace OpenMM {
 

--- a/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
@@ -4,7 +4,7 @@
  * This is part of the OpenMM molecular simulation toolkit.                   *
  * See https://openmm.org/development.                                        *
  *                                                                            *
- * Portions copyright (c) 2008-2024 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2026 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -32,7 +32,11 @@
 #define CL_HPP_MINIMUM_OPENCL_VERSION 120
 #include "OpenCLTests.h"
 #include "TestNonbondedForce.h"
-#include "opencl.hpp"
+#ifdef __APPLE__
+  #include "opencl.hpp"
+#else
+  #include <CL/opencl.hpp>
+#endif
 
 bool canRunHugeTest() {
     // Create a minimal context just to see which platform and device are being used.

--- a/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLNonbondedForce.cpp
@@ -27,16 +27,9 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#define CL_HPP_ENABLE_EXCEPTIONS
-#define CL_HPP_TARGET_OPENCL_VERSION 120
-#define CL_HPP_MINIMUM_OPENCL_VERSION 120
 #include "OpenCLTests.h"
 #include "TestNonbondedForce.h"
-#ifdef __APPLE__
-  #include "opencl.hpp"
-#else
-  #include <CL/opencl.hpp>
-#endif
+#include "OpenCLIncludes.h"
 
 bool canRunHugeTest() {
     // Create a minimal context just to see which platform and device are being used.


### PR DESCRIPTION
Fixes #5327.  `opencl.hpp` is a standard header on all modern OpenCL distributions.  Apple still uses an ancient version that doesn't include it.  That's why we bundle a copy.  On all other platforms, we should use the standard one instead of the bundled one to avoid compatibility issues.