### PR TITLE
Fix replicaexchangereporter reporter format

### DIFF
--- a/wrappers/python/openmm/app/replicaexchangereporter.py
+++ b/wrappers/python/openmm/app/replicaexchangereporter.py
@@ -100,7 +100,7 @@ class ReplicaExchangeReporter(object):
         self.reportInterval = reportInterval
         self.trajectoryPerState = trajectoryPerState
         self.trajectoryPerReplica = trajectoryPerReplica
-        self.format = format
+        self.format = trajectoryFormat
         self._log = None
         self._energy = None
         numStates = len(sampler.states)


### PR DESCRIPTION
Fixes a possible typo when storing the trajectory format during the construction of the reporter. 