### PR TITLE
Support building the Python extension against a DESTDIR-staged install

### DIFF
--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -194,6 +194,17 @@ def buildKeywordDictionary(major_version_num=MAJOR_VERSION_NUM,
     openmm_lib_path = os.getenv('OPENMM_LIB_PATH')
     if not openmm_lib_path:
         reportError("Set OPENMM_LIB_PATH to point to the lib directory for OpenMM")
+    # Packaging workflows that stage a build into DESTDIR before the final
+    # system install (e.g. "make install DESTDIR=...", used by most Linux
+    # distro packagers) build this extension after the C++ libraries have
+    # only been installed to DESTDIR + OPENMM_LIB_PATH, not the real
+    # OPENMM_LIB_PATH yet, so the linker needs to search there instead.
+    # The extension's runtime rpath must still be the real OPENMM_LIB_PATH,
+    # since DESTDIR never exists on the system the extension actually runs
+    # on -- see the runtime_library_dirs assignment below, and the Darwin
+    # -rpath in extra_link_args below, which already uses openmm_lib_path
+    # (not this DESTDIR-aware variant) for the same reason.
+    openmm_lib_search_path = os.environ.get('DESTDIR', '') + openmm_lib_path
 
     extra_compile_args=['-std=c++11']
     extra_link_args=[]
@@ -218,7 +229,7 @@ def buildKeywordDictionary(major_version_num=MAJOR_VERSION_NUM,
                 os.environ['CC'] = 'clang'
                 os.environ['CXX'] = 'clang++'
 
-    library_dirs=[openmm_lib_path]
+    library_dirs=[openmm_lib_search_path]
     include_dirs=openmm_include_path.split(';')
     include_dirs.append(numpy.get_include())
 
@@ -231,7 +242,7 @@ def buildKeywordDictionary(major_version_num=MAJOR_VERSION_NUM,
                     "extra_compile_args": extra_compile_args,
                     "extra_link_args": extra_link_args}
     if platform.system() != "Windows":
-        extensionArgs["runtime_library_dirs"] = library_dirs
+        extensionArgs["runtime_library_dirs"] = [openmm_lib_path]
     setupKeywords["ext_modules"] = [Extension(**extensionArgs)]
     setupKeywords["ext_modules"] += cythonize('openmm/app/internal/*.pyx')
 


### PR DESCRIPTION
setup.py links openmm._openmm against OPENMM_LIB_PATH, which is always the final, real installation directory -- correct for the runtime rpath, but wrong as the linker's search path in any packaging workflow that stages a build into a temporary root (DESTDIR) before the real system install, since the just-built C++ libraries only exist under DESTDIR + OPENMM_LIB_PATH at that point, not OPENMM_LIB_PATH itself. This is the normal pattern used by most Linux distro packaging (RPM, deb, etc.) via "make install DESTDIR=...", and currently fails there with "cannot find -lOpenMM" (confirmed with a from-scratch build).

Search DESTDIR + OPENMM_LIB_PATH (empty DESTDIR is a no-op, so this is unchanged when not building via a staged install) while leaving the extension's runtime_library_dirs -- and the existing Darwin -rpath, which already did this correctly -- pointing at the clean OPENMM_LIB_PATH, since DESTDIR never exists on the system the extension actually runs on.

Verified with a full two-pass DESTDIR build (matching the pattern OpenMM's own docs describe: build+install the C++ libraries, then build the Python wrapper referencing the now-installed libraries): fails with "cannot find -lOpenMM" without this change, builds and installs cleanly with it, and the resulting extension's RUNPATH correctly points at the real (non-DESTDIR) OPENMM_LIB_PATH either way.