### PR TITLE
CMakeLists.txt: avoid deprecated PythonInterp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 #   libOpenMM_static.a
 #----------------------------------------------------
 
-find_package(PythonInterp)
+find_package(Python 3.5 COMPONENTS Interpreter)
 mark_as_advanced(CLEAR PYTHON_EXECUTABLE)
 
 # Don't create a new project name if this is part of a mega-build from the


### PR DESCRIPTION
When configuring `openmm` with `cmake 4.4.0`, one gets the warning
```
CMake Warning (policy) at CMakeLists.txt:15 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.
```
and the detailed version is
```
$ cmake --help-policy CMP0148
CMP0148
-------

.. versionadded:: 3.27

The ``FindPythonInterp`` and ``FindPythonLibs`` modules are removed.

These modules have been deprecated since CMake 3.12.
CMake 3.27 and above prefer to not provide the modules.
This policy provides compatibility for projects that have not been
ported away from them.

Projects using the ``FindPythonInterp`` and/or ``FindPythonLibs``
modules should be updated to use one of their replacements:

* ``FindPython3``
* ``FindPython2``
* ``FindPython``

The ``OLD`` behavior of this policy is for ``find_package(PythonInterp)``
and ``find_package(PythonLibs)`` to load the deprecated modules.  The ``NEW``
behavior is for uses of the modules to fail as if they do not exist.

This policy was introduced in CMake version 3.27.
It may be set by ``cmake_policy()`` or ``cmake_minimum_required()``.
If it is not set, CMake warns, and uses ``OLD`` behavior.

.. note::
  The ``OLD`` behavior of a policy is
  :ref:`deprecated by definition <cmake-policies-intro>`
  and may be removed in a future version of CMake.
```
The trivial patch
```
-find_package(PythonInterp)
+find_package(Python 3.5 COMPONENTS Interpreter)
```
gets rid fo the warning.

Presumably you don't want python 2. I picked 3.5, as it is the same as the choice made by `oneTBB`, and is ancient and probably not found in the wild anyway.

To test, I installed `python 2.7`, so my NetBSD system has
```
$ /usr/pkg/bin/python --version
Python 3.14.6
$ /usr/pkg/bin/python2 --version
Python 2.7.18
$ /usr/pkg/bin/python2.7 --version
Python 2.7.18
$ /usr/pkg/bin/python3 --version
Python 3.14.6
$ /usr/pkg/bin/python3.14 --version
Python 3.14.6
```

Configuring before the patch:
```
-- Found PythonInterp: /usr/pkg/bin/python (found version "3.14.6")
```
and after the patch
```
-- Found Python: /usr/pkg/bin/python3.14 (found suitable version "3.14.6", minimum required is "3.5") found components: Interpreter
```

Testing after building and installing:
```
$ python
Python 3.14.6 (main, Jul 16 2026, 11:27:09) [GCC 14.3.0] on netbsd11
Type "help", "copyright", "credits" or "license" for more information.
>>> import openmm
>>> print(openmm.openmm.Platform.getOpenMMVersion())
8.6
>>> exit()
```

