### PR TITLE
Improve CCMA robustness with delayed position damping

### DIFF
--- a/platforms/common/src/IntegrationUtilities.cpp
+++ b/platforms/common/src/IntegrationUtilities.cpp
@@ -765,6 +765,7 @@ IntegrationUtilities::IntegrationUtilities(ComputeContext& context, const System
         ccmaUpdateKernel->addArg(ccmaDelta2);
         ccmaUpdateKernel->addArg(ccmaConverged);
         ccmaUpdateKernel->addArg();
+        ccmaUpdateKernel->addArg();
         ccmaFullKernel->addArg();
         ccmaFullKernel->addArg(ccmaAtoms);
         ccmaFullKernel->addArg(ccmaNumAtomConstraints);

--- a/platforms/common/src/kernels/integrationUtilities.cc
+++ b/platforms/common/src/kernels/integrationUtilities.cc
@@ -721,8 +721,11 @@ KERNEL void multiplyByCCMAConstraintMatrixKernel(GLOBAL const mixed* RESTRICT de
  */
 DEVICE void updateCCMAAtomPositions(GLOBAL const int* RESTRICT atoms, GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
         GLOBAL const mixed4* RESTRICT constraintDistance, GLOBAL mixed4* RESTRICT atomPositions, GLOBAL const mixed4* RESTRICT velm,
-        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, int iteration) {
-    mixed damping = (iteration < 2 ? 0.5f : 1.0f);
+        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, int iteration, int constrainVelocities) {
+    // Preserve the initial damping, then use half steps for slow position solves
+    // to reduce oscillatory divergence.
+    const int positionDampingStart = 12;
+    mixed damping = (iteration < 2 || (!constrainVelocities && iteration >= positionDampingStart) ? 0.5f : 1.0f);
     for (int i = GLOBAL_ID; i < NUM_CCMA_ATOMS; i += GLOBAL_SIZE) {
         // Compute the new position of this atom.
 
@@ -747,13 +750,13 @@ DEVICE void updateCCMAAtomPositions(GLOBAL const int* RESTRICT atoms, GLOBAL con
 
 KERNEL void updateCCMAAtomPositionsKernel(GLOBAL const int* RESTRICT atoms, GLOBAL const int* RESTRICT numAtomConstraints, GLOBAL const int* RESTRICT atomConstraints,
         GLOBAL const mixed4* RESTRICT constraintDistance, GLOBAL mixed4* RESTRICT atomPositions, GLOBAL const mixed4* RESTRICT velm,
-        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, GLOBAL int* RESTRICT converged, int iteration) {
+        GLOBAL const mixed* RESTRICT delta1, GLOBAL const mixed* RESTRICT delta2, GLOBAL int* RESTRICT converged, int iteration, int constrainVelocities) {
     if (GROUP_ID == 0 && LOCAL_ID == 0)
         converged[1-iteration%2] = 1;
     if (converged[iteration%2])
         return; // The constraint iteration has already converged.
     updateCCMAAtomPositions(atoms, numAtomConstraints, atomConstraints, constraintDistance, atomPositions, velm,
-            delta1, delta2, iteration);
+            delta1, delta2, iteration, constrainVelocities);
 }
 
 /**
@@ -789,10 +792,10 @@ KERNEL void runCCMA(int constrainVelocities, GLOBAL const int* RESTRICT atoms, G
         SYNC_THREADS
         if (constrainVelocities)
             updateCCMAAtomPositions(atoms, numAtomConstraints, atomConstraints, constraintDistance, velm, velm,
-                    delta1, delta2, iteration);
+                    delta1, delta2, iteration, constrainVelocities);
         else
             updateCCMAAtomPositions(atoms, numAtomConstraints, atomConstraints, constraintDistance, posDelta, velm,
-                    delta1, delta2, iteration);
+                    delta1, delta2, iteration, constrainVelocities);
         SYNC_THREADS
         if (groupConverged)
             return;

--- a/platforms/cuda/src/CudaIntegrationUtilities.cpp
+++ b/platforms/cuda/src/CudaIntegrationUtilities.cpp
@@ -111,6 +111,7 @@ void CudaIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, do
             const int checkInterval = 4;
             ccmaConvergedMemory[0] = 0;
             ccmaUpdateKernel->setArg(4, constrainVelocities ? context.getVelm() : posDelta);
+            ccmaUpdateKernel->setArg(10, (int) constrainVelocities);
             for (int i = 0; i < 150; i++) {
                 ccmaForceKernel->setArg(8, i);
                 ccmaForceKernel->execute(ccmaConstraintAtoms.getSize());

--- a/platforms/hip/src/HipIntegrationUtilities.cpp
+++ b/platforms/hip/src/HipIntegrationUtilities.cpp
@@ -112,6 +112,7 @@ void HipIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, dou
             const int checkInterval = 4;
             ccmaConvergedMemory[0] = 0;
             ccmaUpdateKernel->setArg(4, constrainVelocities ? context.getVelm() : posDelta);
+            ccmaUpdateKernel->setArg(10, (int) constrainVelocities);
             for (int i = 0; i < 150; i++) {
                 ccmaForceKernel->setArg(8, i);
                 ccmaForceKernel->execute(ccmaConstraintAtoms.getSize());

--- a/platforms/opencl/src/OpenCLIntegrationUtilities.cpp
+++ b/platforms/opencl/src/OpenCLIntegrationUtilities.cpp
@@ -99,6 +99,7 @@ void OpenCLIntegrationUtilities::applyConstraintsImpl(bool constrainVelocities, 
             ccmaConvergedHostMemory[0] = 0;
             queue.enqueueUnmapMemObject(ccmaConvergedHostBuffer.getDeviceBuffer(), ccmaConvergedHostMemory);
             ccmaUpdateKernel->setArg(4, constrainVelocities ? context.getVelm() : posDelta);
+            ccmaUpdateKernel->setArg(10, (int) constrainVelocities);
             for (int i = 0; i < 150; i++) {
                 ccmaForceKernel->setArg(8, i);
                 ccmaForceKernel->execute(ccmaConstraintAtoms.getSize());

--- a/platforms/reference/src/SimTKReference/ReferenceCCMAAlgorithm.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCCMAAlgorithm.cpp
@@ -251,6 +251,9 @@ void ReferenceCCMAAlgorithm::applyConstraints(vector<Vec3>& atomCoordinates,
 
     // main loop
 
+    // Keep the fast undamped path, then use half steps for slow position solves
+    // to reduce oscillatory divergence.
+    const int positionDampingStart = 12;
     int iterations = 0;
     int numberConverged = 0;
     vector<double> constraintDelta(_numberOfConstraints);
@@ -280,6 +283,7 @@ void ReferenceCCMAAlgorithm::applyConstraints(vector<Vec3>& atomCoordinates,
         }
         if (numberConverged == _numberOfConstraints)
             break;
+        double damping = (!constrainingVelocities && iterations >= positionDampingStart ? 0.5 : 1.0);
         iterations++;
 
         if (_matrix.size() > 0) {
@@ -294,7 +298,7 @@ void ReferenceCCMAAlgorithm::applyConstraints(vector<Vec3>& atomCoordinates,
         for (int ii = 0; ii < _numberOfConstraints; ii++) {
             int atomI = _atomIndices[ii].first;
             int atomJ = _atomIndices[ii].second;
-            Vec3 dr = r_ij[ii]*constraintDelta[ii];
+            Vec3 dr = r_ij[ii]*(damping*constraintDelta[ii]);
             atomCoordinatesP[atomI] += dr*inverseMasses[atomI];
             atomCoordinatesP[atomJ] -= dr*inverseMasses[atomJ];
         }

--- a/tests/TestSettle.h
+++ b/tests/TestSettle.h
@@ -34,6 +34,7 @@
 #include "openmm/System.h"
 #include "openmm/LangevinIntegrator.h"
 #include "sfmt/SFMT.h"
+#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -95,12 +96,56 @@ void testConstraints() {
     }
 }
 
+// Regression for https://github.com/openmm/openmm/issues/3603.
+void testIssue3603FourParticleCCMAConvergence() {
+    const double tolerance = 1e-4;
+    const vector<double> masses = {50.0, 50.0, 50.0, 50.0};
+    const vector<pair<int, int> > constraintParticles = {
+        make_pair(0, 1), make_pair(0, 2), make_pair(1, 2), make_pair(3, 1), make_pair(3, 2)
+    };
+    const vector<double> constraintDistances = {0.4904, 0.6019, 0.2719, 0.7237, 0.5376};
+    const vector<Vec3> positions = {
+        Vec3(5.566, 7.728, 3.213),
+        Vec3(5.494, 7.973, 3.631),
+        Vec3(5.354, 7.788, 3.773),
+        Vec3(5.295, 7.811, 4.307)
+    };
+    System system;
+    for (double mass : masses)
+        system.addParticle(mass);
+    for (int i = 0; i < (int) constraintParticles.size(); i++)
+        system.addConstraint(constraintParticles[i].first, constraintParticles[i].second, constraintDistances[i]);
+    LangevinIntegrator integrator(300.0, 1.0, 0.002);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    context.applyConstraints(tolerance);
+
+    State state = context.getState(State::Positions);
+    const vector<Vec3>& constrainedPositions = state.getPositions();
+    for (const Vec3& position : constrainedPositions)
+        for (int i = 0; i < 3; i++)
+            ASSERT(std::isfinite(position[i]));
+    const double lowerTol = 1-2*tolerance+tolerance*tolerance;
+    const double upperTol = 1+2*tolerance+tolerance*tolerance;
+    for (int i = 0; i < system.getNumConstraints(); i++) {
+        int particle1, particle2;
+        double distance;
+        system.getConstraintParameters(i, particle1, particle2, distance);
+        Vec3 delta = constrainedPositions[particle1]-constrainedPositions[particle2];
+        double distanceSquared = delta.dot(delta);
+        double targetSquared = distance*distance;
+        ASSERT(distanceSquared >= lowerTol*targetSquared);
+        ASSERT(distanceSquared <= upperTol*targetSquared);
+    }
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
     try {
         initializeTests(argc, argv);
         testConstraints();
+        testIssue3603FourParticleCCMAConvergence();
         runPlatformTests();
     }
     catch(const exception& e) {


### PR DESCRIPTION
# Draft PR: Improve CCMA robustness with delayed position damping

## Summary

This draft adds a fallback for CCMA position constraints:

- Reference uses full corrections for iterations 0 through 11, then half
  corrections.
- Common preserves its existing half corrections at iterations 0 and 1, uses
  full corrections at iterations 2 through 11, then returns to half
  corrections.
- Velocity constraints are unchanged.

The threshold of 12 is empirical. This is a robustness fallback, not a general
convergence guarantee.

## Motivation

The four-particle reproducer in #3603 diverges under the current Reference
position iteration. For one anchored linearized mode, the update has a
certified eigenvalue in `(-1.8, -1.75)`. Applying half corrections maps that
mode to approximately `(-0.4, -0.375)`.

This explains one failure mode of the Reference recurrence. It does not prove
global CCMA convergence or cover every constraint graph.

## Changes

- Apply delayed half-step damping to Reference and Common position
  corrections.
- Pass an explicit position-or-velocity flag to the shared Common kernel so
  velocity behavior stays unchanged.
- Add the public four-particle reproducer to the shared SETTLE test suite.

## Tests

Before this patch, the new four-particle regression fails its squared-distance
assertion on Reference and CPU.

With this patch:

- Reference passes.
- CPU passes.
- OpenCL single precision passes.
- Existing Reference, CPU, and OpenCL SETTLE and Verlet tests pass.
- A manual OpenCL test with more than 1,024 constraints passes position and
  velocity checks, exercising the split-kernel path.

The companion audit also models the exact current and patched Common schedules
on 80 bounded float64 inputs. The patched schedule loses none of the 65
current-schedule successes and makes the original issue case converge at
`1e-4` and `1e-6`. This is distance-only numerical evidence. It does not
replace compiled backend tests.

## Known limits

The later eight-particle mixed-angle fixture from #3603 passes on Reference and
CPU. OpenCL single precision still misses the strict squared-distance tolerance
on four of five constraints. This draft therefore does not claim to resolve
every configuration reported in #3603.

Still outstanding:

- CUDA runtime testing
- HIP runtime testing
- OpenCL mixed and double precision
- full CI
- performance measurements
- broader slow-convergence systems

## Maintainer question

Is delayed position damping an acceptable fallback direction for CCMA? Should
the threshold remain a fixed iteration count, become platform-specific, or be
triggered by measured residual behavior before this moves beyond Draft?
