### PR TITLE
Fixed implicit solvent forces on CPU platform with triclinic boxes

### DIFF
--- a/platforms/cpu/include/CpuCustomGBForce.h
+++ b/platforms/cpu/include/CpuCustomGBForce.h
@@ -44,8 +44,10 @@ private:
 
     bool cutoff;
     bool periodic;
+    bool triclinic;
     const CpuNeighborList* neighborList;
     float periodicBoxSize[3];
+    AlignedArray<fvec4> periodicBoxVec4;
     float cutoffDistance, cutoffDistance2;
     int numValues, numParams;
     const std::vector<std::set<int> > exclusions;
@@ -215,10 +217,10 @@ public:
      * already been set, and the smallest side of the periodic box is at least twice the cutoff
      * distance.
      * 
-     * @param boxSize             the X, Y, and Z widths of the periodic box
+     * @param periodicBoxVectors    the vectors defining the periodic box
      */
 
-    void setPeriodic(Vec3& boxSize);
+    void setPeriodic(Vec3* periodicBoxVectors);
 
     /**
      * Calculate custom GB ixn

--- a/platforms/cpu/include/CpuGBSAOBCForce.h
+++ b/platforms/cpu/include/CpuGBSAOBCForce.h
@@ -26,6 +26,7 @@
 #define OPENMM_CPU_GBSAOBC_FORCE_H__
 
 #include "AlignedArray.h"
+#include "openmm/Vec3.h"
 #include "openmm/internal/ThreadPool.h"
 #include "openmm/internal/vectorize.h"
 #include <atomic>
@@ -52,9 +53,9 @@ public:
      * already been set, and the smallest side of the periodic box is at least twice the cutoff
      * distance.
      *
-     * @param boxSize             the X, Y, and Z widths of the periodic box
+     * @param periodicBoxVectors    the vectors defining the periodic box
      */
-    void setPeriodic(float* periodicBoxSize);
+    void setPeriodic(Vec3* periodicBoxVectors);
 
     /**
      * Set the solute dielectric constant.
@@ -100,7 +101,9 @@ public:
 private:
     bool cutoff;
     bool periodic;
+    bool triclinic;
     float periodicBoxSize[3];
+    Vec3 periodicBoxVectors[3];
     float cutoffDistance, soluteDielectric, solventDielectric, surfaceAreaFactor;
     std::vector<std::pair<float, float> > particleParams;        
     AlignedArray<float> bornRadii;

--- a/platforms/cpu/src/CpuCustomGBForce.cpp
+++ b/platforms/cpu/src/CpuCustomGBForce.cpp
@@ -165,16 +165,23 @@ void CpuCustomGBForce::setUseCutoff(float distance, const CpuNeighborList& neigh
     neighborList = &neighbors;
   }
 
-void CpuCustomGBForce::setPeriodic(Vec3& boxSize) {
+void CpuCustomGBForce::setPeriodic(Vec3* periodicBoxVectors) {
     if (cutoff) {
-        assert(boxSize[0] >= 2.0*cutoffDistance);
-        assert(boxSize[1] >= 2.0*cutoffDistance);
-        assert(boxSize[2] >= 2.0*cutoffDistance);
+        assert(periodicBoxVectors[0][0] >= 2.0*cutoffDistance);
+        assert(periodicBoxVectors[1][1] >= 2.0*cutoffDistance);
+        assert(periodicBoxVectors[2][2] >= 2.0*cutoffDistance);
     }
     periodic = true;
-    periodicBoxSize[0] = boxSize[0];
-    periodicBoxSize[1] = boxSize[1];
-    periodicBoxSize[2] = boxSize[2];
+    periodicBoxSize[0] = (float) periodicBoxVectors[0][0];
+    periodicBoxSize[1] = (float) periodicBoxVectors[1][1];
+    periodicBoxSize[2] = (float) periodicBoxVectors[2][2];
+    periodicBoxVec4.resize(3);
+    periodicBoxVec4[0] = fvec4(periodicBoxVectors[0][0], periodicBoxVectors[0][1], periodicBoxVectors[0][2], 0);
+    periodicBoxVec4[1] = fvec4(periodicBoxVectors[1][0], periodicBoxVectors[1][1], periodicBoxVectors[1][2], 0);
+    periodicBoxVec4[2] = fvec4(periodicBoxVectors[2][0], periodicBoxVectors[2][1], periodicBoxVectors[2][2], 0);
+    triclinic = (periodicBoxVectors[0][1] != 0.0 || periodicBoxVectors[0][2] != 0.0 ||
+            periodicBoxVectors[1][0] != 0.0 || periodicBoxVectors[1][2] != 0.0 ||
+            periodicBoxVectors[2][0] != 0.0 || periodicBoxVectors[2][1] != 0.0);
   }
 
 void CpuCustomGBForce::calculateIxn(int numberOfAtoms, float* posq, vector<vector<double> >& atomParameters,
@@ -668,8 +675,15 @@ void CpuCustomGBForce::calculateOnePairChainRule(int atom1, int atom2, ThreadDat
 void CpuCustomGBForce::getDeltaR(const fvec4& posI, const fvec4& posJ, fvec4& deltaR, float& r2, bool periodic, const fvec4& boxSize, const fvec4& invBoxSize) const {
     deltaR = posJ-posI;
     if (periodic) {
-        fvec4 base = round(deltaR*invBoxSize)*boxSize;
-        deltaR = deltaR-base;
+        if (triclinic) {
+            deltaR -= periodicBoxVec4[2]*floorf(deltaR[2]*invBoxSize[2]+0.5f);
+            deltaR -= periodicBoxVec4[1]*floorf(deltaR[1]*invBoxSize[1]+0.5f);
+            deltaR -= periodicBoxVec4[0]*floorf(deltaR[0]*invBoxSize[0]+0.5f);
+        }
+        else {
+            fvec4 base = round(deltaR*invBoxSize)*boxSize;
+            deltaR = deltaR-base;
+        }
     }
     r2 = dot3(deltaR, deltaR);
 }

--- a/platforms/cpu/src/CpuGBSAOBCForce.cpp
+++ b/platforms/cpu/src/CpuGBSAOBCForce.cpp
@@ -50,11 +50,17 @@ void CpuGBSAOBCForce::setUseCutoff(float distance) {
     cutoffDistance = distance;
 }
 
-void CpuGBSAOBCForce::setPeriodic(float* periodicBoxSize) {
+void CpuGBSAOBCForce::setPeriodic(Vec3* periodicBoxVectors) {
     periodic = true;
-    this->periodicBoxSize[0] = periodicBoxSize[0];
-    this->periodicBoxSize[1] = periodicBoxSize[1];
-    this->periodicBoxSize[2] = periodicBoxSize[2];
+    this->periodicBoxVectors[0] = periodicBoxVectors[0];
+    this->periodicBoxVectors[1] = periodicBoxVectors[1];
+    this->periodicBoxVectors[2] = periodicBoxVectors[2];
+    periodicBoxSize[0] = (float) periodicBoxVectors[0][0];
+    periodicBoxSize[1] = (float) periodicBoxVectors[1][1];
+    periodicBoxSize[2] = (float) periodicBoxVectors[2][2];
+    triclinic = (periodicBoxVectors[0][1] != 0.0 || periodicBoxVectors[0][2] != 0.0 ||
+            periodicBoxVectors[1][0] != 0.0 || periodicBoxVectors[1][2] != 0.0 ||
+            periodicBoxVectors[2][0] != 0.0 || periodicBoxVectors[2][1] != 0.0);
 }
 
 void CpuGBSAOBCForce::setSoluteDielectric(float dielectric) {
@@ -397,9 +403,22 @@ void CpuGBSAOBCForce::getDeltaR(const fvec4& posI, const fvec4& x, const fvec4& 
     dy = y-posI[1];
     dz = z-posI[2];
     if (periodic) {
-        dx -= round(dx*invBoxSize[0])*boxSize[0];
-        dy -= round(dy*invBoxSize[1])*boxSize[1];
-        dz -= round(dz*invBoxSize[2])*boxSize[2];
+        if (triclinic) {
+            fvec4 scale3 = floor(dz*invBoxSize[2]+0.5f);
+            dx -= scale3*periodicBoxVectors[2][0];
+            dy -= scale3*periodicBoxVectors[2][1];
+            dz -= scale3*periodicBoxVectors[2][2];
+            fvec4 scale2 = floor(dy*invBoxSize[1]+0.5f);
+            dx -= scale2*periodicBoxVectors[1][0];
+            dy -= scale2*periodicBoxVectors[1][1];
+            fvec4 scale1 = floor(dx*invBoxSize[0]+0.5f);
+            dx -= scale1*periodicBoxVectors[0][0];
+        }
+        else {
+            dx -= round(dx*invBoxSize[0])*boxSize[0];
+            dy -= round(dy*invBoxSize[1])*boxSize[1];
+            dz -= round(dz*invBoxSize[2])*boxSize[2];
+        }
     }
     r2 = dx*dx + dy*dy + dz*dz;
 }

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -70,11 +70,6 @@ static vector<Vec3>& extractForces(ContextImpl& context) {
     return *data->forces;
 }
 
-static Vec3& extractBoxSize(ContextImpl& context) {
-    ReferencePlatform::PlatformData* data = reinterpret_cast<ReferencePlatform::PlatformData*>(context.getPlatformData());
-    return *data->periodicBoxSize;
-}
-
 static Vec3* extractBoxVectors(ContextImpl& context) {
     ReferencePlatform::PlatformData* data = reinterpret_cast<ReferencePlatform::PlatformData*>(context.getPlatformData());
     return data->periodicBoxVectors;
@@ -1431,11 +1426,8 @@ void CpuCalcGBSAOBCForceKernel::initialize(const System& system, const GBSAOBCFo
 
 double CpuCalcGBSAOBCForceKernel::execute(ContextImpl& context, bool includeForces, bool includeEnergy) {
     copyChargesToPosq(context, charges, posqIndex);
-    if (data.isPeriodic) {
-        Vec3& boxSize = extractBoxSize(context);
-        float floatBoxSize[3] = {(float) boxSize[0], (float) boxSize[1], (float) boxSize[2]};
-        obc.setPeriodic(floatBoxSize);
-    }
+    if (data.isPeriodic)
+        obc.setPeriodic(extractBoxVectors(context));
     double energy = 0.0;
     obc.computeForce(data.posq, data.threadForce, includeEnergy ? &energy : NULL, data.threads);
     return energy;
@@ -1622,7 +1614,7 @@ double CpuCalcCustomGBForceKernel::execute(ContextImpl& context, bool includeFor
     double energy = 0;
     Vec3* boxVectors = extractBoxVectors(context);
     if (data.isPeriodic)
-        ixn->setPeriodic(extractBoxSize(context));
+        ixn->setPeriodic(boxVectors);
     if (nonbondedMethod != NoCutoff) {
         vector<set<int> > noExclusions(numParticles);
         neighborList->computeNeighborList(numParticles, data.posq, noExclusions, boxVectors, data.isPeriodic, nonbondedCutoff, data.threads);

--- a/tests/TestCustomGBForce.h
+++ b/tests/TestCustomGBForce.h
@@ -44,7 +44,7 @@ using namespace std;
 
 const double TOL = 1e-5;
 
-void testOBC(GBSAOBCForce::NonbondedMethod obcMethod, CustomGBForce::NonbondedMethod customMethod) {
+void testOBC(GBSAOBCForce::NonbondedMethod obcMethod, CustomGBForce::NonbondedMethod customMethod, bool triclinic=false) {
     const int numMolecules = 70;
     const int numParticles = numMolecules*2;
     const double boxSize = 10.0;
@@ -58,8 +58,14 @@ void testOBC(GBSAOBCForce::NonbondedMethod obcMethod, CustomGBForce::NonbondedMe
         standardSystem.addParticle(1.0);
         customSystem.addParticle(1.0);
     }
-    standardSystem.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0.0, 0.0), Vec3(0.0, boxSize, 0.0), Vec3(0.0, 0.0, boxSize));
-    customSystem.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0.0, 0.0), Vec3(0.0, boxSize, 0.0), Vec3(0.0, 0.0, boxSize));
+    Vec3 a(boxSize, 0.0, 0.0), b(0.0, boxSize, 0.0), c(0.0, 0.0, boxSize);
+    if (triclinic) {
+        b[0] = 0.1*boxSize;
+        c[0] = -0.1*boxSize;
+        c[1] = -0.15*boxSize;
+    }
+    standardSystem.setDefaultPeriodicBoxVectors(a, b, c);
+    customSystem.setDefaultPeriodicBoxVectors(a, b, c);
     GBSAOBCForce* obc = new GBSAOBCForce();
     CustomGBForce* custom = new CustomGBForce();
     obc->setCutoffDistance(cutoff);
@@ -558,6 +564,7 @@ int main(int argc, char* argv[]) {
         testOBC(GBSAOBCForce::NoCutoff, CustomGBForce::NoCutoff);
         testOBC(GBSAOBCForce::CutoffNonPeriodic, CustomGBForce::CutoffNonPeriodic);
         testOBC(GBSAOBCForce::CutoffPeriodic, CustomGBForce::CutoffPeriodic);
+        testOBC(GBSAOBCForce::CutoffPeriodic, CustomGBForce::CutoffPeriodic, true);
         testMembrane();
         testTabulatedFunction();
         testMultipleChainRules();

--- a/tests/TestGBSAOBCForce.h
+++ b/tests/TestGBSAOBCForce.h
@@ -176,7 +176,7 @@ void testCutoffAndPeriodic() {
     ASSERT_EQUAL_VEC(state3.getForces()[1], Vec3(0, 0, 0), 0.01);
 }
 
-void testForce(int numParticles, NonbondedForce::NonbondedMethod method, GBSAOBCForce::NonbondedMethod method2) {
+void testForce(int numParticles, NonbondedForce::NonbondedMethod method, GBSAOBCForce::NonbondedMethod method2, bool triclinic=false) {
     ReferencePlatform reference;
     System system;
     GBSAOBCForce* gbsa = new GBSAOBCForce();
@@ -194,7 +194,10 @@ void testForce(int numParticles, NonbondedForce::NonbondedMethod method, GBSAOBC
     int grid = (int) floor(0.5+pow(numParticles, 1.0/3.0));
     if (method == NonbondedForce::CutoffPeriodic) {
         double boxSize = (grid+1)*1.1;
-        system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0, boxSize, 0), Vec3(0, 0, boxSize));
+        if (triclinic)
+            system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0.1*boxSize, boxSize, 0), Vec3(-0.1*boxSize, -0.15*boxSize, boxSize));
+        else
+            system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0, boxSize, 0), Vec3(0, 0, boxSize));
     }
     system.addForce(gbsa);
     system.addForce(nonbonded);
@@ -270,6 +273,7 @@ int main(int argc, char* argv[]) {
             testForce(i*i*i, NonbondedForce::CutoffNonPeriodic, GBSAOBCForce::CutoffNonPeriodic);
             testForce(i*i*i, NonbondedForce::CutoffPeriodic, GBSAOBCForce::CutoffPeriodic);
         }
+        testForce(1000, NonbondedForce::CutoffPeriodic, GBSAOBCForce::CutoffPeriodic, true);
         runPlatformTests();
     }
     catch(const exception& e) {


### PR DESCRIPTION
Fixes #5387

PBC Implicit solvent simulations with triclinic boxes were incorrectly calculating distances along each cartesian axis independently. This PR includes a corrected calculation and test for implicit solvent triclinic distances on the CPU platform.