### PR TITLE
Call reporters before exchanging replicas

### DIFF
--- a/wrappers/python/openmm/app/replicaexchangesampler.py
+++ b/wrappers/python/openmm/app/replicaexchangesampler.py
@@ -195,10 +195,10 @@ class ReplicaExchangeSampler(object):
                 self.simulateReplica(i)
                 energies.append(self._sampler.computeAllEnergies())
             self.replicaStateEnergy = energies
-            self.exchangeReplicas()
             self.currentIteration += 1
             for reporter in self.reporters:
                 reporter(self)
+            self.exchangeReplicas()
 
     def simulateReplica(self, index: int, steps: int | None = None):
         """


### PR DESCRIPTION
Fixes #5354.  This changes the order of steps in replica exchange so that reporters are invoked before exchanging states.