### PR TITLE
[WIP] Add an experimental native Metal Platform for Apple silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,13 @@ IF(OPENMM_BUILD_HIP_LIB)
     ADD_SUBDIRECTORY(platforms/hip)
 ENDIF(OPENMM_BUILD_HIP_LIB)
 
+# Metal Platform
+
+SET(OPENMM_BUILD_METAL_LIB OFF CACHE BOOL "Build the experimental Metal Platform")
+IF(OPENMM_BUILD_METAL_LIB)
+    ADD_SUBDIRECTORY(platforms/metal)
+ENDIF(OPENMM_BUILD_METAL_LIB)
+
 # Common compute files
 
 SET(OPENMM_BUILD_COMMON OFF CACHE BOOL "Build common files even if CUDA or OpenCL platforms are not built")

--- a/platforms/metal/CMakeLists.txt
+++ b/platforms/metal/CMakeLists.txt
@@ -1,0 +1,88 @@
+# --------------------------------------------------------------------------
+# OpenMM
+#
+# This is part of the OpenMM molecular simulation toolkit.
+# See https://openmm.org/development.
+#
+# Metal Platform code:
+# Portions copyright (c) 2026 Chun-Chi Hung.
+# Authors: Chun-Chi Hung
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# --------------------------------------------------------------------------
+
+# Metal Platform: minimal implementation of the Common compute interfaces.
+# This target does not yet register an OpenMM simulation Platform.
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    message(FATAL_ERROR "The Metal Platform is only available on macOS")
+endif()
+if(NOT CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+    message(FATAL_ERROR "The Metal Platform currently requires an arm64-only build")
+endif()
+if(NOT OPENMM_BUILD_SHARED_LIB)
+    message(FATAL_ERROR "The Metal Platform currently requires OPENMM_BUILD_SHARED_LIB=ON")
+endif()
+
+# Keep the minimum target local to Metal and preserve a newer user target.
+if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "13.0")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
+endif()
+enable_language(OBJCXX)
+
+find_library(METAL_FRAMEWORK Metal)
+find_library(FOUNDATION_FRAMEWORK Foundation)
+if(NOT METAL_FRAMEWORK OR NOT FOUNDATION_FRAMEWORK)
+    message(FATAL_ERROR "The Metal Platform requires the Metal and Foundation frameworks")
+endif()
+
+set(OPENMMMETAL_LIBRARY_NAME OpenMMMetal)
+add_library(${OPENMMMETAL_LIBRARY_NAME} SHARED
+    src/MetalContext.mm
+    src/MetalArray.mm
+    src/MetalKernel.mm
+    src/MetalProgram.mm
+    src/MetalQueue.mm
+    src/MetalEvent.mm
+    ../common/src/ComputeArray.cpp
+    ../common/src/ComputeContext.cpp
+    ../common/src/ComputeForceInfo.cpp)
+target_include_directories(${OPENMMMETAL_LIBRARY_NAME}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+           "${CMAKE_CURRENT_SOURCE_DIR}/../common/include"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+target_link_libraries(${OPENMMMETAL_LIBRARY_NAME}
+    PUBLIC ${OPENMM_LIBRARY_NAME}
+    PRIVATE ${METAL_FRAMEWORK} ${FOUNDATION_FRAMEWORK})
+target_compile_options(${OPENMMMETAL_LIBRARY_NAME} PRIVATE
+    "$<$<COMPILE_LANGUAGE:OBJCXX>:-fobjc-arc>")
+target_compile_definitions(${OPENMMMETAL_LIBRARY_NAME} PRIVATE
+    OPENMM_COMMON_BUILDING_SHARED_LIBRARY)
+set_target_properties(${OPENMMMETAL_LIBRARY_NAME} PROPERTIES
+    CXX_STANDARD 11
+    OBJCXX_STANDARD 11
+    COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS}"
+    LINK_FLAGS "${EXTRA_LINK_FLAGS}")
+
+if(BUILD_TESTING)
+    add_executable(TestMetalComputeContext tests/TestMetalComputeContext.cpp)
+    target_link_libraries(TestMetalComputeContext PRIVATE ${OPENMMMETAL_LIBRARY_NAME})
+    target_compile_definitions(TestMetalComputeContext PRIVATE
+        METAL_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/kernels")
+    set_target_properties(TestMetalComputeContext PROPERTIES
+        COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS}"
+        LINK_FLAGS "${EXTRA_LINK_FLAGS}")
+    add_test(NAME TestMetalComputeContext COMMAND TestMetalComputeContext)
+    set_tests_properties(TestMetalComputeContext PROPERTIES SKIP_RETURN_CODE 77)
+endif()

--- a/platforms/metal/README.md
+++ b/platforms/metal/README.md
@@ -1,0 +1,68 @@
+# Experimental Metal Platform
+
+- Implements `ComputeContext`, `ArrayInterface`, `ComputeQueue`, `ComputeEvent`,
+  `ComputeProgram`, and `ComputeKernel` for one Apple-silicon GPU.
+- Follows the CUDA/HIP class responsibilities, array operations, argument
+  rebinding, and block-based launch flow.
+- Reuses the existing Common context, array wrapper, and force-info sources.
+- Uses private Objective-C++ for Metal API calls and ordinary C++11 headers.
+- Compiles native MSL at runtime with Metal 3.0; no offline library or capability
+  probe is required.
+
+The Metal Platform currently contains only the Common runtime foundation and
+is not yet registered as an OpenMM simulation Platform. It does not yet execute
+existing Common kernel sources or implement force,
+integrator, sorting, neighbor-list, or FFT/PME paths. Unsupported interfaces
+throw explicitly. There is no separate Metal force algorithm, fixed-point
+emulation, or shader translator.
+
+## Porting boundaries
+
+`MetalArray`, `MetalKernel`, `MetalProgram`, `MetalQueue`, and `MetalEvent`
+follow their `Cuda*`/`Hip*` counterparts. `MetalContext` includes the runtime and
+single-precision state-buffer portion, without the force-dependent platform
+initialization. The force buffer uses ordinary 8-byte signed integer elements
+and the existing three-component-plane layout; allocating storage does not
+enable 64-bit atomic accumulation.
+
+The required Metal adaptations are resource ownership, blit transfers, command
+buffers/events, runtime compilation, and encoder bindings. Nonblocking uploads
+and downloads use the context's `getPinnedBuffer()` (or a range within it), like
+CUDA's page-locked-memory requirement. Do not read or reuse that memory until
+the relevant queue/event completes. Blocking transfers accept ordinary host
+memory. Operations select the current queue at execution time, not at array
+creation. Submission to each queue must be serialized by the caller.
+
+Native kernel buffer arguments use sequential `[[buffer(i)]]` slots in Common
+argument order; scalars use constant-buffer references. Stage builtins are
+explicit MSL parameters. The caller supplies the matching signature and legal,
+non-overlapping buffer bindings. Launches use complete threadgroups (64 threads
+by default), capped at a conservative 128 groups, so kernels must support the
+existing grid-stride convention. This cap is not performance tuning.
+
+## Build and test
+
+Configure an arm64 shared-library build on macOS 13 or newer with
+`OPENMM_BUILD_METAL_LIB=ON` and `BUILD_TESTING=ON`. The Metal option is off by
+default; static builds and installation as a simulation plugin are not part
+of this initial target.
+
+```sh
+cmake -S . -B build/metal-common \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+  -DOPENMM_BUILD_METAL_LIB=ON \
+  -DOPENMM_BUILD_SHARED_LIB=ON \
+  -DOPENMM_BUILD_STATIC_LIB=OFF \
+  -DBUILD_TESTING=ON
+cmake --build build/metal-common --target TestMetalComputeContext
+ctest --test-dir build/metal-common -R '^TestMetalComputeContext$' --output-on-failure
+```
+
+The test exercises the Common C++ interfaces using standalone, test-only MSL
+smoke kernels. It covers transfers, resize/rebinding, full and partial logical
+blocks, grid-stride execution, clearing, queue/event ordering, pinned-memory
+readback, and invalid inputs. No GPU returns skip code 77, not a successful GPU
+validation. Passing this test does not establish simulation or Common shader
+compatibility.

--- a/platforms/metal/include/MetalArray.h
+++ b/platforms/metal/include/MetalArray.h
@@ -1,0 +1,181 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/include/CudaArray.h                                 *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2009-2022 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENMM_METALARRAY_H_
+#define OPENMM_METALARRAY_H_
+
+#include "openmm/common/ArrayInterface.h"
+#include <memory>
+
+namespace OpenMM {
+
+class MetalContext;
+
+/**
+ * @brief Owns a private Metal buffer through the Common ArrayInterface.
+ *
+ * Transfers and copies use the context's current queue at the time of the call,
+ * following CudaArray/HipArray. The context must outlive this array. Synchronize
+ * explicitly when accessing the same data from different queues.
+ *
+ * @note Nonblocking host transfers only accept a range within this context's
+ *       pinned buffer. Do not read or reuse that range until the transfer's
+ *       queue, or an event recorded on that queue after the transfer, has completed.
+ */
+class MetalArray : public ArrayInterface {
+public:
+    /**
+     * @brief Creates an uninitialized array with no device storage.
+     * @note Call initialize() before using storage or transferring data.
+     */
+    MetalArray();
+    /**
+     * @brief Creates an array and allocates its private device storage.
+     * @param context The Metal context, which must outlive this array.
+     * @param size The number of elements, including zero for an empty array.
+     * @param elementSize The size of one element in bytes.
+     * @param name The array name used for diagnostics and the buffer label.
+     * @throws OpenMMException If the size is invalid or allocation fails.
+     * @see initialize(ComputeContext&, size_t, int, const std::string&)
+     */
+    MetalArray(MetalContext& context, size_t size, int elementSize, const std::string& name);
+    /** @brief Releases this array's ownership of its Metal buffer without waiting. */
+    ~MetalArray();
+    /**
+     * @brief Initializes this array once and allocates its device storage.
+     * @param context A MetalContext that must outlive this array.
+     * @param size The number of elements; it must fit in an int.
+     * @param elementSize A positive element size in bytes.
+     * @param name The array name used for diagnostics and the buffer label.
+     * @throws OpenMMException If already initialized, the byte count overflows,
+     *         either size is invalid, or allocation fails.
+     * @throws std::bad_cast If context is not a MetalContext.
+     * @note A zero-element array is initialized with a minimal backing buffer.
+     *       Newly allocated contents are not initialized by this class.
+     */
+    void initialize(ComputeContext& context, size_t size, int elementSize, const std::string& name) override;
+    /**
+     * @brief Initializes storage with sizeof(T) bytes per element.
+     * @tparam T The host type whose size defines the element stride.
+     * @param context A MetalContext that must outlive this array.
+     * @param size The number of elements.
+     * @param name The array name used for diagnostics and the buffer label.
+     * @note The caller must ensure T matches the shader's element layout.
+     * @see initialize(ComputeContext&, size_t, int, const std::string&)
+     */
+    template <class T>
+    void initialize(ComputeContext& context, size_t size, const std::string& name) {
+        initialize(context, size, sizeof(T), name);
+    }
+    /**
+     * @brief Replaces the buffer, retaining the context, element size, and name.
+     * @param size The new number of elements.
+     * @throws OpenMMException If uninitialized, the size is invalid, or allocation fails.
+     * @warning Contents are discarded, even if the new size is unchanged.
+     *          Previously borrowed buffer handles refer to the old allocation.
+     */
+    void resize(size_t size) override;
+    /** @return Whether this array owns an allocated Metal buffer. */
+    bool isInitialized() const override;
+    /** @return The logical element count, or zero before initialization. */
+    size_t getSize() const override { return size; }
+    /** @return The element size in bytes, or zero before initialization. */
+    int getElementSize() const override { return elementSize; }
+    /** @return The diagnostic name, or an empty string before initialization. */
+    const std::string& getName() const override { return name; }
+    /**
+     * @return A borrowed reference to the context to which this array belongs.
+     * @throws OpenMMException If the array has not been initialized.
+     */
+    ComputeContext& getContext() override;
+    /**
+     * @brief Returns a borrowed native MTLBuffer handle, not a host data pointer.
+     * @return The buffer object bridged to void*, with no ownership transfer.
+     * @throws OpenMMException If the array has not been initialized.
+     * @note The handle is borrowed until resize() or destruction. Do not release it.
+     */
+    void* getBuffer() const;
+    using ArrayInterface::upload;
+    using ArrayInterface::download;
+    /**
+     * @brief Copies all elements from host memory on the current queue.
+     * @param data The source of getSize()*getElementSize() bytes.
+     * @param blocking Whether to wait for transfer completion before returning.
+     * @note With blocking=false, data must be within the context's pinned buffer.
+     * @see uploadSubArray()
+     */
+    void upload(const void* data, bool blocking=true) override {
+        uploadSubArray(data, 0, getSize(), blocking);
+    }
+    /**
+     * @brief Copies a host range into this array on the current queue.
+     * @param data The source of elements*getElementSize() bytes; may be null for zero elements.
+     * @param offset The first destination element index, not a byte offset.
+     * @param elements The number of elements to copy.
+     * @param blocking Whether to stage the host data and wait for completion.
+     * @throws OpenMMException If uninitialized, the destination range is invalid,
+     *         a nonempty source is null, a nonblocking source is outside the
+     *         context's pinned buffer, or a Metal operation fails.
+     * @note With blocking=false, data may include an offset into the pinned buffer,
+     *       but the entire source range must fit. Keep it unchanged until completion.
+     */
+    void uploadSubArray(const void* data, int offset, int elements, bool blocking=true) override;
+    /**
+     * @brief Copies all elements to host memory on the current queue.
+     * @param data The destination for getSize()*getElementSize() bytes; may be null for an empty array.
+     * @param blocking Whether to wait and copy staged results into data before returning.
+     * @throws OpenMMException If uninitialized, a nonempty destination is null,
+     *         a nonblocking destination is outside the context's pinned buffer,
+     *         or a Metal operation fails.
+     * @note With blocking=false, the entire destination range must fit within the
+     *       context's pinned buffer. Do not read or reuse it until completion.
+     */
+    void download(void* data, bool blocking=true) const override;
+    /**
+     * @brief Enqueues a device-to-device copy on the current queue without waiting.
+     * @param dest An initialized MetalArray, or ComputeArray wrapping one, from
+     *             the same context with matching element count and size.
+     * @throws OpenMMException If either array is uninitialized, the destination
+     *         is incompatible, or a Metal operation fails.
+     * @note Copying to this array itself, or copying an empty array, does no work.
+     */
+    void copyTo(ArrayInterface& dest) const override;
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+    MetalContext* context;
+    size_t size;
+    int elementSize;
+    std::string name;
+};
+
+} // namespace OpenMM
+#endif

--- a/platforms/metal/include/MetalContext.h
+++ b/platforms/metal/include/MetalContext.h
@@ -1,0 +1,325 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/include/CudaContext.h                               *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2009-2026 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENMM_METALCONTEXT_H_
+#define OPENMM_METALCONTEXT_H_
+
+#include "MetalArray.h"
+#include "openmm/common/ComputeContext.h"
+#include <memory>
+
+namespace OpenMM {
+
+class MetalQueue;
+
+/**
+ * @brief Single-device, single-precision ComputeContext for the Metal Platform.
+ *
+ * This runtime foundation follows CudaContext/HipContext. It provides arrays,
+ * queues, events, and native MSL compilation, but is not yet registered as a
+ * simulation Platform and does not translate Common Compute kernel sources.
+ * Unsupported simulation interfaces throw OpenMMException.
+ *
+ * @warning The System must outlive this context. Externally owned arrays,
+ * programs, kernels, and events created for this context must be destroyed before
+ * it. Finish work using context-owned data before destroying the context. Host
+ * access to the context and its shared transfer workspace must be serialized.
+ */
+class MetalContext : public ComputeContext {
+public:
+    /**
+     * @brief Create the default Metal queue and initialize the standard buffers.
+     * @param system System supplying particle masses and default box vectors;
+     *               the context borrows this object.
+     * @throws OpenMMException If no supported Apple silicon device is available,
+     *         the particle count is too large, or resource initialization fails.
+     * @note Atom storage is padded to a multiple of TileSize, with at least one
+     *       tile even for an empty System. Initialization finishes before return.
+     */
+    explicit MetalContext(const System& system);
+    /** @brief Release context-owned resources and its references to the queues. */
+    ~MetalContext();
+    /** @return One; this implementation uses a single device context. */
+    int getNumContexts() const override { return 1; }
+    /** @return Zero, the index of this single device context. */
+    int getContextIndex() const override { return 0; }
+    /** @return A vector containing a borrowed pointer to this context. */
+    std::vector<ComputeContext*> getAllContexts() override { return {this}; }
+    /**
+     * @brief Access the associated simulation context (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; this runtime has no simulation ContextImpl.
+     */
+    ContextImpl* getContextImpl() override;
+    /** @return The mutable host energy accumulator, initially zero. */
+    double& getEnergyWorkspace() override { return energyWorkspace; }
+    /**
+     * @brief Create a queue on this context's device without selecting it.
+     * @return A shared owner of the new MetalQueue.
+     * @throws OpenMMException If queue creation fails.
+     */
+    ComputeQueue createQueue() override;
+    /**
+     * @return A borrowed reference to the currently selected MetalQueue.
+     * @throws OpenMMException If the current queue is not a MetalQueue on this device.
+     */
+    MetalQueue& getCurrentMetalQueue();
+    /** @return A borrowed native @c id<MTLDevice> handle; do not release it. */
+    void* getDevice() const;
+    /** @return A new, uninitialized MetalArray; the caller owns the returned object. */
+    MetalArray* createArray() override;
+    /**
+     * @brief Resolve a MetalArray or a ComputeArray wrapper belonging to this context.
+     * @param array Array to resolve; ownership is not transferred.
+     * @return A borrowed reference to the underlying MetalArray.
+     * @throws OpenMMException If the array is uninitialized, has a different backend,
+     *         or belongs to another context.
+     */
+    MetalArray& unwrap(ArrayInterface& array) const;
+    /** @return A shared owner of a new, initially unrecorded MetalEvent. */
+    ComputeEvent createEvent() override;
+    /**
+     * @brief Create a sorting utility (not implemented).
+     * @param trait Sort description; ownership is taken and it is deleted before throwing.
+     * @param length Requested number of elements (unused).
+     * @param uniform Requested distribution hint (unused).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal sorting is not implemented.
+     */
+    ComputeSort createSort(ComputeSortImpl::SortTrait* trait, unsigned int length, bool uniform=true) override;
+    /**
+     * @brief Compile native MSL 3.0 source with fast math enabled.
+     * @param source Native Metal source, not untranslated Common Compute source.
+     * @param defines Macro names and replacement text prepended as preprocessor definitions.
+     * @return A shared owner of the compiled MetalProgram.
+     * @throws OpenMMException If Metal compilation fails, including compiler diagnostics.
+     */
+    ComputeProgram compileProgram(const std::string source,
+            const std::map<std::string, std::string>& defines={}) override;
+    /**
+     * @brief Choose a SIMD-aligned group size using the device's memory and thread limits.
+     * @param memory Threadgroup-memory bytes required per thread; zero ignores memory usage.
+     * @return The largest permitted multiple of getSIMDWidth().
+     * @throws OpenMMException If memory is negative or nonfinite, or one SIMD group cannot fit.
+     * @note The selected kernel may impose a smaller maximum group size.
+     */
+    int computeThreadBlockSize(double memory) const override;
+    /**
+     * @brief Submit a GPU blit that zeros all bytes in an array on the current queue.
+     * @param array Initialized array belonging to this context.
+     * @throws OpenMMException If array validation or command submission fails.
+     * @note This does not wait for completion. A zero-length array requires no command.
+     */
+    void clearBuffer(ArrayInterface& array) override;
+    /**
+     * @brief Register an array for subsequent calls to clearAutoclearBuffers().
+     * @param array Initialized array from this context, borrowed without deduplication.
+     * @throws OpenMMException If array validation fails.
+     * @warning There is no removal operation; the array or wrapper must remain valid
+     *          for every later clearAutoclearBuffers() call.
+     */
+    void addAutoclearBuffer(ArrayInterface& array) override;
+    /**
+     * @brief Submit clears for all registered arrays on the current queue without waiting.
+     * @note Force and energy buffers are registered by the constructor. This method
+     *       is not yet connected to a simulation force-evaluation lifecycle.
+     * @throws OpenMMException If any array validation or clear submission fails.
+     */
+    void clearAutoclearBuffers();
+    /** @return False; this implementation targets the GPU. */
+    bool getIsCPU() const override { return false; }
+    /** @return The 32-lane SIMD width assumed by this Apple silicon implementation. */
+    int getSIMDWidth() const override { return 32; }
+    /** @return False; 64-bit integer storage does not provide 64-bit atomic accumulation. */
+    bool getSupports64BitGlobalAtomics() const override { return false; }
+    /** @return False; double-precision device arithmetic is not supported. */
+    bool getSupportsDoublePrecision() const override { return false; }
+    /** @return False; device data and calculations use single precision. */
+    bool getUseDoublePrecision() const override { return false; }
+    /** @return False; mixed-precision position storage is not implemented. */
+    bool getUseMixedPrecision() const override { return false; }
+    /** @return The padded atom count divided by TileSize. */
+    int getNumAtomBlocks() const override { return paddedNumAtoms/TileSize; }
+    /** @return The fixed launch-grid cap of 128 threadgroups, not a hardware core count. */
+    int getNumThreadBlocks() const override { return 128; }
+    /** @return The device limit for a one-dimensional group; individual kernels may allow fewer threads. */
+    int getMaxThreadBlockSize() const override;
+    /** @return The owned, padded @c mm_float4 position/charge array, initially zero. */
+    ArrayInterface& getPosq() override { return posq; }
+    /**
+     * @brief Access mixed-precision position corrections (not supported).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; no correction buffer is allocated.
+     */
+    ArrayInterface& getPosqCorrection() override;
+    /** @return The owned, padded @c mm_float4 array of velocity xyz and inverse mass w. */
+    ArrayInterface& getVelm() override { return velm; }
+    /**
+     * @brief Access floating-point force buffers (not supported).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; only the long force buffer is allocated.
+     */
+    ArrayInterface& getForceBuffers() override;
+    /**
+     * @brief Access a floating-point force buffer (not supported).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; only the long force buffer is allocated.
+     */
+    ArrayInterface& getFloatForceBuffer() override;
+    /**
+     * @return The owned @c int64_t force storage in consecutive x, y, z component planes,
+     *         each containing the padded atom count.
+     * @note This allocation alone does not implement fixed-point accumulation or force evaluation.
+     */
+    ArrayInterface& getLongForceBuffer() override { return force; }
+    /** @return The owned, initially zero @c float energy buffer, also registered for autoclear. */
+    ArrayInterface& getEnergyBuffer() override { return energyBuffer; }
+    /**
+     * @brief Access the energy-parameter derivative buffer (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; no derivative buffer is allocated.
+     */
+    ArrayInterface& getEnergyParamDerivBuffer() override;
+    /**
+     * @return A borrowed host pointer to the context-owned shared transfer buffer.
+     * @note Its capacity covers the largest standard array at context construction;
+     *       resizing arrays does not grow this buffer.
+     * @warning Nonblocking array transfers require a range within this buffer. Do not
+     *          read a pending download or modify/reuse a pending transfer's range until
+     *          its queue or a suitably ordered event has completed.
+     */
+    void* getPinnedBuffer() override;
+    /** @return A borrowed reference to the context-owned host thread pool. */
+    ThreadPool& getThreadPool() override;
+    /** @return The owned, padded @c int atom-index array, initially the identity mapping. */
+    ArrayInterface& getAtomIndexArray() override { return atomIndexArray; }
+    /** @return True if any stored box vector has a nonzero off-diagonal component. */
+    bool getBoxIsTriclinic() const override;
+    /**
+     * @brief Copy the stored periodic box vectors, in nanometers.
+     * @param[out] a First box vector.
+     * @param[out] b Second box vector.
+     * @param[out] c Third box vector.
+     */
+    void getPeriodicBoxVectors(Vec3& a, Vec3& b, Vec3& c) const override;
+    /**
+     * @brief Store periodic box vectors without validating them or changing coordinates.
+     * @param a First box vector, in nanometers.
+     * @param b Second box vector, in nanometers.
+     * @param c Third box vector, in nanometers.
+     */
+    void setPeriodicBoxVectors(const Vec3& a, const Vec3& b, const Vec3& c) override;
+    /**
+     * @brief Access integration utilities (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal integration utilities are not implemented.
+     */
+    IntegrationUtilities& getIntegrationUtilities() override;
+    /**
+     * @brief Access expression utilities (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal expression utilities are not implemented.
+     */
+    ExpressionUtilities& getExpressionUtilities() override;
+    /**
+     * @brief Access bonded utilities (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal bonded utilities are not implemented.
+     */
+    BondedUtilities& getBondedUtilities() override;
+    /**
+     * @brief Access nonbonded utilities (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal nonbonded utilities are not implemented.
+     */
+    NonbondedUtilities& getNonbondedUtilities() override;
+    /**
+     * @brief Create nonbonded utilities (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal nonbonded utilities are not implemented.
+     */
+    NonbondedUtilities* createNonbondedUtilities() override;
+    /**
+     * @brief Create an FFT utility (not implemented).
+     * @param xsize Requested x dimension (unused).
+     * @param ysize Requested y dimension (unused).
+     * @param zsize Requested z dimension (unused).
+     * @param realToComplex Requested transform type (unused).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; Metal FFT is not implemented.
+     */
+    FFT3D createFFT(int xsize, int ysize, int zsize, bool realToComplex=false) override;
+    /** @brief No-op; runtime buffers are initialized by the constructor, not simulation setup. */
+    void initializeContexts() override {}
+    /**
+     * @brief Set nonbonded charges (not implemented).
+     * @param charges Requested charges in elementary-charge units (unused).
+     * @throws OpenMMException Always; nonbonded charge handling is not implemented.
+     */
+    void setCharges(const std::vector<double>& charges) override;
+    /**
+     * @brief Request use of the position array's charge component (not implemented).
+     * @return Never returns; this method always throws.
+     * @throws OpenMMException Always; nonbonded charge handling is not implemented.
+     */
+    bool requestPosqCharges() override;
+    /** @return The empty derivative-name list; derivative registration is not implemented. */
+    const std::vector<std::string>& getEnergyParamDerivNames() const override { return energyParamDerivNames; }
+    /** @return Mutable host derivative bookkeeping; no device derivative evaluation is implemented. */
+    std::map<std::string, double>& getEnergyParamDerivWorkspace() override { return energyParamDerivWorkspace; }
+    /**
+     * @brief Register an energy-parameter derivative (not implemented).
+     * @param param Requested parameter name (unused).
+     * @throws OpenMMException Always; energy-parameter derivatives are not implemented.
+     */
+    void addEnergyParameterDerivative(const std::string& param) override;
+    /**
+     * @brief Wait for tracked work on the current queue, matching CUDA/HIP flush behavior.
+     * @throws OpenMMException If the current queue is invalid or GPU execution fails.
+     * @note This is a host completion wait, not just a request to submit pending commands.
+     */
+    void flushQueue() override;
+private:
+    friend class MetalArray;
+    /** @return A borrowed native @c id<MTLBuffer> handle for the shared transfer workspace. */
+    void* getPinnedBufferHandle() const;
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+    MetalArray posq, velm, force, energyBuffer, atomIndexArray;
+    std::vector<ArrayInterface*> autoclearBuffers;
+    Vec3 periodicBoxVectors[3];
+    double energyWorkspace;
+    std::vector<std::string> energyParamDerivNames;
+    std::map<std::string, double> energyParamDerivWorkspace;
+};
+
+} // namespace OpenMM
+#endif

--- a/platforms/metal/include/MetalEvent.h
+++ b/platforms/metal/include/MetalEvent.h
@@ -1,0 +1,89 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/include/CudaEvent.h                                 *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2019-2025 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENMM_METALEVENT_H_
+#define OPENMM_METALEVENT_H_
+
+#include "openmm/common/ComputeEvent.h"
+#include <memory>
+
+namespace OpenMM {
+
+class MetalContext;
+
+/**
+ * @brief Record a Metal queue position for host waits and cross-queue GPU dependencies.
+ *
+ * Adapted from CudaEvent. Each enqueue() uses a fresh native event so recording
+ * again does not alter GPU waits already submitted for an earlier recording.
+ * @warning The associated MetalContext must outlive this event. Host access must
+ *          be serialized with recording and queue submission.
+ */
+class MetalEvent : public ComputeEventImpl {
+public:
+    /**
+     * @brief Create an initially unrecorded event.
+     * @param context Borrowed context whose current queue is used by enqueue().
+     */
+    explicit MetalEvent(MetalContext& context);
+    /** @brief Release this event's native handles and recorded source-queue reference. */
+    ~MetalEvent();
+    /**
+     * @brief Record a marker after preceding work on the context's current queue.
+     * @throws OpenMMException If the current queue is invalid or recording/submission fails.
+     * @note This does not wait for GPU completion. Subsequent wait() and queueWait()
+     *       calls refer to this latest recording, even if the current queue changes.
+     */
+    void enqueue() override;
+    /**
+     * @brief Block the host until the recorded source queue completes through the marker.
+     * @throws OpenMMException If the source queue reports an execution error.
+     * @note An unrecorded event is a no-op; later source-queue commands are not waited for.
+     */
+    void wait() override;
+    /**
+     * @brief Submit a GPU dependency before subsequent work on a target queue.
+     * @param queue Target MetalQueue on the same device as this event's context.
+     * @throws OpenMMException If the queue is null, has a different backend/device,
+     *         or wait-command creation/submission fails.
+     * @note This does not block the host or change the context's selected queue.
+     *       For an unrecorded event, the target is validated but no wait is submitted.
+     */
+    void queueWait(ComputeQueue queue) override;
+private:
+    class Impl;
+    MetalContext& context;
+    std::unique_ptr<Impl> impl;
+};
+
+} // namespace OpenMM
+
+#endif /*OPENMM_METALEVENT_H_*/

--- a/platforms/metal/include/MetalKernel.h
+++ b/platforms/metal/include/MetalKernel.h
@@ -1,0 +1,137 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/include/CudaKernel.h                                *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2019 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENMM_METALKERNEL_H_
+#define OPENMM_METALKERNEL_H_
+
+#include "openmm/common/ComputeKernel.h"
+#include "openmm/common/ComputeVectorTypes.h"
+#include <memory>
+#include <vector>
+
+namespace OpenMM {
+
+class MetalArray;
+class MetalContext;
+
+/**
+ * @brief Executes a Metal compute pipeline through the Common kernel interface.
+ *
+ * Arguments use consecutive direct Metal buffer bindings starting at zero.
+ * Arrays and copied primitive values share the same 31 slots (indices 0-30). The
+ * caller must match the native MSL signature, byte layouts, and resource-access
+ * rules; this class does not inspect or translate the shader's argument ABI.
+ *
+ * @note The context must outlive this kernel. Array arguments are non-owning
+ *       references and must remain alive while bound; their current buffers are
+ *       resolved at each launch so that resizing and rebinding are observed.
+ */
+class MetalKernel : public ComputeKernelImpl {
+public:
+    /**
+     * @brief Retains a native compute pipeline for subsequent launches.
+     * @param context The Metal context, which must outlive this kernel.
+     * @param pipeline A valid MTLComputePipelineState from the context's device,
+     *                 bridged to void*. The caller's ownership is unchanged.
+     * @param name The shader entry-point name used for diagnostics.
+     */
+    MetalKernel(MetalContext& context, void* pipeline, const std::string& name);
+    /** @brief Releases the retained pipeline and argument storage without waiting. */
+    ~MetalKernel();
+    /** @return The shader entry-point name. */
+    std::string getName() const override { return name; }
+    /** @return The pipeline's maximum threads per threadgroup. */
+    int getMaxBlockSize() const override;
+    /**
+     * @brief Enqueues a one-dimensional launch on the context's current queue.
+     * @param threads The nonnegative logical thread count; zero enqueues no work.
+     * @param blockSize Threads per group, or -1 for ComputeContext::ThreadBlockSize.
+     * @throws OpenMMException If the thread count or block size is invalid, a
+     *         nonempty launch has more than 31 or unbound arguments, or submission fails.
+     * @note Launches complete threadgroups, rounding up and capping the group
+     *       count at context.getNumThreadBlocks(). The shader must handle bounds
+     *       and use grid-stride iteration when the capped grid is smaller than
+     *       its workload. This method does not wait for GPU completion.
+     */
+    void execute(int threads, int blockSize=-1) override;
+protected:
+    /**
+     * @brief Appends a non-owning array argument at the next buffer binding.
+     * @param value An initialized MetalArray, or ComputeArray wrapping one,
+     *              from this kernel's context.
+     * @throws OpenMMException If value is uninitialized or from another backend or context.
+     */
+    void addArrayArg(ArrayInterface& value) override;
+    /**
+     * @brief Appends a primitive argument by copying its host bytes.
+     * @param value A non-null pointer to the value; it need not remain alive after this call.
+     * @param size The byte count, from 1 through sizeof(mm_double4) (32 bytes).
+     * @throws OpenMMException If value is null or size is unsupported.
+     * @note Bytes are passed without type conversion; their layout must match MSL.
+     */
+    void addPrimitiveArg(const void* value, int size) override;
+    /**
+     * @brief Appends an unbound argument slot.
+     * @note Bind it with setArg() before a nonempty launch. The 31-slot limit is
+     *       checked at execution, not when the placeholder is appended.
+     */
+    void addEmptyArg() override;
+    /**
+     * @brief Replaces an existing slot with a non-owning array binding.
+     * @param index The zero-based index of an already appended argument.
+     * @param value An initialized MetalArray, or ComputeArray wrapping one,
+     *              from this kernel's context.
+     * @throws OpenMMException If the index is invalid or the array is incompatible.
+     * @note The previous slot may hold a primitive value, an array, or a placeholder.
+     */
+    void setArrayArg(int index, ArrayInterface& value) override;
+    /**
+     * @brief Replaces an existing slot with a copy of a primitive value.
+     * @param index The zero-based index of an already appended argument.
+     * @param value A non-null pointer to the host bytes to copy.
+     * @param size The byte count, from 1 through sizeof(mm_double4) (32 bytes).
+     * @throws OpenMMException If the index, pointer, or size is invalid.
+     * @note The slot may previously hold an array or a differently sized value.
+     *       The new bytes and size must match the shader's binding contract.
+     */
+    void setPrimitiveArg(int index, const void* value, int size) override;
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+    MetalContext& context;
+    std::string name;
+    std::vector<mm_double4> primitiveArgs;
+    std::vector<int> primitiveArgSizes;
+    std::vector<MetalArray*> arrayArgs;
+};
+
+} // namespace OpenMM
+#endif

--- a/platforms/metal/include/MetalProgram.h
+++ b/platforms/metal/include/MetalProgram.h
@@ -1,0 +1,76 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/include/CudaProgram.h                               *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2019 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENMM_METALPROGRAM_H_
+#define OPENMM_METALPROGRAM_H_
+
+#include "openmm/common/ComputeProgram.h"
+#include <memory>
+
+namespace OpenMM {
+
+class MetalContext;
+
+/**
+ * @brief Wraps a compiled Metal library through the Common program interface.
+ *
+ * MetalContext::compileProgram() creates this object from native Metal 3.0
+ * source. It does not translate existing Common kernel source into MSL.
+ * The library is retained by this object; the context must outlive it and any
+ * kernels created from it.
+ */
+class MetalProgram : public ComputeProgramImpl {
+public:
+    /**
+     * @brief Retains a compiled library for kernel lookup and pipeline creation.
+     * @param context The Metal context, which must outlive this program.
+     * @param library A valid MTLLibrary from the context's device, bridged to void*.
+     *                The caller's ownership is unchanged.
+     */
+    MetalProgram(MetalContext& context, void* library);
+    /** @brief Releases this program's retained library without destroying its kernels. */
+    ~MetalProgram();
+    /**
+     * @brief Creates an independently owned compute pipeline for a library entry point.
+     * @param name The host-visible name of the Metal kernel function.
+     * @return A shared-ownership ComputeKernel handle with no arguments bound.
+     *         It may outlive this program, but not the context.
+     * @throws OpenMMException If the function is missing or pipeline creation fails.
+     */
+    ComputeKernel createKernel(const std::string& name) override;
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+    MetalContext& context;
+};
+
+} // namespace OpenMM
+#endif

--- a/platforms/metal/include/MetalQueue.h
+++ b/platforms/metal/include/MetalQueue.h
@@ -1,0 +1,99 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/include/CudaQueue.h                                 *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2025 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENMM_METALQUEUE_H_
+#define OPENMM_METALQUEUE_H_
+
+#include "openmm/common/ComputeQueue.h"
+#include <memory>
+
+namespace OpenMM {
+
+/**
+ * @brief Metal command queue with submission tracking and GPU error reporting.
+ *
+ * Adapted from CudaQueue. Native handles are kept opaque so callers can include
+ * this header from ordinary C++ code.
+ * @warning Host calls must be serialized by the caller; this wrapper has no lock.
+ */
+class MetalQueue : public ComputeQueueImpl {
+public:
+    /**
+     * @brief Create and own a native command queue on the supplied device.
+     * @param device Borrowed, non-null native @c id<MTLDevice> handle.
+     * @throws OpenMMException If the device is null or queue creation fails.
+     */
+    explicit MetalQueue(void* device);
+    /**
+     * @brief Wait for tracked submissions before releasing native resources.
+     * @note Destruction does not report GPU errors; use wait() or finish() explicitly.
+     */
+    ~MetalQueue();
+    /**
+     * @return A borrowed native @c id<MTLCommandQueue> handle; do not release it.
+     * @note Submit its command buffers through submit() so completion and errors are tracked.
+     */
+    void* getQueue() const;
+    /**
+     * @brief Retain and commit a command buffer without waiting for GPU execution.
+     * @param commandBuffer Borrowed native @c id<MTLCommandBuffer> from this queue,
+     *                      not yet committed.
+     * @throws OpenMMException If the buffer is null, foreign, or already committed,
+     *         or an earlier completed submission reports an error.
+     * @note Completed submissions are reaped first. If one reports an error, the
+     *       supplied command buffer is not committed by this call.
+     */
+    void submit(void* commandBuffer);
+    /**
+     * @brief Wait for all currently tracked submissions and report execution errors.
+     * @throws OpenMMException If GPU execution fails.
+     * @note An empty queue requires no wait. Other queues are not synchronized.
+     */
+    void finish();
+    /**
+     * @brief Wait through a submitted marker, checking preceding tracked commands for errors.
+     * @param commandBuffer Borrowed native @c id<MTLCommandBuffer> already committed
+     *                      on this queue; it may already have completed or been reaped.
+     * @throws OpenMMException If the marker is null, uncommitted, or foreign, or GPU
+     *         execution fails. Tracked commands through the marker are drained before
+     *         their first execution error is reported.
+     * @note Later submissions are not waited for. Errors from already-reaped preceding
+     *       commands are not retained; the marker's own status is always checked.
+     */
+    void wait(void* commandBuffer);
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+} // namespace OpenMM
+
+#endif /*OPENMM_METALQUEUE_H_*/

--- a/platforms/metal/src/MetalArray.mm
+++ b/platforms/metal/src/MetalArray.mm
@@ -1,0 +1,204 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/src/CudaArray.cpp                                   *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2012-2022 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalArray.h"
+#include "MetalContext.h"
+#include "MetalQueue.h"
+#include "openmm/OpenMMException.h"
+#import <Metal/Metal.h>
+#include <cstring>
+#include <cstdint>
+#include <limits>
+
+using namespace OpenMM;
+using namespace std;
+
+struct MetalArray::Impl {
+    id<MTLBuffer> buffer = nil;
+};
+
+static size_t getPinnedOffset(id<MTLBuffer> buffer, const void* data, size_t bytes) {
+    uintptr_t start = reinterpret_cast<uintptr_t>(buffer.contents);
+    uintptr_t address = reinterpret_cast<uintptr_t>(data);
+    if (address < start || address-start > buffer.length || bytes > buffer.length-(address-start))
+        throw OpenMMException("Nonblocking Metal transfers require memory from getPinnedBuffer()");
+    return address-start;
+}
+
+MetalArray::MetalArray() : impl(new Impl()), context(nullptr), size(0), elementSize(0) {
+}
+
+MetalArray::MetalArray(MetalContext& context, size_t size, int elementSize, const string& name) : MetalArray() {
+    initialize(context, size, elementSize, name);
+}
+
+MetalArray::~MetalArray() {
+}
+
+void MetalArray::initialize(ComputeContext& context, size_t size, int elementSize, const string& name) {
+    if (isInitialized())
+        throw OpenMMException("MetalArray has already been initialized");
+    MetalContext& metal = dynamic_cast<MetalContext&>(context);
+    if (elementSize <= 0 || size > numeric_limits<int>::max() ||
+            size > numeric_limits<size_t>::max()/elementSize)
+        throw OpenMMException("Invalid MetalArray size: "+name);
+    @autoreleasepool {
+        id<MTLDevice> device = (__bridge id<MTLDevice>) metal.getDevice();
+        // A zero-length logical array still needs a legal Metal resource.
+        impl->buffer = [device newBufferWithLength:max(size*elementSize, size_t(1)) options:MTLResourceStorageModePrivate];
+        if (impl->buffer == nil)
+            throw OpenMMException("Error creating Metal array "+name);
+        impl->buffer.label = [NSString stringWithUTF8String:name.c_str()];
+    }
+    this->context = &metal;
+    this->size = size;
+    this->elementSize = elementSize;
+    this->name = name;
+}
+
+void MetalArray::resize(size_t size) {
+    if (!isInitialized())
+        throw OpenMMException("MetalArray has not been initialized");
+    MetalArray replacement(*context, size, elementSize, name);
+    impl.swap(replacement.impl);
+    this->size = size;
+}
+
+bool MetalArray::isInitialized() const {
+    return impl->buffer != nil;
+}
+
+ComputeContext& MetalArray::getContext() {
+    if (!isInitialized())
+        throw OpenMMException("MetalArray has not been initialized");
+    return *context;
+}
+
+void* MetalArray::getBuffer() const {
+    if (!isInitialized())
+        throw OpenMMException("MetalArray has not been initialized");
+    return (__bridge void*) impl->buffer;
+}
+
+void MetalArray::uploadSubArray(const void* data, int offset, int elements, bool blocking) {
+    if (!isInitialized())
+        throw OpenMMException("MetalArray has not been initialized");
+    if (offset < 0 || elements < 0 || size_t(offset) > size || size_t(elements) > size-offset)
+        throw OpenMMException("uploadSubArray: data exceeds range of array");
+    if (elements == 0)
+        return;
+    if (data == nullptr)
+        throw OpenMMException("Null source for Metal array upload");
+    @autoreleasepool {
+        MetalQueue& queue = context->getCurrentMetalQueue();
+        id<MTLDevice> device = (__bridge id<MTLDevice>) context->getDevice();
+        size_t bytes = size_t(elements)*elementSize;
+        id<MTLBuffer> staging;
+        size_t sourceOffset = 0;
+        if (blocking)
+            staging = [device newBufferWithBytes:data length:bytes options:MTLResourceStorageModeShared];
+        else {
+            staging = (__bridge id<MTLBuffer>) context->getPinnedBufferHandle();
+            sourceOffset = getPinnedOffset(staging, data, bytes);
+        }
+        if (staging == nil)
+            throw OpenMMException("Error creating upload buffer for "+name);
+        id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) queue.getQueue();
+        id<MTLCommandBuffer> command = [commandQueue commandBuffer];
+        id<MTLBlitCommandEncoder> encoder = [command blitCommandEncoder];
+        if (encoder == nil)
+            throw OpenMMException("Error creating Metal upload command");
+        [encoder copyFromBuffer:staging sourceOffset:sourceOffset toBuffer:impl->buffer
+                destinationOffset:size_t(offset)*elementSize size:bytes];
+        [encoder endEncoding];
+        queue.submit((__bridge void*) command);
+        if (blocking)
+            queue.wait((__bridge void*) command);
+    }
+}
+
+void MetalArray::download(void* data, bool blocking) const {
+    if (!isInitialized())
+        throw OpenMMException("MetalArray has not been initialized");
+    if (size == 0)
+        return;
+    if (data == nullptr)
+        throw OpenMMException("Null destination for Metal array download");
+    @autoreleasepool {
+        MetalQueue& queue = context->getCurrentMetalQueue();
+        id<MTLDevice> device = (__bridge id<MTLDevice>) context->getDevice();
+        size_t bytes = size*elementSize;
+        id<MTLBuffer> staging;
+        size_t destinationOffset = 0;
+        if (blocking)
+            staging = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        else {
+            staging = (__bridge id<MTLBuffer>) context->getPinnedBufferHandle();
+            destinationOffset = getPinnedOffset(staging, data, bytes);
+        }
+        if (staging == nil)
+            throw OpenMMException("Error creating download buffer for "+name);
+        id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) queue.getQueue();
+        id<MTLCommandBuffer> command = [commandQueue commandBuffer];
+        id<MTLBlitCommandEncoder> encoder = [command blitCommandEncoder];
+        if (encoder == nil)
+            throw OpenMMException("Error creating Metal download command");
+        [encoder copyFromBuffer:impl->buffer sourceOffset:0 toBuffer:staging destinationOffset:destinationOffset size:bytes];
+        [encoder endEncoding];
+        queue.submit((__bridge void*) command);
+        if (blocking) {
+            queue.wait((__bridge void*) command);
+            memcpy(data, staging.contents, bytes);
+        }
+    }
+}
+
+void MetalArray::copyTo(ArrayInterface& dest) const {
+    if (!isInitialized())
+        throw OpenMMException("MetalArray has not been initialized");
+    if (dest.getSize() != size || dest.getElementSize() != elementSize)
+        throw OpenMMException("Error copying array "+name+": destination size does not match");
+    MetalArray& metalDest = context->unwrap(dest);
+    if (size == 0 || &metalDest == this)
+        return;
+    @autoreleasepool {
+        MetalQueue& queue = context->getCurrentMetalQueue();
+        id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) queue.getQueue();
+        id<MTLCommandBuffer> command = [commandQueue commandBuffer];
+        id<MTLBlitCommandEncoder> encoder = [command blitCommandEncoder];
+        if (encoder == nil)
+            throw OpenMMException("Error creating Metal copy command");
+        [encoder copyFromBuffer:impl->buffer sourceOffset:0 toBuffer:metalDest.impl->buffer
+                destinationOffset:0 size:size*elementSize];
+        [encoder endEncoding];
+        queue.submit((__bridge void*) command);
+    }
+}

--- a/platforms/metal/src/MetalContext.mm
+++ b/platforms/metal/src/MetalContext.mm
@@ -1,0 +1,312 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/src/CudaContext.cpp                                 *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2009-2026 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalContext.h"
+#include "MetalEvent.h"
+#include "MetalProgram.h"
+#include "MetalQueue.h"
+#include "openmm/internal/ThreadPool.h"
+#import <Metal/Metal.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <numeric>
+
+using namespace OpenMM;
+using namespace std;
+
+struct MetalContext::Impl {
+    id<MTLDevice> device = nil;
+    id<MTLBuffer> pinnedBuffer = nil;
+    ThreadPool threads;
+    Impl() : threads(1) {
+    }
+};
+
+MetalContext::MetalContext(const System& system) : ComputeContext(system), energyWorkspace(0.0) {
+    try {
+        impl.reset(new Impl());
+        @autoreleasepool {
+            impl->device = MTLCreateSystemDefaultDevice();
+            if (impl->device == nil)
+                throw OpenMMException("No Metal device is available");
+            if (![impl->device supportsFamily:MTLGPUFamilyApple7])
+                throw OpenMMException("The Metal Platform requires Apple silicon");
+            defaultQueue = createQueue();
+            restoreDefaultQueue();
+            numAtoms = system.getNumParticles();
+            if (numAtoms > numeric_limits<int>::max()-TileSize)
+                throw OpenMMException("Too many atoms for the Metal Platform");
+            paddedNumAtoms = max(TileSize, TileSize*((numAtoms+TileSize-1)/TileSize));
+            posq.initialize<mm_float4>(*this, paddedNumAtoms, "posq");
+            velm.initialize<mm_float4>(*this, paddedNumAtoms, "velm");
+            // Standard CUDA/HIP component planes; no custom fixed-point storage ABI.
+            force.initialize<int64_t>(*this, 3*size_t(paddedNumAtoms), "force");
+            energyBuffer.initialize<float>(*this, getNumThreadBlocks()*ThreadBlockSize, "energyBuffer");
+            atomIndexArray.initialize<int>(*this, paddedNumAtoms, "atomIndex");
+            atomIndex.resize(paddedNumAtoms);
+            iota(atomIndex.begin(), atomIndex.end(), 0);
+            atomIndexArray.upload(atomIndex);
+            posCellOffsets.resize(paddedNumAtoms, mm_int4(0, 0, 0, 0));
+            vector<mm_float4> velocities(paddedNumAtoms, mm_float4(0, 0, 0, 0));
+            for (int i = 0; i < numAtoms; i++) {
+                double mass = system.getParticleMass(i);
+                velocities[i].w = (mass == 0.0 ? 0.0f : (float) (1.0/mass));
+            }
+            velm.upload(velocities);
+            clearBuffer(posq);
+            clearBuffer(force);
+            clearBuffer(energyBuffer);
+            addAutoclearBuffer(force);
+            addAutoclearBuffer(energyBuffer);
+            size_t pinnedBytes = max(force.getSize()*force.getElementSize(),
+                    energyBuffer.getSize()*energyBuffer.getElementSize());
+            impl->pinnedBuffer = [impl->device newBufferWithLength:pinnedBytes options:MTLResourceStorageModeShared];
+            if (impl->pinnedBuffer == nil)
+                throw OpenMMException("Error creating Metal pinned transfer buffer");
+            system.getDefaultPeriodicBoxVectors(periodicBoxVectors[0], periodicBoxVectors[1], periodicBoxVectors[2]);
+            getCurrentMetalQueue().finish();
+        }
+    }
+    catch (...) {
+        delete workThread;
+        workThread = nullptr;
+        throw;
+    }
+}
+
+MetalContext::~MetalContext() {
+    delete workThread;
+    for (auto* value : forces)
+        delete value;
+    for (auto* value : reorderListeners)
+        delete value;
+    for (auto* value : preComputations)
+        delete value;
+    for (auto* value : postComputations)
+        delete value;
+    // Queue destructors finish pending work without throwing from destruction.
+    currentQueue.reset();
+    defaultQueue.reset();
+}
+
+void* MetalContext::getDevice() const {
+    return (__bridge void*) impl->device;
+}
+
+ContextImpl* MetalContext::getContextImpl() {
+    throw OpenMMException("The Metal Platform is not attached to a simulation Context");
+}
+
+ComputeQueue MetalContext::createQueue() {
+    return ComputeQueue(new MetalQueue(getDevice()));
+}
+
+MetalQueue& MetalContext::getCurrentMetalQueue() {
+    MetalQueue* queue = dynamic_cast<MetalQueue*>(currentQueue.get());
+    if (queue == nullptr)
+        throw OpenMMException("The current queue is not a MetalQueue");
+    id<MTLCommandQueue> native = (__bridge id<MTLCommandQueue>) queue->getQueue();
+    if (native.device != impl->device)
+        throw OpenMMException("The current Metal queue belongs to a different device");
+    return *queue;
+}
+
+MetalArray* MetalContext::createArray() {
+    return new MetalArray();
+}
+
+MetalArray& MetalContext::unwrap(ArrayInterface& array) const {
+    ComputeArray* wrapper = dynamic_cast<ComputeArray*>(&array);
+    MetalArray* metalArray = dynamic_cast<MetalArray*>(wrapper == nullptr ? &array : &wrapper->getArray());
+    if (metalArray == nullptr || &metalArray->getContext() != this)
+        throw OpenMMException("Array argument is not a MetalArray from this context");
+    return *metalArray;
+}
+
+ComputeEvent MetalContext::createEvent() {
+    return ComputeEvent(new MetalEvent(*this));
+}
+
+ComputeProgram MetalContext::compileProgram(const string source, const map<string, string>& defines) {
+    @autoreleasepool {
+        string code;
+        for (auto& define : defines)
+            code += "#define "+define.first+" "+define.second+"\n";
+        code += source;
+        MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+        options.languageVersion = MTLLanguageVersion3_0;
+        options.fastMathEnabled = YES;
+        NSError* error = nil;
+        id<MTLLibrary> library = [impl->device newLibraryWithSource:[NSString stringWithUTF8String:code.c_str()]
+                options:options error:&error];
+        if (library == nil)
+            throw OpenMMException("Error compiling Metal program: "+
+                    (error == nil ? string("unknown error") : string(error.localizedDescription.UTF8String)));
+        return ComputeProgram(new MetalProgram(*this, (__bridge void*) library));
+    }
+}
+
+int MetalContext::getMaxThreadBlockSize() const {
+    return impl->device.maxThreadsPerThreadgroup.width;
+}
+
+int MetalContext::computeThreadBlockSize(double memory) const {
+    if (!isfinite(memory) || memory < 0)
+        throw OpenMMException("Invalid shared memory requirement");
+    int maximum = getMaxThreadBlockSize();
+    if (memory > 0)
+        maximum = min(double(maximum), floor(impl->device.maxThreadgroupMemoryLength/memory));
+    if (maximum < getSIMDWidth())
+        throw OpenMMException("Shared memory requirement exceeds Metal threadgroup capacity");
+    return (maximum/getSIMDWidth())*getSIMDWidth();
+}
+
+void MetalContext::clearBuffer(ArrayInterface& array) {
+    MetalArray& metalArray = unwrap(array);
+    if (metalArray.getSize() == 0)
+        return;
+    @autoreleasepool {
+        MetalQueue& queue = getCurrentMetalQueue();
+        id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) queue.getQueue();
+        id<MTLCommandBuffer> command = [commandQueue commandBuffer];
+        id<MTLBlitCommandEncoder> encoder = [command blitCommandEncoder];
+        if (encoder == nil)
+            throw OpenMMException("Error creating Metal clear command");
+        [encoder fillBuffer:(__bridge id<MTLBuffer>) metalArray.getBuffer()
+                range:NSMakeRange(0, metalArray.getSize()*metalArray.getElementSize()) value:0];
+        [encoder endEncoding];
+        queue.submit((__bridge void*) command);
+    }
+}
+
+void MetalContext::addAutoclearBuffer(ArrayInterface& array) {
+    unwrap(array);
+    autoclearBuffers.push_back(&array);
+}
+
+void MetalContext::clearAutoclearBuffers() {
+    for (auto* array : autoclearBuffers)
+        clearBuffer(*array);
+}
+
+void* MetalContext::getPinnedBuffer() {
+    return impl->pinnedBuffer.contents;
+}
+
+void* MetalContext::getPinnedBufferHandle() const {
+    return (__bridge void*) impl->pinnedBuffer;
+}
+
+ThreadPool& MetalContext::getThreadPool() {
+    return impl->threads;
+}
+
+bool MetalContext::getBoxIsTriclinic() const {
+    return periodicBoxVectors[0][1] != 0.0 || periodicBoxVectors[0][2] != 0.0 ||
+            periodicBoxVectors[1][0] != 0.0 || periodicBoxVectors[1][2] != 0.0 ||
+            periodicBoxVectors[2][0] != 0.0 || periodicBoxVectors[2][1] != 0.0;
+}
+
+void MetalContext::getPeriodicBoxVectors(Vec3& a, Vec3& b, Vec3& c) const {
+    a = periodicBoxVectors[0];
+    b = periodicBoxVectors[1];
+    c = periodicBoxVectors[2];
+}
+
+void MetalContext::setPeriodicBoxVectors(const Vec3& a, const Vec3& b, const Vec3& c) {
+    periodicBoxVectors[0] = a;
+    periodicBoxVectors[1] = b;
+    periodicBoxVectors[2] = c;
+}
+
+void MetalContext::flushQueue() {
+    // Match CudaContext/HipContext: flush also waits for the current stream.
+    getCurrentMetalQueue().finish();
+}
+
+ArrayInterface& MetalContext::getPosqCorrection() {
+    throw OpenMMException("Metal does not use mixed precision");
+}
+
+ArrayInterface& MetalContext::getForceBuffers() {
+    throw OpenMMException("Metal does not use floating point force buffers");
+}
+
+ArrayInterface& MetalContext::getFloatForceBuffer() {
+    throw OpenMMException("Metal does not use floating point force buffers");
+}
+
+ArrayInterface& MetalContext::getEnergyParamDerivBuffer() {
+    throw OpenMMException("Metal energy parameter derivatives are not implemented");
+}
+
+void MetalContext::addEnergyParameterDerivative(const string& param) {
+    throw OpenMMException("Metal energy parameter derivatives are not implemented");
+}
+
+ComputeSort MetalContext::createSort(ComputeSortImpl::SortTrait* trait, unsigned int length, bool uniform) {
+    delete trait;
+    throw OpenMMException("Metal sorting is not implemented");
+}
+
+IntegrationUtilities& MetalContext::getIntegrationUtilities() {
+    throw OpenMMException("Metal integration utilities are not implemented");
+}
+
+ExpressionUtilities& MetalContext::getExpressionUtilities() {
+    throw OpenMMException("Metal expression utilities are not implemented");
+}
+
+BondedUtilities& MetalContext::getBondedUtilities() {
+    throw OpenMMException("Metal bonded utilities are not implemented");
+}
+
+NonbondedUtilities& MetalContext::getNonbondedUtilities() {
+    throw OpenMMException("Metal nonbonded utilities are not implemented");
+}
+
+NonbondedUtilities* MetalContext::createNonbondedUtilities() {
+    throw OpenMMException("Metal nonbonded utilities are not implemented");
+}
+
+FFT3D MetalContext::createFFT(int xsize, int ysize, int zsize, bool realToComplex) {
+    throw OpenMMException("Metal FFT is not implemented");
+}
+
+void MetalContext::setCharges(const vector<double>& charges) {
+    throw OpenMMException("Metal nonbonded charges are not implemented");
+}
+
+bool MetalContext::requestPosqCharges() {
+    throw OpenMMException("Metal nonbonded charges are not implemented");
+}

--- a/platforms/metal/src/MetalEvent.mm
+++ b/platforms/metal/src/MetalEvent.mm
@@ -1,0 +1,87 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/src/CudaEvent.cpp                                   *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2019-2025 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalEvent.h"
+#include "MetalContext.h"
+#include "MetalQueue.h"
+#include "openmm/OpenMMException.h"
+#import <Metal/Metal.h>
+
+using namespace OpenMM;
+
+class MetalEvent::Impl {
+public:
+    id<MTLEvent> event;
+    id<MTLCommandBuffer> marker;
+    ComputeQueue queue;
+};
+
+MetalEvent::MetalEvent(MetalContext& context) : context(context), impl(new Impl()) {
+}
+
+MetalEvent::~MetalEvent() {
+}
+
+void MetalEvent::enqueue() {
+    MetalQueue& queue = context.getCurrentMetalQueue();
+    id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) queue.getQueue();
+    // Separate recordings must not signal each other when made on different queues.
+    id<MTLEvent> event = [commandQueue.device newEvent];
+    id<MTLCommandBuffer> marker = [commandQueue commandBuffer];
+    if (event == nil || marker == nil)
+        throw OpenMMException("Error recording Metal event");
+    [marker encodeSignalEvent:event value:1];
+    queue.submit((__bridge void*) marker);
+    impl->event = event;
+    impl->marker = marker;
+    impl->queue = context.getCurrentQueue();
+}
+
+void MetalEvent::wait() {
+    if (impl->marker != nil)
+        static_cast<MetalQueue&>(*impl->queue).wait((__bridge void*) impl->marker);
+}
+
+void MetalEvent::queueWait(ComputeQueue queue) {
+    MetalQueue* target = dynamic_cast<MetalQueue*>(queue.get());
+    if (target == nullptr)
+        throw OpenMMException("Metal event requires a Metal command queue");
+    id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) target->getQueue();
+    if (commandQueue.device != (__bridge id<MTLDevice>) context.getDevice())
+        throw OpenMMException("Metal event and command queue belong to different devices");
+    if (impl->marker == nil)
+        return;
+    id<MTLCommandBuffer> buffer = [commandQueue commandBuffer];
+    if (buffer == nil)
+        throw OpenMMException("Error creating Metal event wait command buffer");
+    [buffer encodeWaitForEvent:impl->event value:1];
+    target->submit((__bridge void*) buffer);
+}

--- a/platforms/metal/src/MetalKernel.mm
+++ b/platforms/metal/src/MetalKernel.mm
@@ -1,0 +1,124 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/src/CudaKernel.cpp                                  *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2019 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalKernel.h"
+#include "MetalContext.h"
+#include "MetalQueue.h"
+#include "openmm/internal/AssertionUtilities.h"
+#import <Metal/Metal.h>
+#include <algorithm>
+#include <cstring>
+
+using namespace OpenMM;
+using namespace std;
+
+struct MetalKernel::Impl {
+    id<MTLComputePipelineState> pipeline;
+};
+
+MetalKernel::MetalKernel(MetalContext& context, void* pipeline, const string& name) :
+        impl(new Impl()), context(context), name(name) {
+    impl->pipeline = (__bridge id<MTLComputePipelineState>) pipeline;
+}
+
+MetalKernel::~MetalKernel() {
+}
+
+int MetalKernel::getMaxBlockSize() const {
+    return impl->pipeline.maxTotalThreadsPerThreadgroup;
+}
+
+void MetalKernel::execute(int threads, int blockSize) {
+    if (blockSize == -1)
+        blockSize = ComputeContext::ThreadBlockSize;
+    if (threads < 0 || blockSize <= 0 || blockSize > getMaxBlockSize())
+        throw OpenMMException("Invalid thread block size or thread count for Metal kernel "+name);
+    if (threads == 0)
+        return;
+    if (arrayArgs.size() > 31)
+        throw OpenMMException("Metal kernel exceeds the direct buffer argument limit");
+    for (int i = 0; i < arrayArgs.size(); i++)
+        if (arrayArgs[i] == nullptr && primitiveArgSizes[i] == 0)
+            throw OpenMMException("Unbound argument for Metal kernel "+name);
+    @autoreleasepool {
+        MetalQueue& queue = context.getCurrentMetalQueue();
+        id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>) queue.getQueue();
+        id<MTLCommandBuffer> command = [commandQueue commandBuffer];
+        id<MTLComputeCommandEncoder> encoder = [command computeCommandEncoder];
+        if (encoder == nil)
+            throw OpenMMException("Error creating Metal kernel command");
+        [encoder setComputePipelineState:impl->pipeline];
+        // Like CudaKernel, resolve arrays at each launch so resize/rebinding is visible.
+        for (int i = 0; i < arrayArgs.size(); i++) {
+            if (arrayArgs[i] != nullptr)
+                [encoder setBuffer:(__bridge id<MTLBuffer>) arrayArgs[i]->getBuffer() offset:0 atIndex:i];
+            else
+                [encoder setBytes:&primitiveArgs[i] length:primitiveArgSizes[i] atIndex:i];
+        }
+        int gridSize = min(1+(threads-1)/blockSize, context.getNumThreadBlocks());
+        [encoder dispatchThreadgroups:MTLSizeMake(gridSize, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(blockSize, 1, 1)];
+        [encoder endEncoding];
+        queue.submit((__bridge void*) command);
+    }
+}
+
+void MetalKernel::addArrayArg(ArrayInterface& value) {
+    int index = arrayArgs.size();
+    addEmptyArg();
+    setArrayArg(index, value);
+}
+
+void MetalKernel::addPrimitiveArg(const void* value, int size) {
+    int index = arrayArgs.size();
+    addEmptyArg();
+    setPrimitiveArg(index, value, size);
+}
+
+void MetalKernel::addEmptyArg() {
+    primitiveArgs.push_back(mm_double4(0, 0, 0, 0));
+    primitiveArgSizes.push_back(0);
+    arrayArgs.push_back(nullptr);
+}
+
+void MetalKernel::setArrayArg(int index, ArrayInterface& value) {
+    ASSERT_VALID_INDEX(index, arrayArgs);
+    arrayArgs[index] = &context.unwrap(value);
+}
+
+void MetalKernel::setPrimitiveArg(int index, const void* value, int size) {
+    ASSERT_VALID_INDEX(index, primitiveArgs);
+    if (value == nullptr || size <= 0 || size > sizeof(mm_double4))
+        throw OpenMMException("Unsupported value type for kernel argument");
+    memcpy(&primitiveArgs[index], value, size);
+    primitiveArgSizes[index] = size;
+    arrayArgs[index] = nullptr;
+}

--- a/platforms/metal/src/MetalProgram.mm
+++ b/platforms/metal/src/MetalProgram.mm
@@ -1,0 +1,64 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/src/CudaProgram.cpp                                 *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2019 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalProgram.h"
+#include "MetalContext.h"
+#include "MetalKernel.h"
+#import <Metal/Metal.h>
+
+using namespace OpenMM;
+using namespace std;
+
+struct MetalProgram::Impl {
+    id<MTLLibrary> library;
+};
+
+MetalProgram::MetalProgram(MetalContext& context, void* library) : impl(new Impl()), context(context) {
+    impl->library = (__bridge id<MTLLibrary>) library;
+}
+
+MetalProgram::~MetalProgram() {
+}
+
+ComputeKernel MetalProgram::createKernel(const string& name) {
+    @autoreleasepool {
+        id<MTLFunction> function = [impl->library newFunctionWithName:[NSString stringWithUTF8String:name.c_str()]];
+        if (function == nil)
+            throw OpenMMException("Unknown Metal kernel: "+name);
+        id<MTLDevice> device = (__bridge id<MTLDevice>) context.getDevice();
+        NSError* error = nil;
+        id<MTLComputePipelineState> pipeline = [device newComputePipelineStateWithFunction:function error:&error];
+        if (pipeline == nil)
+            throw OpenMMException("Error creating Metal pipeline "+name+": "+
+                    (error == nil ? string("unknown error") : string(error.localizedDescription.UTF8String)));
+        return ComputeKernel(new MetalKernel(context, (__bridge void*) pipeline, name));
+    }
+}

--- a/platforms/metal/src/MetalQueue.mm
+++ b/platforms/metal/src/MetalQueue.mm
@@ -1,0 +1,108 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Ported from the OpenMM CUDA Platform.                                      *
+ * Source: platforms/cuda/src/CudaQueue.cpp                                   *
+ *                                                                            *
+ * Original CUDA Platform code:                                               *
+ * Portions copyright (c) 2025 Stanford University and the Authors.           *
+ * Authors: Peter Eastman                                                     *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalQueue.h"
+#include "openmm/OpenMMException.h"
+#import <Metal/Metal.h>
+#include <algorithm>
+#include <deque>
+#include <string>
+
+using namespace OpenMM;
+using namespace std;
+
+class MetalQueue::Impl {
+public:
+    id<MTLCommandQueue> queue;
+    deque<id<MTLCommandBuffer>> pending;
+};
+
+MetalQueue::MetalQueue(void* device) : impl(new Impl()) {
+    if (device == nullptr)
+        throw OpenMMException("Cannot create a Metal queue without a device");
+    impl->queue = [(__bridge id<MTLDevice>) device newCommandQueue];
+    if (impl->queue == nil)
+        throw OpenMMException("Error creating Metal command queue");
+}
+
+MetalQueue::~MetalQueue() {
+    // Finish outstanding device work; explicit waits report execution errors.
+    for (id<MTLCommandBuffer> buffer : impl->pending)
+        [buffer waitUntilCompleted];
+}
+
+void* MetalQueue::getQueue() const {
+    return (__bridge void*) impl->queue;
+}
+
+void MetalQueue::submit(void* commandBuffer) {
+    id<MTLCommandBuffer> buffer = (__bridge id<MTLCommandBuffer>) commandBuffer;
+    if (buffer == nil || buffer.commandQueue != impl->queue)
+        throw OpenMMException("Metal command buffer does not belong to this queue");
+    if (buffer.status >= MTLCommandBufferStatusCommitted)
+        throw OpenMMException("Metal command buffer has already been submitted");
+    while (!impl->pending.empty() && impl->pending.front().status >= MTLCommandBufferStatusCompleted)
+        wait((__bridge void*) impl->pending.front());
+    impl->pending.push_back(buffer);
+    [buffer commit];
+}
+
+void MetalQueue::finish() {
+    if (!impl->pending.empty())
+        wait((__bridge void*) impl->pending.back());
+}
+
+void MetalQueue::wait(void* commandBuffer) {
+    id<MTLCommandBuffer> marker = (__bridge id<MTLCommandBuffer>) commandBuffer;
+    if (marker == nil || marker.commandQueue != impl->queue || marker.status < MTLCommandBufferStatusCommitted)
+        throw OpenMMException("Cannot wait for an unsubmitted or foreign Metal command buffer");
+    auto markerPosition = find(impl->pending.begin(), impl->pending.end(), marker);
+    string error;
+    // A marker may already have been reaped by a later submission.
+    size_t count = (markerPosition == impl->pending.end() ? 0 : markerPosition-impl->pending.begin()+1);
+    for (size_t i = 0; i < count; i++) {
+        id<MTLCommandBuffer> buffer = impl->pending.front();
+        // Check each command so a successful marker cannot hide an earlier error.
+        [buffer waitUntilCompleted];
+        if (buffer.status == MTLCommandBufferStatusError && error.empty()) {
+            const char* message = buffer.error.localizedDescription.UTF8String;
+            error = (message == nullptr ? "Unknown GPU error" : message);
+        }
+        impl->pending.pop_front();
+    }
+    [marker waitUntilCompleted];
+    if (marker.status == MTLCommandBufferStatusError && error.empty()) {
+        const char* message = marker.error.localizedDescription.UTF8String;
+        error = (message == nullptr ? "Unknown GPU error" : message);
+    }
+    if (!error.empty())
+        throw OpenMMException("Error executing Metal command buffer: "+error);
+}

--- a/platforms/metal/tests/TestMetalComputeContext.cpp
+++ b/platforms/metal/tests/TestMetalComputeContext.cpp
@@ -1,0 +1,378 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+#include "MetalContext.h"
+#include "MetalQueue.h"
+#include "openmm/System.h"
+#include "openmm/common/ComputeArray.h"
+#include "openmm/common/ComputeVectorTypes.h"
+#include "openmm/internal/AssertionUtilities.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace OpenMM;
+using namespace std;
+
+// These tests exercise the Common runtime interfaces with native MSL smoke
+// kernels.  They do not establish Common kernel-source or simulation support.
+
+void expectException(const string& description, const function<void()>& operation) {
+    try {
+        operation();
+    }
+    catch (const OpenMMException&) {
+        return;
+    }
+    throw OpenMMException("Expected an exception: "+description);
+}
+
+string loadSource() {
+    const string path = string(METAL_TEST_SOURCE_DIR)+"/runtime.metal";
+    ifstream input(path.c_str());
+    if (!input)
+        throw OpenMMException("Cannot open Metal test source: "+path);
+    return string(istreambuf_iterator<char>(input), istreambuf_iterator<char>());
+}
+
+vector<int> inputValues(int count) {
+    vector<int> values(count);
+    for (int i = 0; i < count; i++)
+        values[i] = i-17;
+    return values;
+}
+
+void checkTransform(const vector<int>& input, const vector<int>& output, int offset) {
+    ASSERT_EQUAL(input.size(), output.size());
+    for (size_t i = 0; i < input.size(); i++)
+        ASSERT_EQUAL(3*input[i]+offset, output[i]);
+}
+
+ComputeKernel createTransform(ComputeProgram program, ArrayInterface& input,
+        ArrayInterface& output, int count, int offset) {
+    ComputeKernel kernel = program->createKernel("transform");
+    kernel->addArg(input);
+    kernel->addArg(output);
+    kernel->addArg(count);
+    kernel->addArg(offset);
+    return kernel;
+}
+
+void testContext(ComputeContext& context) {
+    const size_t paddedAtoms = context.getPaddedNumAtoms();
+    ASSERT_EQUAL(65, context.getNumAtoms());
+    ASSERT(context.getPaddedNumAtoms() >= context.getNumAtoms());
+    ASSERT_EQUAL(1, context.getNumContexts());
+    ASSERT(!context.getUseDoublePrecision());
+    ASSERT(!context.getUseMixedPrecision());
+    ASSERT(!context.getSupports64BitGlobalAtomics());
+    ASSERT_EQUAL(paddedAtoms, context.getPosq().getSize());
+    ASSERT_EQUAL(sizeof(mm_float4), context.getPosq().getElementSize());
+    ASSERT_EQUAL(paddedAtoms, context.getVelm().getSize());
+    ASSERT_EQUAL(sizeof(mm_float4), context.getVelm().getElementSize());
+    ASSERT_EQUAL(3*paddedAtoms, context.getLongForceBuffer().getSize());
+    ASSERT_EQUAL(sizeof(int64_t), context.getLongForceBuffer().getElementSize());
+    ASSERT_EQUAL(sizeof(float), context.getEnergyBuffer().getElementSize());
+    ASSERT_EQUAL(paddedAtoms, context.getAtomIndexArray().getSize());
+}
+
+void testArrays(ComputeContext& context) {
+    ComputeArray source, destination;
+    ASSERT(!source.isInitialized());
+    source.initialize<int>(context, 9, "source");
+    destination.initialize<int>(context, 9, "destination");
+    ArrayInterface& array = source;
+    ASSERT(array.isInitialized());
+    ASSERT_EQUAL(string("source"), array.getName());
+    ASSERT(&array.getContext() == &context);
+    vector<int> expected = inputValues(9), result;
+    array.upload(expected);
+    const int replacement[] = {101, 102, 103};
+    array.uploadSubArray(replacement, 2, 3);
+    copy(replacement, replacement+3, expected.begin()+2);
+    array.download(result);
+    ASSERT_EQUAL_CONTAINERS(expected, result);
+    array.copyTo(destination);
+    destination.download(result);
+    ASSERT_EQUAL_CONTAINERS(expected, result);
+    destination.resize(17);
+    expected = inputValues(17);
+    destination.upload(expected);
+    destination.download(result);
+    ASSERT_EQUAL_CONTAINERS(expected, result);
+    expectException("copy size mismatch", [&] { array.copyTo(destination); });
+    expectException("upload size mismatch", [&] { array.upload(expected); });
+    expectException("negative subarray offset", [&] { array.uploadSubArray(replacement, -1, 1); });
+    expectException("subarray past end", [&] { array.uploadSubArray(replacement, 8, 2); });
+    expectException("negative subarray length", [&] { array.uploadSubArray(replacement, 0, -1); });
+    expectException("non-pinned asynchronous upload", [&] { array.upload(expected.data(), false); });
+    expectException("non-pinned asynchronous download", [&] { array.download(result.data(), false); });
+    const size_t pinnedBytes = max(context.getLongForceBuffer().getSize()*context.getLongForceBuffer().getElementSize(),
+            context.getEnergyBuffer().getSize()*context.getEnergyBuffer().getElementSize());
+    unsigned char* pinned = static_cast<unsigned char*>(context.getPinnedBuffer());
+    expectException("pinned upload exceeds capacity", [&] { array.upload(pinned+pinnedBytes-sizeof(int), false); });
+    expectException("pinned download exceeds capacity", [&] { array.download(pinned+pinnedBytes-sizeof(int), false); });
+    expectException("pinned offset past end", [&] { array.download(pinned+pinnedBytes, false); });
+
+    // Use raw-pointer overloads: Common's vector helpers assume nonempty vectors.
+    ComputeArray empty, emptyCopy;
+    empty.initialize<int>(context, 0, "empty");
+    emptyCopy.initialize<int>(context, 0, "emptyCopy");
+    ASSERT_EQUAL(size_t(0), empty.getSize());
+    empty.upload(static_cast<const void*>(nullptr));
+    empty.download(static_cast<void*>(nullptr));
+    empty.copyTo(emptyCopy);
+    context.clearBuffer(empty);
+    empty.resize(1);
+    empty.upload(vector<int>(1, 9));
+    empty.download(result);
+    ASSERT_EQUAL(9, result[0]);
+    empty.resize(0);
+    context.clearBuffer(empty);
+}
+
+void testLaunches(ComputeContext& context, ComputeProgram program) {
+    const int sizes[] = {1, 63, 64, 65, 129, context.getNumThreadBlocks()*64+129};
+    for (int count : sizes) {
+        ComputeArray input, output, groups;
+        input.initialize<int>(context, count, "launchInput");
+        output.initialize<int>(context, count, "launchOutput");
+        vector<int> values = inputValues(count), result;
+        input.upload(values);
+        ComputeKernel kernel = createTransform(program, input, output, count, 5);
+        // Cover both explicit and default launch sizes.
+        kernel->execute(count, 64);
+        output.download(result);
+        checkTransform(values, result, 5);
+        kernel->setArg(3, -9);
+        kernel->execute(count);
+        output.download(result);
+        checkTransform(values, result, -9);
+
+        const int numGroups = min((count+63)/64, context.getNumThreadBlocks());
+        groups.initialize<unsigned int>(context, numGroups, "groupWidths");
+        context.clearBuffer(groups);
+        ComputeKernel widths = program->createKernel("recordGroupWidth");
+        widths->addArg(groups);
+        widths->execute(count, 64);
+        vector<unsigned int> actualWidths;
+        groups.download(actualWidths);
+        for (unsigned int width : actualWidths)
+            ASSERT_EQUAL(64, width);
+    }
+}
+
+void testArguments(ComputeContext& context, ComputeProgram program) {
+    ComputeArray input, output, replacement;
+    input.initialize<int>(context, 1, "argumentInput");
+    output.initialize<int>(context, 1, "argumentOutput");
+    replacement.initialize<int>(context, 1, "replacementOutput");
+    vector<int> values = inputValues(1), result;
+    input.upload(values);
+    ComputeKernel kernel = program->createKernel("transform");
+    kernel->addArg();
+    kernel->addArg();
+    kernel->addArg();
+    kernel->addArg();
+    expectException("unbound kernel arguments", [&] { kernel->execute(1); });
+    kernel->setArg(0, input);
+    kernel->setArg(1, output);
+    kernel->setArg(2, 1);
+    kernel->setArg(3, 7);
+    kernel->execute(1);
+    output.download(result);
+    checkTransform(values, result, 7);
+    kernel->setArg(1, replacement);
+    kernel->setArg(3, -2);
+    kernel->execute(1);
+    replacement.download(result);
+    checkTransform(values, result, -2);
+    output.download(result);
+    checkTransform(values, result, 7);
+
+    // Bound ArrayInterface objects must resolve their current storage after resize.
+    input.resize(129);
+    replacement.resize(129);
+    values = inputValues(129);
+    input.upload(values);
+    kernel->setArg(2, 129);
+    kernel->execute(129);
+    replacement.download(result);
+    checkTransform(values, result, -2);
+    expectException("invalid argument index", [&] { kernel->setArg(4, 1); });
+    struct OversizedArgument { double values[5]; } oversized = {};
+    expectException("oversized primitive argument", [&] { kernel->setArg(3, oversized); });
+    expectException("zero block size", [&] { kernel->execute(129, 0); });
+    expectException("excessive block size", [&] { kernel->execute(129, kernel->getMaxBlockSize()+1); });
+}
+
+void testClearing(MetalContext& metal) {
+    ComputeContext& context = metal;
+    ArrayInterface& force = context.getLongForceBuffer();
+    vector<int64_t> forceValues(force.getSize(), (int64_t(1)<<40)+7), forceResult;
+    force.upload(forceValues);
+    force.download(forceResult);
+    ASSERT_EQUAL_CONTAINERS(forceValues, forceResult);
+    // Common uses the pinned workspace for the full force buffer.  flushQueue()
+    // must make the asynchronous device-to-host transfer observable on the CPU.
+    void* pinned = context.getPinnedBuffer();
+    ASSERT(pinned != nullptr);
+    force.download(pinned, false);
+    context.flushQueue();
+    ASSERT_EQUAL(0, memcmp(forceValues.data(), pinned, forceValues.size()*sizeof(int64_t)));
+    context.clearBuffer(force);
+    force.download(forceResult);
+    for (int64_t value : forceResult)
+        ASSERT_EQUAL(0, value);
+
+    // The registered array is context-owned and outlives subsequent clear calls.
+    ArrayInterface& energy = context.getEnergyBuffer();
+    vector<float> energyValues(energy.getSize(), 7.0f), energyResult;
+    context.addAutoclearBuffer(energy);
+    for (int repeat = 0; repeat < 2; repeat++) {
+        energy.upload(energyValues);
+        metal.clearAutoclearBuffers();
+        energy.download(energyResult);
+        for (float value : energyResult)
+            ASSERT_EQUAL(0.0f, value);
+    }
+}
+
+void testQueues(MetalContext& metal, ComputeProgram program) {
+    ComputeContext& context = metal;
+    ComputeQueue original = context.getCurrentQueue(), secondary = context.createQueue();
+    ComputeArray input, output, copied;
+    const int count = 129;
+    input.initialize<int>(context, count, "queueInput");
+    output.initialize<int>(context, count, "queueOutput");
+    copied.initialize<int>(context, count, "queueCopy");
+    vector<int> values = inputValues(count), result(count, 0);
+    int* pinned = static_cast<int*>(context.getPinnedBuffer());
+    // Exercise an interior pinned pointer as well as the workspace base.
+    int* offsetPinned = pinned+4;
+    const size_t bytes = count*sizeof(int);
+    memcpy(offsetPinned, values.data(), bytes);
+    input.upload(offsetPinned, false);
+    ComputeEvent uploaded = context.createEvent();
+    uploaded->enqueue();
+    uploaded->queueWait(secondary);
+    context.setCurrentQueue(secondary);
+    ComputeKernel kernel = createTransform(program, input, output, count, 23);
+    kernel->execute(count);
+    output.copyTo(copied);
+    // The uploaded event orders this write after the input transfer consumed
+    // the same pinned memory.  No CPU access occurs while either is in flight.
+    copied.download(offsetPinned, false);
+    ComputeEvent computed = context.createEvent();
+    computed->enqueue();
+    computed->queueWait(original);
+    context.restoreDefaultQueue();
+    ASSERT(context.getCurrentQueue() == original);
+
+    // A GPU event dependency must make the source queue's readback transitively
+    // observable after finishing the target queue, without a source host wait.
+    context.flushQueue();
+    memcpy(result.data(), offsetPinned, bytes);
+    checkTransform(values, result, 23);
+    kernel->setArg(3, -4);
+    kernel->execute(count);
+    output.download(pinned, false);
+    ComputeEvent downloaded = context.createEvent();
+    downloaded->enqueue();
+    downloaded->wait();
+    memcpy(result.data(), pinned, bytes);
+    checkTransform(values, result, -4);
+    kernel->setArg(3, 17);
+    kernel->execute(count);
+    output.download(offsetPinned, false);
+    downloaded->enqueue();
+    downloaded->wait();
+    memcpy(result.data(), offsetPinned, bytes);
+    checkTransform(values, result, 17);
+    metal.getCurrentMetalQueue().finish();
+}
+
+void testErrors(ComputeContext& context, ComputeProgram program) {
+    expectException("simulation context is unavailable", [&] { context.getContextImpl(); });
+    expectException("integration utilities are unavailable", [&] { context.getIntegrationUtilities(); });
+    expectException("nonbonded utilities are unavailable", [&] { context.getNonbondedUtilities(); });
+    expectException("invalid shader source", [&] { context.compileProgram("This is not valid MSL."); });
+    expectException("missing kernel", [&] { program->createKernel("missingKernel"); });
+    System emptySystem;
+    MetalContext other(emptySystem);
+    ASSERT_EQUAL(0, other.getNumAtoms());
+    ComputeArray local, foreign;
+    local.initialize<int>(context, 1, "local");
+    foreign.initialize<int>(other, 1, "foreign");
+    expectException("cross-context array copy", [&] { local.copyTo(foreign); });
+    expectException("cross-context array clear", [&] { context.clearBuffer(foreign); });
+    ComputeKernel kernel = program->createKernel("transform");
+    expectException("cross-context kernel argument", [&] { kernel->addArg(foreign); });
+}
+
+int main() {
+    System system;
+    for (int i = 0; i < 65; i++)
+        system.addParticle(1.0);
+    unique_ptr<MetalContext> metal;
+    try {
+        metal.reset(new MetalContext(system));
+    }
+    catch (const exception& error) {
+        if (string(error.what()).find("No Metal device") != string::npos) {
+            cout << "SKIPPED: No Metal device; GPU tests were not executed." << endl;
+            return 77;
+        }
+        cerr << "Exception creating Metal context: " << error.what() << endl;
+        return 1;
+    }
+    try {
+        ComputeContext& context = *metal;
+        map<string, string> defines;
+        defines["VALUE_SCALE"] = "3";
+        ComputeProgram program = context.compileProgram(loadSource(), defines);
+        testContext(context);
+        testArrays(context);
+        testLaunches(context, program);
+        testArguments(context, program);
+        testClearing(*metal);
+        testQueues(*metal, program);
+        testErrors(context, program);
+        metal->getCurrentMetalQueue().finish();
+    }
+    catch (const exception& error) {
+        cerr << "Exception: " << error.what() << endl;
+        return 1;
+    }
+    cout << "Done: Metal Platform Common interface tests executed successfully." << endl;
+    return 0;
+}

--- a/platforms/metal/tests/kernels/runtime.metal
+++ b/platforms/metal/tests/kernels/runtime.metal
@@ -1,0 +1,81 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ *                                                                            *
+ * This is part of the OpenMM molecular simulation toolkit.                   *
+ * See https://openmm.org/development.                                        *
+ *                                                                            *
+ * Metal Platform code:                                                       *
+ * Portions copyright (c) 2026 Chun-Chi Hung.                                 *
+ * Authors: Chun-Chi Hung                                                     *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU Lesser General Public License as published   *
+ * by the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
+ * GNU Lesser General Public License for more details.                        *
+ *                                                                            *
+ * You should have received a copy of the GNU Lesser General Public License   *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file
+ * @brief Test-only native MSL kernels with buffer slots in Common argument order.
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+/**
+ * @brief Apply an integer transform while exercising array and scalar bindings.
+ * @param input Source array at buffer 0, containing at least count integers.
+ * @param output Separate destination array at buffer 1, containing at least count integers.
+ * @param count Nonnegative element count at buffer 2.
+ * @param offset Additive constant at buffer 3.
+ * @param globalID Metal-provided thread position in the one-dimensional grid.
+ * @param numGroups Metal-provided number of threadgroups in the grid.
+ * @param groupWidth Metal-provided threads per threadgroup.
+ * @note VALUE_SCALE is supplied at compilation. The grid-stride loop supports
+ *       both padded and capped launches; stage builtins consume no buffer slots.
+ */
+kernel void transform(device const int* input [[buffer(0)]],
+        device int* output [[buffer(1)]],
+        constant int& count [[buffer(2)]],
+        constant int& offset [[buffer(3)]],
+        uint globalID [[thread_position_in_grid]],
+        uint numGroups [[threadgroups_per_grid]],
+        uint groupWidth [[threads_per_threadgroup]]) {
+    for (uint i = globalID; i < uint(count); i += numGroups*groupWidth)
+        output[i] = VALUE_SCALE*input[i]+offset;
+}
+
+/**
+ * @brief Count participating threads to test complete threadgroup dispatch.
+ * @param output Buffer 0, with one uint result per dispatched threadgroup.
+ * @param localID Metal-provided thread index within the threadgroup.
+ * @param groupID Metal-provided threadgroup position in the one-dimensional grid.
+ * @pre Launch with exactly 64 threads per group.
+ * @note All threads participate in both barriers. Zeroing all 64 entries makes
+ *       an accidental partial final group detectable without reading uninitialized memory.
+ */
+kernel void recordGroupWidth(device uint* output [[buffer(0)]],
+        uint localID [[thread_index_in_threadgroup]],
+        uint groupID [[threadgroup_position_in_grid]]) {
+    threadgroup uint lanes[64];
+    if (localID == 0)
+        for (uint i = 0; i < 64; i++)
+            lanes[i] = 0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    lanes[localID] = 1;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (localID == 0) {
+        uint sum = 0;
+        for (uint i = 0; i < 64; i++)
+            sum += lanes[i];
+        output[groupID] = sum;
+    }
+}


### PR DESCRIPTION
Related discussion: #5397
Current commit: [8f6a7332f](https://github.com/NORPG/openmm/commit/8f6a7332f4bca326cd43366f2916da396db661ae)

### Current technical choices

- **Target:** Apple silicon, macOS 13+, one GPU, single precision.
- **Structure:** Follow the CUDA/HIP runtime interfaces and reuse existing Common context, array-wrapper, and force-info sources.
- **Host implementation:** Private Objective-C++ with ordinary C++11-facing interfaces.
- **Build:** Optional Metal build, disabled by default.

Following the [review feedback](https://github.com/openmm/openmm/pull/5416#issuecomment-5575475013), I restarted the branch from `master` and replaced the earlier prototype with a smaller foundation. The priority is simple, readable code that follows existing platforms, with eventual Common Compute kernel reuse and minimal Metal-specific code.

### Implementation status

- Basic runtime and standard state buffers through `ComputeContext`, `ArrayInterface`, `ComputeQueue`, `ComputeEvent`, `ComputeProgram`, and `ComputeKernel`.
- Buffer transfers and clearing, argument rebinding, native MSL 3.0 compilation, threadgroup dispatch, and queue/event synchronization.
- Doxygen documentation for ownership, asynchronous transfers, bindings, and unsupported interfaces.

This is **not yet a registered simulation Platform**, and it does not execute existing Common kernel sources. The earlier simulation paths and custom fixed-point implementation are no longer included. Forces, integrators, sorting, neighbor lists, and FFT/PME remain unimplemented.

### Host API and language choice

- **Objective-C++:** implemented in this branch.
- **metal-cpp:** alternative using a private C++17 implementation.
- **Swift:** alternative behind a C/C++ bridge.

Objective-C++ requires the least porting work because the runtime already exists behind C++11 interfaces. Retaining it still needs maintainer agreement, given the concern raised in #5397.

[Apple's metal-cpp](https://developer.apple.com/metal/cpp/) is a header-only interface requiring C++17. We could apply that requirement only to the optional Metal implementation and keep `MTL::`/`NS::` types private. I would pin a release and rebuild/test header updates without assuming a separate stable wrapper ABI.

Swift would add build/runtime integration and ownership/error-handling work. [Direct C++ interoperability requires Swift 5.9+ and C++14+](https://www.swift.org/documentation/cxx-interop/status/) at the bridge boundary; an isolated adapter or C bridge could preserve C++11-facing interfaces. Swift's [stable Apple-platform ABI](https://www.swift.org/blog/library-evolution/) is distinct from its [evolving C++ interop compatibility policy](https://www.swift.org/documentation/cxx-interop/#source-stability-guarantees-for-mixed-language-codebases).

All three options concern the host layer. MSL kernels and Common Compute reuse remain shared goals. Which option would maintainers prefer to evaluate?

### Validation

- `TestMetalComputeContext` passes with Metal API Validation and GPU Validation enabled.
- Coverage includes transfers, resizing/rebinding, complete threadgroups, grid-stride execution, clearing, pinned-memory readback, queue/event ordering, and invalid inputs.
- Doxygen generation completes without warnings.

These tests validate runtime interfaces only—not simulation correctness, Common shader compatibility, or performance. Build instructions are in the [Metal README](https://github.com/NORPG/openmm/blob/Objective-C/platforms/metal/README.md).

Feedback on whether this smaller foundation follows the intended CUDA/HIP porting approach would be appreciated.
