### PR TITLE
Made writing checkpoints from ReplicaExchangeReporter optional

### DIFF
--- a/wrappers/python/openmm/app/replicaexchangereporter.py
+++ b/wrappers/python/openmm/app/replicaexchangereporter.py
@@ -43,8 +43,8 @@ class ReplicaExchangeReporter(object):
     As the simulation runs, it creates the following files in a user specified directory.
 
     - A CSV file containing a log of what state each replica was in at each iteration.
-    - A set of XML files containing serialized State objects for each replica. These serve as checkpoints, allowing a
-      simulation to be resumed later.
+    - (optional) A set of XML files containing serialized State objects for each replica. These serve as checkpoints,
+      allowing a simulation to be resumed later.
     - (optional) A trajectory file for each thermodynamic state.  The coordinates in these files jump discontinuously
       whenever an exchange happens.
     - (optional) A trajectory file for each replica.  The coordinates in these files are continuous, but the
@@ -65,9 +65,9 @@ class ReplicaExchangeReporter(object):
     information and configure the ReplicaExchangeSampler correctly.
     """
     def __init__(self, directory: str, reportInterval: int, sampler: "app.ReplicaExchangeSampler",
-                 trajectoryPerState: bool = True, trajectoryPerReplica: bool = False, trajectoryFormat: str = 'xtc',
+                 trajectoryPerState: bool = False, trajectoryPerReplica: bool = False, trajectoryFormat: str = 'xtc',
                  enforcePeriodicBox: bool | None = None, energy: bool = False, volume: bool = False,
-                 resume: bool = False):
+                 checkpoints: bool = False, resume: bool = False):
         """
         Create a ReplicaExchangeReporter.
 
@@ -96,6 +96,8 @@ class ReplicaExchangeReporter(object):
             If True, a CSV file will be saved containing reduced energies.
         volume: bool
             If True, a CSV file will be saved containing periodic box volumes.
+        checkpoints: bool
+            If True, checkpoint files will be saved to allow resuming
         resume: bool
             Specifies whether to resume an earlier simulation.  If True, the checkpoint and log data will be loaded into
             the ReplicaExchangeSampler, and future output will be appended to the existing files.
@@ -109,6 +111,7 @@ class ReplicaExchangeReporter(object):
         self._log = None
         self._energy = None
         self._volume = None
+        self._checkpoints = checkpoints
         numStates = len(sampler.states)
 
         # Validate the inputs and create the output directory if necessary.
@@ -216,4 +219,5 @@ class ReplicaExchangeReporter(object):
                 self._stateReporters[sampler.replicaStateIndex[i]].report(sampler.simulation, conf)
             if len(self._replicaReporters) > 0:
                 self._replicaReporters[i].report(sampler.simulation, conf)
-            safesave.save(mm.XmlSerializer.serialize(conf), os.path.join(self.directory, f'checkpoint_{i}.xml'))
+            if self._checkpoints:
+                safesave.save(mm.XmlSerializer.serialize(conf), os.path.join(self.directory, f'checkpoint_{i}.xml'))

--- a/wrappers/python/tests/TestReplicaExchangeSampler.py
+++ b/wrappers/python/tests/TestReplicaExchangeSampler.py
@@ -71,7 +71,7 @@ class TestReplicaExchangeSampler(unittest.TestCase):
 
             repex.reporters.append(recordDisplacements)
             with tempfile.TemporaryDirectory() as directory:
-                repex.reporters.append(ReplicaExchangeReporter(directory, 1, repex, trajectoryPerState=False, energy=True))
+                repex.reporters.append(ReplicaExchangeReporter(directory, 1, repex, energy=True))
                 for i in range(len(states)):
                     repex.simulateReplica(i, 100)
                 steps = 2000
@@ -115,7 +115,7 @@ class TestReplicaExchangeSampler(unittest.TestCase):
                 conformations.append(sampler.replicaConformation[:])
 
         with tempfile.TemporaryDirectory() as directory:
-            sampler.reporters.append(ReplicaExchangeReporter(directory, 3, sampler, trajectoryPerState=True, trajectoryPerReplica=True, energy=True, volume=True))
+            sampler.reporters.append(ReplicaExchangeReporter(directory, 3, sampler, trajectoryPerState=True, trajectoryPerReplica=True, energy=True, volume=True, checkpoints=True))
             sampler.reporters.append(report)
 
             # Generate some output.
@@ -130,7 +130,7 @@ class TestReplicaExchangeSampler(unittest.TestCase):
             integrator = LangevinIntegrator(300*kelvin, 1/picosecond, 0.001*picosecond)
             simulation = Simulation(pdb.topology, system, integrator, Platform.getPlatform('Reference'))
             sampler = ReplicaExchangeSampler(states, simulation, 5)
-            sampler.reporters.append(ReplicaExchangeReporter(directory, 3, sampler, trajectoryPerState=True, trajectoryPerReplica=True, energy=True, volume=True, resume=True))
+            sampler.reporters.append(ReplicaExchangeReporter(directory, 3, sampler, trajectoryPerState=True, trajectoryPerReplica=True, energy=True, volume=True, resume=True, checkpoints=True))
             sampler.reporters.append(report)
 
             # Check that it loaded the checkpoints correctly.


### PR DESCRIPTION
This adds a `checkpoints` argument to specify whether it should write checkpoints or not.

I also made it so all optional outputs default to false.  Previously `trajectoryPerState` defaulted to true for no good reason.

Fixes #5369.