### PR TITLE
Fixed a GPU thread synchronization bug

### DIFF
--- a/platforms/common/src/kernels/orientationRestraintForce.cc
+++ b/platforms/common/src/kernels/orientationRestraintForce.cc
@@ -11,6 +11,7 @@ DEVICE real reduceValue(real value, LOCAL_ARG volatile real* temp) {
             temp[thread] = temp[thread] + temp[thread+step];
         SYNC_WARPS;
     }
+    SYNC_THREADS;
     for (int step = 32; step < LOCAL_SIZE; step *= 2) {
         if (thread+step < LOCAL_SIZE && thread%(2*step) == 0)
             temp[thread] = temp[thread] + temp[thread+step];

--- a/platforms/common/src/kernels/rg.cc
+++ b/platforms/common/src/kernels/rg.cc
@@ -11,6 +11,7 @@ DEVICE real reduceValue(real value, LOCAL_ARG volatile real* temp) {
             temp[thread] = temp[thread] + temp[thread+step];
         SYNC_WARPS;
     }
+    SYNC_THREADS;
     for (int step = 32; step < LOCAL_SIZE; step *= 2) {
         if (thread+step < LOCAL_SIZE && thread%(2*step) == 0)
             temp[thread] = temp[thread] + temp[thread+step];

--- a/platforms/common/src/kernels/rmsd.cc
+++ b/platforms/common/src/kernels/rmsd.cc
@@ -14,6 +14,7 @@ DEVICE real reduceValue(real value, LOCAL_ARG volatile real* temp) {
             temp[thread] = temp[thread] + temp[thread+step];
         SYNC_WARPS;
     }
+    SYNC_THREADS;
     for (int step = 32; step < LOCAL_SIZE; step *= 2) {
         if (thread+step < LOCAL_SIZE && thread%(2*step) == 0)
             temp[thread] = temp[thread] + temp[thread+step];


### PR DESCRIPTION
Fixes #5328.  This was a subtle threading issue that could cause incorrect results in RMSDForce, RGForce, and OrientationRestraintForce.  But usually it didn't.  It only seemed to occur when the GPU was trying to run multiple sets of kernels on different streams at the same time.  I really don't know why!