### PR TITLE
Fix default ion separation cutoff in Modeller

### DIFF
--- a/wrappers/python/openmm/app/modeller.py
+++ b/wrappers/python/openmm/app/modeller.py
@@ -255,7 +255,7 @@ class Modeller(object):
         self.topology = newTopology
         self.positions = newPositions
 
-    def _addIons(self, forcefield, numWaters, replaceableMols, ionCutoff=0.05*nanometer, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*molar, neutralize=True, residueTemplates=dict()):
+    def _addIons(self, forcefield, numWaters, replaceableMols, ionCutoff=0.5*nanometer, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*molar, neutralize=True, residueTemplates=dict()):
         """Adds ions to the system by replacing certain molecules.
 
         Parameters

--- a/wrappers/python/tests/TestModeller.py
+++ b/wrappers/python/tests/TestModeller.py
@@ -398,7 +398,12 @@ class TestModeller(unittest.TestCase):
         topology_start.setUnitCellDimensions(Vec3(3.5, 3.5, 3.5)*nanometers)
         modeller = Modeller(topology_start, self.positions)
         modeller.deleteWater()
-        modeller.addSolvent(self.forcefield, ionicStrength = 2.0*molar)
+        random_state = random.getstate()
+        random.seed(0)
+        try:
+            modeller.addSolvent(self.forcefield, ionicStrength = 2.0*molar)
+        finally:
+            random.setstate(random_state)
         topology_after = modeller.getTopology()
 
         water_count=0
@@ -418,6 +423,11 @@ class TestModeller(unittest.TestCase):
         expected_ions = math.floor(total_added*expected_ion_fraction+0.5)
         self.assertEqual(sodium_count, expected_ions)
         self.assertEqual(chlorine_count, expected_ions)
+
+        ion_positions = [modeller.positions[atom.index] for atom in topology_after.atoms() if atom.residue.name in ('NA', 'CL')]
+        for i, position in enumerate(ion_positions):
+            for other_position in ion_positions[:i]:
+                self.assertGreater(norm(position-other_position), 0.5*nanometer)
 
     def test_addSolventNegativeSolvent(self):
         """ Test the addSolvent() method; test adding ions to a negatively charged solvent. """

--- a/wrappers/python/tests/TestModeller.py
+++ b/wrappers/python/tests/TestModeller.py
@@ -398,12 +398,7 @@ class TestModeller(unittest.TestCase):
         topology_start.setUnitCellDimensions(Vec3(3.5, 3.5, 3.5)*nanometers)
         modeller = Modeller(topology_start, self.positions)
         modeller.deleteWater()
-        random_state = random.getstate()
-        random.seed(0)
-        try:
-            modeller.addSolvent(self.forcefield, ionicStrength = 2.0*molar)
-        finally:
-            random.setstate(random_state)
+        modeller.addSolvent(self.forcefield, ionicStrength = 2.0*molar)
         topology_after = modeller.getTopology()
 
         water_count=0
@@ -424,10 +419,11 @@ class TestModeller(unittest.TestCase):
         self.assertEqual(sodium_count, expected_ions)
         self.assertEqual(chlorine_count, expected_ions)
 
-        ion_positions = [modeller.positions[atom.index] for atom in topology_after.atoms() if atom.residue.name in ('NA', 'CL')]
+        positions = modeller.positions.value_in_unit(nanometer)
+        ion_positions = [positions[atom.index] for atom in topology_after.atoms() if atom.residue.name in ('NA', 'CL')]
         for i, position in enumerate(ion_positions):
             for other_position in ion_positions[:i]:
-                self.assertGreater(norm(position-other_position), 0.5*nanometer)
+                self.assertGreater(norm(position-other_position), 0.5)
 
     def test_addSolventNegativeSolvent(self):
         """ Test the addSolvent() method; test adding ions to a negatively charged solvent. """


### PR DESCRIPTION
Change the default `Modeller._addIons()` separation cutoff from `0.05 nm` to the documented `0.5 nm`.

`_addIons()` selects water molecules and replaces their oxygen atoms with ions. It is intended to reject a candidate when it is too close to an ion that has already been placed. The previous `0.05 nm` cutoff was too small to affect normal solvent configurations:

- The effective water radii used by `Modeller.addSolvent()` are approximately `0.175-0.179 nm`.
- The minimum periodic oxygen-oxygen distances in OpenMM's bundled pre-equilibrated water boxes range from approximately `0.223 nm` to `0.264 nm`.
- Consequently, candidate water oxygen sites are already much farther apart than `0.05 nm`, so the cutoff could not reject neighboring candidate sites and was effectively inactive.

This is also inconsistent with the `_addIons()` documentation, which specifies a default of `0.5 nm`. The original design [discussion](https://github.com/openmm/openmm/pull/2100#issuecomment-396787891) explicitly proposed an `ionCutoff` of `0.5 nm` when introducing the shared ion-placement routine, but it later appeared with a `0.05 nm` default while retaining `0.5 nm` in its docstring, indicating a decimal-place error.