### PR TITLE
Use more threads for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -303,7 +303,7 @@ jobs:
           python -m openmm.testInstallation
           python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, '---Failed---', *mm.Platform.getPluginLoadFailures(), sep='\n')"
           cd build/python/tests
-          python -m pytest -v -n 4
+          python -m pytest -v -n 2
 
   windows:
     runs-on: windows-latest
@@ -448,7 +448,7 @@ jobs:
           python -m openmm.testInstallation
           python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, '---Failed---', *mm.Platform.getPluginLoadFailures(), sep='\n')"
           cd build\python\tests
-          python -m pytest -v -n 4
+          python -m pytest -v -n 2
 
   docker:
     name: ${{ matrix.name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -252,14 +252,14 @@ jobs:
         shell: bash -l {0}
         run: |
           cd build
-          make -j2 install
+          make -j4 install
 
       - name: "Build Python wrappers"
         shell: bash -l {0}
         if: ${{ !contains(matrix.CMAKE_FLAGS, 'OPENMM_BUILD_PYTHON_WRAPPERS=OFF') }}
         run: |
           cd build
-          make -j2 PythonInstall
+          make -j4 PythonInstall
 
       - name: "Check ccache performance"
         shell: bash -l {0}
@@ -274,7 +274,7 @@ jobs:
           if [[ ${{ matrix.OPENCL }} == true ]]; then
             source /opt/intel/oneapi/setvars.sh
           fi
-          python ../devtools/run-ctest.py --parallel 2 --timeout 600 --job-duration 900 --attempts 3
+          python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3
 
           if [[ ${{ matrix.os }} == ubuntu-* ]]; then SHLIB=so; else SHLIB=dylib; fi
           # This is always built
@@ -303,7 +303,7 @@ jobs:
           python -m openmm.testInstallation
           python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, '---Failed---', *mm.Platform.getPluginLoadFailures(), sep='\n')"
           cd build/python/tests
-          python -m pytest -v -n 2
+          python -m pytest -v -n 4
 
   windows:
     runs-on: windows-latest
@@ -405,9 +405,9 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd build
-          jom -j 2
+          jom -j 4
           if errorlevel 1 exit 1
-          jom -j 2 install
+          jom -j 4 install
           if errorlevel 1 exit 1
 
       - name: "Build Python wrappers"
@@ -416,7 +416,7 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cd build
-          jom -j 2 PythonInstall
+          jom -j 4 PythonInstall
 
       - name: "Check ccache performance"
         shell: cmd /C call {0}
@@ -428,7 +428,7 @@ jobs:
         run: |
           @echo on
           cd build
-          python ..\devtools\run-ctest.py --parallel 2 --timeout 600 --job-duration 900 --attempts 3
+          python ..\devtools\run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3
           if errorlevel 1 exit 1
 
           if not exist %CONDA_PREFIX%/Library/lib/OpenMM.lib exit 1
@@ -448,7 +448,7 @@ jobs:
           python -m openmm.testInstallation
           python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, '---Failed---', *mm.Platform.getPluginLoadFailures(), sep='\n')"
           cd build\python\tests
-          python -m pytest -v -n 2
+          python -m pytest -v -n 4
 
   docker:
     name: ${{ matrix.name }}
@@ -616,11 +616,11 @@ jobs:
         run: |
           set -x
           cd build
-          make -j2 install PythonInstall
-          make -j2 sphinxhtml
-          make -j2 sphinxpdf
-          make -j2 C++ApiDocs
-          make -j2 PythonApiDocs
+          make -j4 install PythonInstall
+          make -j4 sphinxhtml
+          make -j4 sphinxpdf
+          make -j4 C++ApiDocs
+          make -j4 PythonApiDocs
           mkdir -p api-docs
           mv sphinx-docs/userguide/html api-docs/userguide
           mv sphinx-docs/userguide/latex/*.pdf api-docs/userguide/

--- a/devtools/ci/gh-actions/scripts/run_steps_inside_docker_image.sh
+++ b/devtools/ci/gh-actions/scripts/run_steps_inside_docker_image.sh
@@ -88,7 +88,7 @@ python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, 
 cd python/tests
 # Gromacs is not available on condaforge for PPC/ARM
 # Membrane an MTS Langevin Integrator tests timeout (>6h!), possibly due to the emulation slowdown
-python -m pytest -v -k "not gromacs and not membrane and not MTSLangevinIntegrator" -n 4
+python -m pytest -v -k "not gromacs and not membrane and not MTSLangevinIntegrator" -n 2
 echo "::endgroup::"
 
 echo "We are done!"

--- a/devtools/ci/gh-actions/scripts/run_steps_inside_docker_image.sh
+++ b/devtools/ci/gh-actions/scripts/run_steps_inside_docker_image.sh
@@ -61,7 +61,7 @@ echo "::endgroup::"
 
 # Build
 echo "::group::Build with make..."
-make -j2 install PythonInstall
+make -j4 install PythonInstall
 echo "::endgroup::"
 
 echo "::group::Check ccache performance..."
@@ -71,7 +71,7 @@ echo "::endgroup::"
 # Core tests
 
 echo "::group::Run core tests..."
-python ${WORKSPACE}/devtools/run-ctest.py --parallel 2 --timeout 1500 --job-duration 360 --attempts 3
+python ${WORKSPACE}/devtools/run-ctest.py --parallel 4 --timeout 1500 --job-duration 360 --attempts 3
 test -f ${CONDA_PREFIX}/lib/libOpenMM.so
 test -f ${CONDA_PREFIX}/lib/plugins/libOpenMMCPU.so
 test -f ${CONDA_PREFIX}/lib/plugins/libOpenMMPME.so
@@ -88,7 +88,7 @@ python -c "import openmm as mm; print('---Loaded---', *mm.pluginLoadedLibNames, 
 cd python/tests
 # Gromacs is not available on condaforge for PPC/ARM
 # Membrane an MTS Langevin Integrator tests timeout (>6h!), possibly due to the emulation slowdown
-python -m pytest -v -k "not gromacs and not membrane and not MTSLangevinIntegrator" -n 2
+python -m pytest -v -k "not gromacs and not membrane and not MTSLangevinIntegrator" -n 4
 echo "::endgroup::"
 
 echo "We are done!"


### PR DESCRIPTION
The CI scripts specify two threads/processes for compiling and running tests.  At some point, Github updated their [configurations](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) so most free runners have four cores instead of two.  This updates the scripts accordingly.  Hopefully it should make builds run faster.