### PR TITLE
Validate complete constraint triangles before solver initialization

### DIFF
--- a/openmmapi/src/ContextImpl.cpp
+++ b/openmmapi/src/ContextImpl.cpp
@@ -50,6 +50,49 @@ using namespace OpenMM;
 using namespace std;
 const static char CHECKPOINT_MAGIC_BYTES[] = "OpenMM Binary Checkpoint\n";
 
+namespace {
+
+bool violatesStrictTriangleInequality(double distance1, double distance2, double distance3) {
+    double distances[] = {distance1, distance2, distance3};
+    sort(distances, distances+3);
+    // Subtraction avoids overflow.  Equality is unsafe: constraint solvers
+    // require a nondegenerate triangle.
+    return distances[0] <= distances[2]-distances[1];
+}
+
+bool isUnsafeAtSettlePrecision(double distance1, double distance2, double distance3) {
+    float distance12 = (float) distance1;
+    float distance13 = (float) distance2;
+    float distance23 = (float) distance3;
+    float arm, base;
+    if (distance12 == distance13) {
+        arm = distance12;
+        base = distance23;
+    }
+    else if (distance12 == distance23) {
+        arm = distance12;
+        base = distance13;
+    }
+    else if (distance13 == distance23) {
+        arm = distance13;
+        base = distance12;
+    }
+    else
+        return false;
+    float stored[] = {distance12, distance13, distance23};
+    for (int i = 0; i < 3; i++)
+        if (!std::isfinite(stored[i]) || stored[i] <= 0)
+            return true;
+    float halfBase = 0.5f*base;
+    float radicand = arm*arm-halfBase*halfBase;
+    if (!(radicand > 0 && std::isnormal(radicand)))
+        return true;
+    sort(stored, stored+3);
+    // SETTLE selects and stores its geometry in float on every backend.
+    return (double) stored[0] <= (double) stored[2]-(double) stored[1];
+}
+
+}
 
 ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integrator, Platform* platform, const map<string, string>& properties, ContextImpl* originalContext) :
         owner(owner), system(system), integrator(integrator), hasInitializedForces(false), hasSetPositions(false), integratorIsDeleted(false), hasMinimizeKernel(false),
@@ -64,6 +107,7 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
         if (system.isVirtualSite(i) && system.getParticleMass(i) != 0.0)
             throw OpenMMException("Virtual site has nonzero mass");
     set<pair<int, int> > constraintAtoms;
+    vector<map<int, double> > constraintDistances(numParticles);
     for (int i = 0; i < system.getNumConstraints(); i++) {
         int particle1, particle2;
         double distance;
@@ -72,6 +116,8 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
             throw OpenMMException("A constraint cannot connect a particle to itself");
         if (particle1 < 0 || particle2 < 0 || particle1 >= numParticles || particle2 >= numParticles)
             throw OpenMMException("Illegal particle index in constraint");
+        if (!std::isfinite(distance) || distance <= 0)
+            throw OpenMMException("Constraint distance must be finite and positive");
         double mass1 = system.getParticleMass(particle1);
         double mass2 = system.getParticleMass(particle2);
         if ((mass1 == 0.0 && mass2 != 0.0) || (mass2 == 0.0 && mass1 != 0.0))
@@ -80,6 +126,33 @@ ContextImpl::ContextImpl(Context& owner, const System& system, Integrator& integ
         if (constraintAtoms.find(atoms) != constraintAtoms.end())
             throw OpenMMException("The System has two constraints between the same atoms.  This will produce a singular constraint matrix.");
         constraintAtoms.insert(atoms);
+        constraintDistances[particle1][particle2] = distance;
+        constraintDistances[particle2][particle1] = distance;
+    }
+    // Check each complete triangle once.  Search the smaller adjacency list so
+    // high-degree partial graphs remain inexpensive.
+    for (auto atoms : constraintAtoms) {
+        int particle1 = atoms.first;
+        int particle2 = atoms.second;
+        bool searchFromParticle1 = constraintDistances[particle1].size() < constraintDistances[particle2].size();
+        const map<int, double>& candidates = searchFromParticle1 ? constraintDistances[particle1] : constraintDistances[particle2];
+        const map<int, double>& otherNeighbors = searchFromParticle1 ? constraintDistances[particle2] : constraintDistances[particle1];
+        double distance12 = constraintDistances[particle1].find(particle2)->second;
+        for (auto candidate : candidates) {
+            int particle3 = candidate.first;
+            if (particle3 <= particle2)
+                continue;
+            auto otherDistance = otherNeighbors.find(particle3);
+            bool isSettleCandidate = constraintDistances[particle1].size() == 2 &&
+                    constraintDistances[particle2].size() == 2 && constraintDistances[particle3].size() == 2 &&
+                    system.getParticleMass(particle1) != 0 && system.getParticleMass(particle2) != 0 &&
+                    system.getParticleMass(particle3) != 0;
+            if (otherDistance != otherNeighbors.end() &&
+                    (violatesStrictTriangleInequality(distance12, candidate.second, otherDistance->second) ||
+                    (isSettleCandidate && isUnsafeAtSettlePrecision(distance12, candidate.second, otherDistance->second))))
+                throw OpenMMException("Constraints among particles "+to_string(particle1)+", "+to_string(particle2)+", and "+
+                        to_string(particle3)+" form a degenerate, inconsistent, or numerically unsafe triangle");
+        }
     }
     
     // Validate the list of properties.

--- a/tests/TestSettle.h
+++ b/tests/TestSettle.h
@@ -31,14 +31,241 @@
 #include "openmm/internal/AssertionUtilities.h"
 #include "openmm/Context.h"
 #include "openmm/NonbondedForce.h"
+#include "openmm/OpenMMException.h"
 #include "openmm/System.h"
 #include "openmm/LangevinIntegrator.h"
 #include "sfmt/SFMT.h"
+#include <cmath>
 #include <iostream>
+#include <limits>
+#include <string>
 #include <vector>
 
 using namespace OpenMM;
 using namespace std;
+
+struct TriangleExecutionResult {
+    bool contextRejected;
+    bool positionsFinite;
+    bool velocitiesFinite;
+};
+
+bool areFinite(const vector<Vec3>& values) {
+    for (const Vec3& value : values)
+        for (int component = 0; component < 3; component++)
+            if (!isfinite(value[component]))
+                return false;
+    return true;
+}
+
+TriangleExecutionResult executeTriangleAtConstraintSeam(double distance12) {
+    TriangleExecutionResult result = {false, true, true};
+    System system;
+    for (int i = 0; i < 3; i++)
+        system.addParticle(1.0);
+    system.addConstraint(0, 1, 1.0);
+    system.addConstraint(0, 2, 1.0);
+    system.addConstraint(1, 2, distance12);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    Context* context = NULL;
+    try {
+        context = new Context(system, integrator, platform);
+    }
+    catch (const OpenMMException& exception) {
+        result.contextRejected = true;
+        ASSERT(string(exception.what()).find("degenerate, inconsistent, or numerically unsafe triangle") != string::npos);
+    }
+    if (context != NULL) {
+        vector<Vec3> positions = {Vec3(0, 0, 0), Vec3(1, 0, 0), Vec3(0, 1, 0)};
+        vector<Vec3> velocities = {Vec3(0.1, 0.2, 0.3), Vec3(-0.2, 0.1, -0.1), Vec3(0.3, -0.1, 0.2)};
+        context->setPositions(positions);
+        context->setVelocities(velocities);
+        context->applyConstraints(1e-5);
+        result.positionsFinite = areFinite(context->getState(State::Positions).getPositions());
+        context->applyVelocityConstraints(1e-5);
+        result.velocitiesFinite = areFinite(context->getState(State::Velocities).getVelocities());
+        delete context;
+    }
+    return result;
+}
+
+void testDegenerateTriangleExecution() {
+    const double previousFloat = nextafterf(2.0f, 0.0f);
+    const double roundingBoundary = 0.5*(2.0+previousFloat);
+    const double lastRoundsDown = nextafter(roundingBoundary, 0.0);
+    const double firstRoundsToCollinear = nextafter(roundingBoundary, 2.0);
+    const double nextBelowTwo = nextafter(2.0, 0.0);
+    const double nextAboveTwo = nextafter(2.0, numeric_limits<double>::infinity());
+    ASSERT((float) lastRoundsDown == (float) previousFloat);
+    ASSERT((float) firstRoundsToCollinear == 2.0f);
+    ASSERT((float) nextBelowTwo == 2.0f);
+    ASSERT((float) nextAboveTwo == 2.0f);
+
+    TriangleExecutionResult exact = executeTriangleAtConstraintSeam(2.0);
+    TriangleExecutionResult nextBelow = executeTriangleAtConstraintSeam(nextBelowTwo);
+    TriangleExecutionResult nextAbove = executeTriangleAtConstraintSeam(nextAboveTwo);
+    TriangleExecutionResult firstRounded = executeTriangleAtConstraintSeam(firstRoundsToCollinear);
+    TriangleExecutionResult nondegenerate = executeTriangleAtConstraintSeam(lastRoundsDown);
+
+    ASSERT(exact.contextRejected);
+    ASSERT(nextBelow.contextRejected);
+    ASSERT(nextAbove.contextRejected);
+    ASSERT(firstRounded.contextRejected);
+    ASSERT(!nondegenerate.contextRejected);
+    ASSERT(nondegenerate.positionsFinite);
+    ASSERT(nondegenerate.velocitiesFinite);
+}
+
+void testEmbeddedNearDegenerateTriangle() {
+    const double previousFloat = nextafterf(2.0f, 0.0f);
+    const double roundingBoundary = 0.5*(2.0+previousFloat);
+    const double firstRoundsToCollinear = nextafter(roundingBoundary, 2.0);
+    System system;
+    for (int i = 0; i < 4; i++)
+        system.addParticle(1.0);
+    system.addConstraint(0, 1, 1.0);
+    system.addConstraint(0, 2, 1.0);
+    system.addConstraint(1, 2, firstRoundsToCollinear);
+    system.addConstraint(0, 3, 1.0);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    Context context(system, integrator, platform);
+    const double halfBase = 0.5*firstRoundsToCollinear;
+    const double height = sqrt(1.0-halfBase*halfBase);
+    vector<Vec3> positions = {Vec3(0, height, 0), Vec3(-halfBase, 0, 0),
+            Vec3(halfBase, 0, 0), Vec3(0, height, 1)};
+    vector<Vec3> velocities = {Vec3(0.1, 0.2, 0.3), Vec3(-0.2, 0.1, -0.1),
+            Vec3(0.3, -0.1, 0.2), Vec3(-0.1, 0.2, -0.2)};
+    context.setPositions(positions);
+    context.setVelocities(velocities);
+    context.applyConstraints(1e-5);
+    ASSERT(areFinite(context.getState(State::Positions).getPositions()));
+    context.applyVelocityConstraints(1e-5);
+    ASSERT(areFinite(context.getState(State::Velocities).getVelocities()));
+}
+
+void assertTriangleRejected(double distance01, double distance02, double distance12) {
+    System system;
+    for (int i = 0; i < 3; i++)
+        system.addParticle(1.0);
+    system.addConstraint(0, 1, distance01);
+    system.addConstraint(0, 2, distance02);
+    system.addConstraint(1, 2, distance12);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    bool threwException = false;
+    try {
+        Context context(system, integrator, platform);
+    }
+    catch (const OpenMMException& exception) {
+        threwException = true;
+        ASSERT(string(exception.what()).find("degenerate, inconsistent, or numerically unsafe triangle") != string::npos);
+    }
+    ASSERT(threwException);
+}
+
+void testImpossibleTriangle() {
+    assertTriangleRejected(1.0, 1.0, 3.0);
+    assertTriangleRejected(1.0, 2.0, 4.0);
+    assertTriangleRejected(1.0e-20, 1.0e-20, 3.0e-20);
+    assertTriangleRejected(1.0e20, 1.0e20, 3.0e20);
+    const double denorm = numeric_limits<double>::denorm_min();
+    const double maximum = numeric_limits<double>::max();
+    assertTriangleRejected(denorm, denorm, 3*denorm);
+    assertTriangleRejected(maximum/3, maximum/3, maximum);
+    const double scale = 1.0e20;
+    const double epsilon = numeric_limits<double>::epsilon();
+    assertTriangleRejected(scale, scale, 2*scale*(1+16*epsilon));
+}
+
+void testSettleArithmeticBoundaries() {
+    const float largeArm = 1.0e20f;
+    const float largeHalfBase = 0.5f*largeArm;
+    const float largeRadicand = largeArm*largeArm-largeHalfBase*largeHalfBase;
+    ASSERT(!isfinite(largeRadicand) || largeRadicand <= 0);
+    assertTriangleRejected(1.0e20, 1.0e20, 1.0e20);
+
+    const float subnormalArm = 1.0e-19f;
+    const float subnormalHalfBase = 0.5f*subnormalArm;
+    const float subnormalRadicand = subnormalArm*subnormalArm-subnormalHalfBase*subnormalHalfBase;
+    ASSERT(subnormalRadicand > 0);
+    ASSERT(!std::isnormal(subnormalRadicand));
+    assertTriangleRejected(1.0e-19, 1.0e-19, 1.0e-19);
+
+    const float smallArm = 1.0e-30f;
+    const float smallHalfBase = 0.5f*smallArm;
+    const float smallRadicand = smallArm*smallArm-smallHalfBase*smallHalfBase;
+    ASSERT(!isfinite(smallRadicand) || smallRadicand <= 0);
+    assertTriangleRejected(1.0e-30, 1.0e-30, 1.0e-30);
+}
+
+void testEmbeddedImpossibleTriangle() {
+    System system;
+    for (int i = 0; i < 6; i++)
+        system.addParticle(1.0);
+    system.addConstraint(4, 1, 1.0);
+    system.addConstraint(5, 1, 1.0);
+    system.addConstraint(5, 4, 3.0);
+    system.addConstraint(4, 2, 1.0);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    bool threwException = false;
+    try {
+        Context context(system, integrator, platform);
+    }
+    catch (const OpenMMException& exception) {
+        threwException = true;
+        ASSERT(string(exception.what()).find("degenerate, inconsistent, or numerically unsafe triangle") != string::npos);
+    }
+    ASSERT(threwException);
+}
+
+void assertTriangleAccepted(double distance01, double distance02, double distance12) {
+    System system;
+    for (int i = 0; i < 3; i++)
+        system.addParticle(1.0);
+    system.addConstraint(0, 1, distance01);
+    system.addConstraint(0, 2, distance02);
+    system.addConstraint(1, 2, distance12);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    Context context(system, integrator, platform);
+}
+
+void testTriangleBoundaries() {
+    assertTriangleAccepted(3.0, 4.0, 5.0);
+}
+
+void testPartialConstraintGraph() {
+    System system;
+    for (int i = 0; i < 6; i++)
+        system.addParticle(1.0);
+    for (int particle1 = 0; particle1 < 3; particle1++)
+        for (int particle2 = 3; particle2 < 6; particle2++)
+            system.addConstraint(particle1, particle2, 1.0);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    Context context(system, integrator, platform);
+}
+
+void assertInvalidConstraintDistance(double distance) {
+    System system;
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    system.addConstraint(0, 1, distance);
+    LangevinIntegrator integrator(100.0, 2.0, 0.001);
+    bool threwException = false;
+    try {
+        Context context(system, integrator, platform);
+    }
+    catch (const OpenMMException& exception) {
+        threwException = true;
+        ASSERT(string(exception.what()).find("finite and positive") != string::npos);
+    }
+    ASSERT(threwException);
+}
+
+void testInvalidConstraintDistances() {
+    assertInvalidConstraintDistance(0.0);
+    assertInvalidConstraintDistance(-1.0);
+    assertInvalidConstraintDistance(numeric_limits<double>::infinity());
+    assertInvalidConstraintDistance(numeric_limits<double>::quiet_NaN());
+}
 
 void testConstraints() {
     const int numMolecules = 10;
@@ -100,6 +327,14 @@ void runPlatformTests();
 int main(int argc, char* argv[]) {
     try {
         initializeTests(argc, argv);
+        testImpossibleTriangle();
+        testSettleArithmeticBoundaries();
+        testEmbeddedImpossibleTriangle();
+        testTriangleBoundaries();
+        testDegenerateTriangleExecution();
+        testEmbeddedNearDegenerateTriangle();
+        testPartialConstraintGraph();
+        testInvalidConstraintDistances();
         testConstraints();
         runPlatformTests();
     }


### PR DESCRIPTION
## Summary

- Reject non-finite or non-positive constraint distances when OpenMM creates a `Context`.
- Reject complete constraint triangles that are degenerate or violate the strict triangle inequality.
- Reject isolated SETTLE triangles whose float-stored geometry is not numerically safe for the solver.

## Motivation

OpenMM accepts a system with three unit-mass particles and constraint distances `1, 1, 2`. It selects SETTLE after storing those distances as `float`. Position constraints then compute a zero `rb` and `ra` before dividing by `ra`, producing NaN positions. The corresponding velocity constraint system is singular.

A strictly valid double-precision triangle can reach the same failure: the double immediately below `2` rounds to `2.0f`, so `1, 1, nextafter(2, 0)` becomes exactly collinear in SETTLE's stored geometry.

The new validation raises an `OpenMMException` before a platform initializes its constraint solver.

## Numerical policy

For every complete triangle, the validator sorts the double-precision side lengths and checks:

`smallest <= largest - middle`

The subtraction form avoids overflow and enforces a strict, nondegenerate triangle without a tolerance band.

The additional float check applies only to an isolated potential SETTLE cluster: all three particles have exactly two constrained neighbors, all have nonzero mass, and at least two float-stored sides compare equal under SETTLE's selection rules.

For that cluster, validation rejects:

- zero or non-finite float-stored sides;
- non-strict float-stored side lengths;
- a SETTLE radicand that is not both positive and normal.

The radicand is evaluated with the same float arithmetic used by the common SETTLE path:

`arm*arm - (0.5f*base)*(0.5f*base)`

Strictly valid near-degenerate triangles that are not isolated SETTLE clusters remain available to CCMA. Incomplete constraint graphs remain accepted because their missing distances may admit a realization.

## Tests

The shared SETTLE tests now cover:

- exact `1, 1, 2`;
- adjacent double values below and above `2`;
- the first valid double value that rounds to a collinear SETTLE geometry;
- the last value that remains nondegenerate after float storage, including finite position and velocity constraint execution;
- float-square overflow (`1e20`), a positive subnormal radicand (`1e-19`), and float-square underflow (`1e-30`);
- an embedded near-degenerate triangle routed through CCMA, with finite position and velocity results;
- existing valid, inconsistent, extreme-scale, embedded, scalar-distance, and partial-graph cases.

`TestReferenceSettle` and `TestCpuSettle` pass after the final guard.

The configured 124-test serial suite was also run twice before the final narrow normal-radicand guard. Each run passed 123 tests and had one different stochastic test fail; each failed test passed immediately on isolated rerun. Both SETTLE tests passed in both full runs.

CUDA was unavailable locally. The common float storage and kernel arithmetic were inspected, and the unsafe arithmetic boundaries are covered by the shared tests for upstream platform CI.

## Scope

This change validates constraint input at `Context` creation. SETTLE and CCMA keep their existing algorithms, damping, convergence criteria, and tolerances. Issue #3603 remains a separate solver-convergence problem.
