### PR TITLE
Add CI on self-hosted runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -675,3 +675,30 @@ jobs:
           ((exitcode+=$?))
           echo "::endgroup::"
           exit $exitcode
+
+  gpu:
+    runs-on: self-hosted
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux GPU
+            CMAKE_FLAGS: |
+              -DOPENMM_BUILD_REFERENCE_TESTS=OFF \
+              -DOPENMM_BUILD_CPU_TESTS=OFF \
+              -DOPENMM_BUILD_EXAMPLES=OFF \
+              -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
+              -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
+        steps:
+          - uses: actions/checkout@v7
+
+          - name: "Build"
+            run: |
+              mkdir build
+              cd build
+              cmake .. \
+                -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+                ${{ matrix.CMAKE_FLAGS }}
+              make -j4 install
+              python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -690,15 +690,14 @@ jobs:
               -DOPENMM_BUILD_EXAMPLES=OFF \
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
               -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
-        steps:
-          - uses: actions/checkout@v7
-
-          - name: "Build"
-            run: |
-              mkdir build
-              cd build
-              cmake .. \
-                -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
-                ${{ matrix.CMAKE_FLAGS }}
-              make -j4 install
-              python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3
+      steps:
+        - uses: actions/checkout@v7
+        - name: "Build"
+          run: |
+            mkdir build
+            cd build
+            cmake .. \
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+              ${{ matrix.CMAKE_FLAGS }}
+            make -j4 install
+            python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -733,7 +733,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd build
-          make -j10 install
+          make -j8 install
 
       - name: "Test OpenMM"
         shell: bash -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -687,11 +687,13 @@ jobs:
             python-version: "3.13"
             env: ubuntu-arm
             CMAKE_FLAGS: |
-              -DOPENMM_BUILD_REFERENCE_TESTS=OFF \
               -DOPENMM_BUILD_CPU_TESTS=OFF \
-              -DOPENMM_BUILD_EXAMPLES=OFF \
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
+              -DOPENMM_BUILD_EXAMPLES=OFF \
               -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
+              -DOPENMM_BUILD_REFERENCE_TESTS=OFF \
+              -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF \
+
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -684,6 +684,8 @@ jobs:
       matrix:
         include:
           - name: Linux GPU
+            python-version: "3.13"
+            env: ubuntu-arm
             CMAKE_FLAGS: |
               -DOPENMM_BUILD_REFERENCE_TESTS=OFF \
               -DOPENMM_BUILD_CPU_TESTS=OFF \
@@ -692,12 +694,34 @@ jobs:
               -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
     steps:
       - uses: actions/checkout@v7
-      - name: "Build"
+
+      - uses: conda-incubator/setup-miniconda@v2
+        name: "Prepare base dependencies"
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: build
+          environment-file: devtools/ci/gh-actions/conda-envs/build-${{ matrix.env }}.yml
+          auto-activate-base: false
+          miniforge-variant: Miniforge3
+          use-mamba: true
+
+      - name: "Configure build with CMake"
+        shell: bash -l {0}
         run: |
           mkdir build
           cd build
           cmake .. \
             -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
             ${{ matrix.CMAKE_FLAGS }}
+
+      - name: "Build OpenMM"
+        shell: bash -l {0}
+        run: |
+          cd build
           make -j4 install
+
+      - name: "Test OpenMM"
+        shell: bash -l {0}
+        run: |
+          cd build
           python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -683,16 +683,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux GPU
+          - name: Linux GPU OpenCL
             python-version: "3.13"
             env: ubuntu-arm
             CMAKE_FLAGS: |
-              -DOPENMM_BUILD_CPU_TESTS=OFF \
-              -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
-              -DOPENMM_BUILD_EXAMPLES=OFF \
+              -DOPENMM_BUILD_CUDA_TESTS=OFF \
+              -DOPENMM_BUILD_CPU_LIB=OFF \
               -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
               -DOPENMM_BUILD_REFERENCE_TESTS=OFF \
               -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF \
+              -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
+              -DOPENMM_BUILD_EXAMPLES=OFF \
+
+          - name: Linux GPU CUDA
+            python-version: "3.13"
+            env: ubuntu-arm
+            CMAKE_FLAGS: |
+              -DOPENMM_BUILD_OPENCL_TESTS=OFF \
+              -DOPENMM_BUILD_CPU_LIB=OFF \
+              -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
+              -DOPENMM_BUILD_REFERENCE_TESTS=OFF \
+              -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF \
+              -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
+              -DOPENMM_BUILD_EXAMPLES=OFF \
 
     steps:
       - uses: actions/checkout@v7
@@ -720,10 +733,13 @@ jobs:
         shell: bash -l {0}
         run: |
           cd build
-          make -j4 install
+          make -j10 install
 
       - name: "Test OpenMM"
         shell: bash -l {0}
         run: |
           cd build
-          python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3
+          python ../devtools/run-ctest.py --parallel 2 --timeout 600 --job-duration 900 --attempts 3
+          test -f ${CONDA_PREFIX}/lib/libOpenMM.so
+          test -f ${CONDA_PREFIX}/lib/plugins/libOpenMMCUDA.so
+          test -f ${CONDA_PREFIX}/lib/plugins/libOpenMMOpenCL.so

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -690,14 +690,14 @@ jobs:
               -DOPENMM_BUILD_EXAMPLES=OFF \
               -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF \
               -DOPENMM_BUILD_PYTHON_WRAPPERS=OFF \
-      steps:
-        - uses: actions/checkout@v7
-        - name: "Build"
-          run: |
-            mkdir build
-            cd build
-            cmake .. \
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
-              ${{ matrix.CMAKE_FLAGS }}
-            make -j4 install
-            python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3
+    steps:
+      - uses: actions/checkout@v7
+      - name: "Build"
+        run: |
+          mkdir build
+          cd build
+          cmake .. \
+            -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+            ${{ matrix.CMAKE_FLAGS }}
+          make -j4 install
+          python ../devtools/run-ctest.py --parallel 4 --timeout 600 --job-duration 900 --attempts 3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -695,7 +695,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v4
         name: "Prepare base dependencies"
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Adds CI for OpenCL and CUDA on self-hosted runners.

Note that like the existing Jenkins setup, these runs don't do the Python tests, but this should be possible to add if we want to.  Unlike the existing Jenkins setup, this doesn't add any CPU tests, since we already have many such configurations on GitHub runners, including ARM on Linux.