### PR TITLE
Give kernel interface classes a key function

### DIFF
--- a/olla/include/openmm/kernels.h
+++ b/olla/include/openmm/kernels.h
@@ -92,6 +92,7 @@ public:
     }
     CalcForcesAndEnergyKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcForcesAndEnergyKernel();
     /**
      * Initialize the kernel.
      * 
@@ -136,6 +137,7 @@ public:
     }
     UpdateStateDataKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~UpdateStateDataKernel();
     /**
      * Initialize the kernel.
      *
@@ -255,6 +257,7 @@ public:
     }
     ApplyConstraintsKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~ApplyConstraintsKernel();
     /**
      * Initialize the kernel.
      *
@@ -287,6 +290,7 @@ public:
     }
     VirtualSitesKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~VirtualSitesKernel();
     /**
      * Initialize the kernel.
      *
@@ -311,6 +315,7 @@ public:
     }
     MinimizeKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~MinimizeKernel();
     /**
      * Initialize the kernel.
      *
@@ -338,6 +343,7 @@ public:
     }
     CalcHarmonicBondForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcHarmonicBondForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -375,6 +381,7 @@ public:
     }
     CalcCustomBondForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomBondForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -412,6 +419,7 @@ public:
     }
     CalcHarmonicAngleForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcHarmonicAngleForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -449,6 +457,7 @@ public:
     }
     CalcCustomAngleForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomAngleForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -486,6 +495,7 @@ public:
     }
     CalcPeriodicTorsionForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcPeriodicTorsionForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -523,6 +533,7 @@ public:
     }
     CalcRBTorsionForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcRBTorsionForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -558,6 +569,7 @@ public:
     }
     CalcCMAPTorsionForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCMAPTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -593,6 +605,7 @@ public:
     }
     CalcCustomTorsionForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -638,6 +651,7 @@ public:
     }
     CalcNonbondedForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcNonbondedForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -697,6 +711,7 @@ public:
     }
     CalcConstantPotentialForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcConstantPotentialForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -760,6 +775,7 @@ public:
     }
     CalcCustomNonbondedForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomNonbondedForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -797,6 +813,7 @@ public:
     }
     CalcGBSAOBCForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcGBSAOBCForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -837,6 +854,7 @@ public:
     }
     CalcCustomGBForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomGBForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -872,6 +890,7 @@ public:
     }
     CalcCustomExternalForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomExternalForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -914,6 +933,7 @@ public:
     }
     CalcCustomHbondForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomHbondForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -949,6 +969,7 @@ public:
     }
     CalcCustomCentroidBondForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomCentroidBondForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -984,6 +1005,7 @@ public:
     }
     CalcCustomCompoundBondForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomCompoundBondForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1024,6 +1046,7 @@ public:
     }
     CalcCustomManyParticleForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomManyParticleForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1059,6 +1082,7 @@ public:
     }
     CalcGayBerneForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcGayBerneForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1094,6 +1118,7 @@ public:
     }
     CalcLCPOForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcLCPOForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1129,6 +1154,7 @@ public:
     }
     CalcCustomCVForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomCVForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1173,6 +1199,7 @@ public:
     }
     CalcRMSDForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcRMSDForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1208,6 +1235,7 @@ public:
     }
     CalcRGForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcRGForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1236,6 +1264,7 @@ public:
     }
     CalcOrientationRestraintForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcOrientationRestraintForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1271,6 +1300,7 @@ public:
     }
     IntegrateVerletStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateVerletStepKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1304,6 +1334,7 @@ public:
     }
     IntegrateNoseHooverStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateNoseHooverStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -1396,6 +1427,7 @@ public:
     }
     IntegrateLangevinMiddleStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateLangevinMiddleStepKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1429,6 +1461,7 @@ public:
     }
     IntegrateBrownianStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateBrownianStepKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1462,6 +1495,7 @@ public:
     }
     IntegrateVariableLangevinStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateVariableLangevinStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -1497,6 +1531,7 @@ public:
     }
     IntegrateVariableVerletStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateVariableVerletStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -1532,6 +1567,7 @@ public:
     }
     IntegrateCustomStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateCustomStepKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1603,6 +1639,7 @@ public:
     }
     IntegrateDPDStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateDPDStepKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1636,6 +1673,7 @@ public:
     }
     IntegrateQTBStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateQTBStepKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1702,6 +1740,7 @@ public:
     }
     ApplyAndersenThermostatKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~ApplyAndersenThermostatKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1727,6 +1766,7 @@ public:
     }
     ApplyMonteCarloBarostatKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~ApplyMonteCarloBarostatKernel();
     /**
      * Initialize the kernel.
      *
@@ -1797,6 +1837,7 @@ public:
     }
     RemoveCMMotionKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~RemoveCMMotionKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1827,6 +1868,7 @@ public:
     }
     CalcPmeReciprocalForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcPmeReciprocalForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1909,6 +1951,7 @@ public:
     }
     CalcDispersionPmeReciprocalForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcDispersionPmeReciprocalForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -1956,6 +1999,7 @@ public:
     }
     CalcATMForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcATMForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -2002,6 +2046,7 @@ public:
     }
     CalcCustomCPPForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcCustomCPPForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -2030,6 +2075,7 @@ public:
     }
     CalcPythonForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcPythonForceKernel();
     /**
      * Initialize the kernel.
      *

--- a/olla/src/KernelImpl.cpp
+++ b/olla/src/KernelImpl.cpp
@@ -35,6 +35,10 @@ using namespace std;
 KernelImpl::KernelImpl(string name, const Platform& platform) : name(name), platform(&platform), referenceCount(0) {
 }
 
+KernelImpl::~KernelImpl() {
+    assert(referenceCount == 0);
+}
+
 std::string KernelImpl::getName() const {
     return name;
 }

--- a/olla/src/kernels.cpp
+++ b/olla/src/kernels.cpp
@@ -1,0 +1,124 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Portions copyright (c) 2008 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#include "openmm/kernels.h"
+
+using namespace OpenMM;
+
+CalcForcesAndEnergyKernel::~CalcForcesAndEnergyKernel() = default;
+
+UpdateStateDataKernel::~UpdateStateDataKernel() = default;
+
+ApplyConstraintsKernel::~ApplyConstraintsKernel() = default;
+
+VirtualSitesKernel::~VirtualSitesKernel() = default;
+
+MinimizeKernel::~MinimizeKernel() = default;
+
+CalcHarmonicBondForceKernel::~CalcHarmonicBondForceKernel() = default;
+
+CalcCustomBondForceKernel::~CalcCustomBondForceKernel() = default;
+
+CalcHarmonicAngleForceKernel::~CalcHarmonicAngleForceKernel() = default;
+
+CalcCustomAngleForceKernel::~CalcCustomAngleForceKernel() = default;
+
+CalcPeriodicTorsionForceKernel::~CalcPeriodicTorsionForceKernel() = default;
+
+CalcRBTorsionForceKernel::~CalcRBTorsionForceKernel() = default;
+
+CalcCMAPTorsionForceKernel::~CalcCMAPTorsionForceKernel() = default;
+
+CalcCustomTorsionForceKernel::~CalcCustomTorsionForceKernel() = default;
+
+CalcNonbondedForceKernel::~CalcNonbondedForceKernel() = default;
+
+CalcConstantPotentialForceKernel::~CalcConstantPotentialForceKernel() = default;
+
+CalcCustomNonbondedForceKernel::~CalcCustomNonbondedForceKernel() = default;
+
+CalcGBSAOBCForceKernel::~CalcGBSAOBCForceKernel() = default;
+
+CalcCustomGBForceKernel::~CalcCustomGBForceKernel() = default;
+
+CalcCustomExternalForceKernel::~CalcCustomExternalForceKernel() = default;
+
+CalcCustomHbondForceKernel::~CalcCustomHbondForceKernel() = default;
+
+CalcCustomCentroidBondForceKernel::~CalcCustomCentroidBondForceKernel() = default;
+
+CalcCustomCompoundBondForceKernel::~CalcCustomCompoundBondForceKernel() = default;
+
+CalcCustomManyParticleForceKernel::~CalcCustomManyParticleForceKernel() = default;
+
+CalcGayBerneForceKernel::~CalcGayBerneForceKernel() = default;
+
+CalcLCPOForceKernel::~CalcLCPOForceKernel() = default;
+
+CalcCustomCVForceKernel::~CalcCustomCVForceKernel() = default;
+
+CalcRMSDForceKernel::~CalcRMSDForceKernel() = default;
+
+CalcRGForceKernel::~CalcRGForceKernel() = default;
+
+CalcOrientationRestraintForceKernel::~CalcOrientationRestraintForceKernel() = default;
+
+IntegrateVerletStepKernel::~IntegrateVerletStepKernel() = default;
+
+IntegrateNoseHooverStepKernel::~IntegrateNoseHooverStepKernel() = default;
+
+IntegrateLangevinMiddleStepKernel::~IntegrateLangevinMiddleStepKernel() = default;
+
+IntegrateBrownianStepKernel::~IntegrateBrownianStepKernel() = default;
+
+IntegrateVariableLangevinStepKernel::~IntegrateVariableLangevinStepKernel() = default;
+
+IntegrateVariableVerletStepKernel::~IntegrateVariableVerletStepKernel() = default;
+
+IntegrateCustomStepKernel::~IntegrateCustomStepKernel() = default;
+
+IntegrateDPDStepKernel::~IntegrateDPDStepKernel() = default;
+
+IntegrateQTBStepKernel::~IntegrateQTBStepKernel() = default;
+
+ApplyAndersenThermostatKernel::~ApplyAndersenThermostatKernel() = default;
+
+ApplyMonteCarloBarostatKernel::~ApplyMonteCarloBarostatKernel() = default;
+
+RemoveCMMotionKernel::~RemoveCMMotionKernel() = default;
+
+CalcPmeReciprocalForceKernel::~CalcPmeReciprocalForceKernel() = default;
+
+CalcDispersionPmeReciprocalForceKernel::~CalcDispersionPmeReciprocalForceKernel() = default;
+
+CalcATMForceKernel::~CalcATMForceKernel() = default;
+
+CalcCustomCPPForceKernel::~CalcCustomCPPForceKernel() = default;
+
+CalcPythonForceKernel::~CalcPythonForceKernel() = default;

--- a/plugins/amoeba/openmmapi/include/openmm/amoebaKernels.h
+++ b/plugins/amoeba/openmmapi/include/openmm/amoebaKernels.h
@@ -54,6 +54,7 @@ public:
 
     CalcAmoebaTorsionTorsionForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcAmoebaTorsionTorsionForceKernel();
 
     /**
      * Initialize the kernel.
@@ -87,6 +88,7 @@ public:
 
     CalcAmoebaMultipoleForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcAmoebaMultipoleForceKernel();
 
     /**
      * Initialize the kernel.
@@ -146,6 +148,7 @@ public:
 
     CalcAmoebaGeneralizedKirkwoodForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcAmoebaGeneralizedKirkwoodForceKernel();
 
     /**
      * Initialize the kernel.
@@ -186,6 +189,7 @@ public:
 
     CalcAmoebaVdwForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcAmoebaVdwForceKernel();
 
     /**
      * Initialize the kernel.
@@ -226,6 +230,7 @@ public:
 
     CalcAmoebaWcaDispersionForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcAmoebaWcaDispersionForceKernel();
 
     /**
      * Initialize the kernel.
@@ -263,6 +268,7 @@ public:
     }
     CalcHippoNonbondedForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcHippoNonbondedForceKernel();
     /**
      * Initialize the kernel.
      *

--- a/plugins/amoeba/openmmapi/src/amoebaKernels.cpp
+++ b/plugins/amoeba/openmmapi/src/amoebaKernels.cpp
@@ -1,6 +1,3 @@
-#ifndef OPENMM_KERNELIMPL_H_
-#define OPENMM_KERNELIMPL_H_
-
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -30,44 +27,18 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#include "Platform.h"
-#include <string>
-#include <cassert>
-#include "openmm/internal/windowsExport.h"
+#include "openmm/amoebaKernels.h"
 
-namespace OpenMM {
+using namespace OpenMM;
 
-/**
- * A KernelImpl defines the internal implementation of a Kernel object.  A subclass will typically
- * declare an abstract execute() method which defines the API for executing the kernel.  Other classes
- * will in turn subclass it and provide concrete implementations of the execute() method.
- */
+CalcAmoebaTorsionTorsionForceKernel::~CalcAmoebaTorsionTorsionForceKernel() = default;
 
-class OPENMM_EXPORT KernelImpl {
-public:
-    /**
-     * Create a KernelImpl.
-     * 
-     * @param name      the name of the kernel to create
-     * @param platform  the Platform that created this kernel
-     */
-    KernelImpl(std::string name, const Platform& platform);
-    virtual ~KernelImpl();
-    /**
-     * Get the name of this kernel.
-     */
-    std::string getName() const;
-    /**
-     * Get the Platform that created this KernelImpl.
-     */
-    const Platform& getPlatform();
-private:
-    friend class Kernel;
-    std::string name;
-    const Platform* platform;
-    int referenceCount;
-};
+CalcAmoebaMultipoleForceKernel::~CalcAmoebaMultipoleForceKernel() = default;
 
-} // namespace OpenMM
+CalcAmoebaGeneralizedKirkwoodForceKernel::~CalcAmoebaGeneralizedKirkwoodForceKernel() = default;
 
-#endif /*OPENMM_KERNELIMPL_H_*/
+CalcAmoebaVdwForceKernel::~CalcAmoebaVdwForceKernel() = default;
+
+CalcAmoebaWcaDispersionForceKernel::~CalcAmoebaWcaDispersionForceKernel() = default;
+
+CalcHippoNonbondedForceKernel::~CalcHippoNonbondedForceKernel() = default;

--- a/plugins/drude/openmmapi/include/openmm/DrudeKernels.h
+++ b/plugins/drude/openmmapi/include/openmm/DrudeKernels.h
@@ -51,6 +51,7 @@ public:
     }
     CalcDrudeForceKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~CalcDrudeForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -86,6 +87,7 @@ public:
     }
     IntegrateDrudeLangevinStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateDrudeLangevinStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -117,6 +119,7 @@ public:
     }
     IntegrateDrudeSCFStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateDrudeSCFStepKernel();
     /**
      * Initialize the kernel.
      *

--- a/plugins/drude/openmmapi/src/DrudeKernels.cpp
+++ b/plugins/drude/openmmapi/src/DrudeKernels.cpp
@@ -1,6 +1,3 @@
-#ifndef OPENMM_KERNELIMPL_H_
-#define OPENMM_KERNELIMPL_H_
-
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -30,44 +27,12 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#include "Platform.h"
-#include <string>
-#include <cassert>
-#include "openmm/internal/windowsExport.h"
+#include "openmm/DrudeKernels.h"
 
-namespace OpenMM {
+using namespace OpenMM;
 
-/**
- * A KernelImpl defines the internal implementation of a Kernel object.  A subclass will typically
- * declare an abstract execute() method which defines the API for executing the kernel.  Other classes
- * will in turn subclass it and provide concrete implementations of the execute() method.
- */
+CalcDrudeForceKernel::~CalcDrudeForceKernel() = default;
 
-class OPENMM_EXPORT KernelImpl {
-public:
-    /**
-     * Create a KernelImpl.
-     * 
-     * @param name      the name of the kernel to create
-     * @param platform  the Platform that created this kernel
-     */
-    KernelImpl(std::string name, const Platform& platform);
-    virtual ~KernelImpl();
-    /**
-     * Get the name of this kernel.
-     */
-    std::string getName() const;
-    /**
-     * Get the Platform that created this KernelImpl.
-     */
-    const Platform& getPlatform();
-private:
-    friend class Kernel;
-    std::string name;
-    const Platform* platform;
-    int referenceCount;
-};
+IntegrateDrudeLangevinStepKernel::~IntegrateDrudeLangevinStepKernel() = default;
 
-} // namespace OpenMM
-
-#endif /*OPENMM_KERNELIMPL_H_*/
+IntegrateDrudeSCFStepKernel::~IntegrateDrudeSCFStepKernel() = default;

--- a/plugins/rpmd/openmmapi/include/openmm/RpmdKernels.h
+++ b/plugins/rpmd/openmmapi/include/openmm/RpmdKernels.h
@@ -50,6 +50,7 @@ public:
     }
     IntegrateRPMDStepKernel(std::string name, const Platform& platform) : KernelImpl(name, platform) {
     }
+    virtual ~IntegrateRPMDStepKernel();
     /**
      * Initialize the kernel.
      *

--- a/plugins/rpmd/openmmapi/src/RpmdKernels.cpp
+++ b/plugins/rpmd/openmmapi/src/RpmdKernels.cpp
@@ -1,6 +1,3 @@
-#ifndef OPENMM_KERNELIMPL_H_
-#define OPENMM_KERNELIMPL_H_
-
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -30,44 +27,8 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#include "Platform.h"
-#include <string>
-#include <cassert>
-#include "openmm/internal/windowsExport.h"
+#include "openmm/RpmdKernels.h"
 
-namespace OpenMM {
+using namespace OpenMM;
 
-/**
- * A KernelImpl defines the internal implementation of a Kernel object.  A subclass will typically
- * declare an abstract execute() method which defines the API for executing the kernel.  Other classes
- * will in turn subclass it and provide concrete implementations of the execute() method.
- */
-
-class OPENMM_EXPORT KernelImpl {
-public:
-    /**
-     * Create a KernelImpl.
-     * 
-     * @param name      the name of the kernel to create
-     * @param platform  the Platform that created this kernel
-     */
-    KernelImpl(std::string name, const Platform& platform);
-    virtual ~KernelImpl();
-    /**
-     * Get the name of this kernel.
-     */
-    std::string getName() const;
-    /**
-     * Get the Platform that created this KernelImpl.
-     */
-    const Platform& getPlatform();
-private:
-    friend class Kernel;
-    std::string name;
-    const Platform* platform;
-    int referenceCount;
-};
-
-} // namespace OpenMM
-
-#endif /*OPENMM_KERNELIMPL_H_*/
+IntegrateRPMDStepKernel::~IntegrateRPMDStepKernel() = default;


### PR DESCRIPTION
On Linux, an OpenMM built against libc++ could not create a Context on any plugin platform from Python as Kernel::getAs() threw std::bad_cast. The abstract kernel classes declared only pure virtual members and inline constructors, so they had no key function, and every library that included the headers emitted its own weak copy of the typeinfo. Python loads the extension module with RTLD_LOCAL, so those copies were never unified. libc++abi compares typeinfo by address and the cast failed; libstdc++ compares mangled names and survived.

Declare a virtual destructor for each of the 56 kernel interface classes and for KernelImpl, and define it out of line. Each destructor is then the key function for its class, so the vtable and typeinfo are emitted once with strong linkage and every plugin refers to that single definition.

Three separate cast boundaries were affected, each only visible once the previous one was fixed: libOpenMM to plugin, plugin to plugin, and API library to plugin.

The destructors must stay out of line. Defaulting one on its declaration in a header makes it inline, which leaves the class without a key function and silently reintroduces the problem: nothing is diagnosed at build time with either standard library and it is invisible at run time on libstdc++.