### PR TITLE
Clone CustomNonbondedForce with XmlSerializer::clone()

### DIFF
--- a/platforms/common/src/CommonCalcCustomNonbondedForceKernel.cpp
+++ b/platforms/common/src/CommonCalcCustomNonbondedForceKernel.cpp
@@ -28,6 +28,7 @@
 #include "openmm/common/ExpressionUtilities.h"
 #include "openmm/Context.h"
 #include "openmm/internal/ContextImpl.h"
+#include "openmm/serialization/XmlSerializer.h"
 #include "CommonKernelSources.h"
 #include "lepton/CustomFunction.h"
 #include "lepton/ExpressionTreeNode.h"
@@ -360,7 +361,7 @@ void CommonCalcCustomNonbondedForceKernel::initialize(const System& system, cons
     // Record information for the long range correction.
 
     if (force.getNonbondedMethod() == CustomNonbondedForce::CutoffPeriodic && force.getUseLongRangeCorrection() && cc.getContextIndex() == 0) {
-        forceCopy = new CustomNonbondedForce(force);
+        forceCopy = XmlSerializer::clone(force);
         longRangeCorrectionData = CustomNonbondedForceImpl::prepareLongRangeCorrection(force, cc.getThreadPool().getNumThreads());
         cc.addPostComputation(new LongRangePostComputation(cc, longRangeCoefficient, longRangeCoefficientDerivs, forceCopy));
         hasInitializedLongRangeCorrection = false;
@@ -755,7 +756,8 @@ void CommonCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& 
     if (forceCopy != NULL) {
         longRangeCorrectionData = CustomNonbondedForceImpl::prepareLongRangeCorrection(force, cc.getThreadPool().getNumThreads());
         hasInitializedLongRangeCorrection = false;
-        *forceCopy = force;
+        delete forceCopy;
+        forceCopy = XmlSerializer::clone(force);
         longRangeCoefficientCache.clear();
         longRangeCoefficientDerivsCache.clear();
     }

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -4,7 +4,7 @@
  * This is part of the OpenMM molecular simulation toolkit.                   *
  * See https://openmm.org/development.                                        *
  *                                                                            *
- * Portions copyright (c) 2013-2025 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2026 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -45,6 +45,7 @@
 #include "openmm/internal/NonbondedForceImpl.h"
 #include "openmm/internal/ConstantPotentialForceImpl.h"
 #include "openmm/internal/vectorize.h"
+#include "openmm/serialization/XmlSerializer.h"
 #include "lepton/CompiledExpression.h"
 #include "lepton/CustomFunction.h"
 #include "lepton/Operation.h"
@@ -1232,7 +1233,7 @@ void CpuCalcCustomNonbondedForceKernel::initialize(const System& system, const C
     // Record information for the long range correction.
 
     if (force.getNonbondedMethod() == CustomNonbondedForce::CutoffPeriodic && force.getUseLongRangeCorrection()) {
-        forceCopy = new CustomNonbondedForce(force);
+        forceCopy = XmlSerializer::clone(force);
         hasInitializedLongRangeCorrection = false;
     }
     else {
@@ -1385,7 +1386,8 @@ void CpuCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& con
         longRangeCorrectionData = CustomNonbondedForceImpl::prepareLongRangeCorrection(force, data.threads.getNumThreads());
         CustomNonbondedForceImpl::calcLongRangeCorrection(force, longRangeCorrectionData, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs, data.threads);
         hasInitializedLongRangeCorrection = true;
-        *forceCopy = force;
+        delete forceCopy;
+        forceCopy = XmlSerializer::clone(force);
     }
 
     // See if any tabulated functions have changed.

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -85,6 +85,7 @@
 #include "openmm/internal/ConstantPotentialForceImpl.h"
 #include "openmm/Integrator.h"
 #include "openmm/OpenMMException.h"
+#include "openmm/serialization/XmlSerializer.h"
 #include "SimTKOpenMMUtilities.h"
 #include "lepton/CustomFunction.h"
 #include "lepton/Operation.h"
@@ -1449,7 +1450,7 @@ void ReferenceCalcCustomNonbondedForceKernel::initialize(const System& system, c
     // Record information for the long range correction.
     
     if (force.getNonbondedMethod() == CustomNonbondedForce::CutoffPeriodic && force.getUseLongRangeCorrection()) {
-        forceCopy = new CustomNonbondedForce(force);
+        forceCopy = XmlSerializer::clone(force);
         hasInitializedLongRangeCorrection = false;
     }
     else {
@@ -1600,7 +1601,8 @@ void ReferenceCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImp
         longRangeCorrectionData = CustomNonbondedForceImpl::prepareLongRangeCorrection(force, threads.getNumThreads());
         CustomNonbondedForceImpl::calcLongRangeCorrection(force, longRangeCorrectionData, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs, threads);
         hasInitializedLongRangeCorrection = true;
-        *forceCopy = force;
+        delete forceCopy;
+        forceCopy = XmlSerializer::clone(force);
     }
 
     // See if any tabulated functions have changed.


### PR DESCRIPTION
Fixes #5409.  We really should get rid of the copy constructor altogether, but that's a bigger change, so I'll save it for another PR.  I'm including just the minimal fix here so we can include it in 8.6.1.